### PR TITLE
Handle dup episodes between basics and binging

### DIFF
--- a/ibdb/db_dump.sql
+++ b/ibdb/db_dump.sql
@@ -273,7 +273,7 @@ ALTER TABLE ONLY public.show ALTER COLUMN id SET DEFAULT nextval('public.show_id
 --
 
 COPY public.alembic_version (version_num) FROM stdin;
-c68d372abaa7
+1fba43043f30
 \.
 
 
@@ -2182,11 +2182,11 @@ ALTER TABLE ONLY public.episode_inspired_by
 
 
 --
--- Name: episode episode_name_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: episode episode_name_show_uindex; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
 ALTER TABLE ONLY public.episode
-    ADD CONSTRAINT episode_name_key UNIQUE (name);
+    ADD CONSTRAINT episode_name_show_uindex UNIQUE (name, show_id);
 
 
 --

--- a/ibdb/models.py
+++ b/ibdb/models.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from sqlalchemy import Column, ForeignKey, Integer, String, Table, Text, text, Date
+from sqlalchemy import Column, ForeignKey, Integer, String, Table, Text, text, Date, UniqueConstraint
 from sqlalchemy.orm import relationship, backref
 from flask_sqlalchemy import SQLAlchemy
 from flask import request
@@ -85,9 +85,12 @@ class Show(Base):
 
 class Episode(Base):
     __tablename__ = 'episode'
+    __table_args__ = (
+        UniqueConstraint('name', 'show_id', name='episode_name_show_uindex'),
+    )
 
     id = Column(String, primary_key=True)
-    name = Column(String, nullable=False, unique=True)
+    name = Column(String, nullable=False)
     youtube_link = Column(String, nullable=False)
     official_link = Column(String, nullable=False)
     image_link = Column(String)

--- a/migrations/versions/1fba43043f30_.py
+++ b/migrations/versions/1fba43043f30_.py
@@ -1,0 +1,25 @@
+"""convert episode name to be unique by show
+
+Revision ID: 1fba43043f30
+Revises: c68d372abaa7
+Create Date: 2021-02-22 21:53:44.025720
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '1fba43043f30'
+down_revision = 'c68d372abaa7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint('episode_name_show_uindex', 'episode', ['name', 'show_id'])
+    op.drop_constraint('episode_name_key', 'episode', type_='unique')
+
+
+def downgrade():
+    op.create_unique_constraint('episode_name_key', 'episode', ['name'])
+    op.drop_constraint('episode_name_show_uindex', 'episode', type_='unique')


### PR DESCRIPTION
This episode is listed under both _Basics_ and _Binging with Babish_.
* https://basicswithbabish.co/basicsepisodes/pantomate-crabcakes
* https://bingingwithbabish.com/recipes/pancontomate-crabcakes

This PR adjusts our unique constraint to allow both references to be created.

This will probably need to be manually cleaned up later.