### PR TITLE
Declare explicit GITHUB_TOKEN permissions in CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,11 @@ on:
     # The branches below must be a subset of the branches above
     branches: [master]
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   flake8:
     name: Flake8


### PR DESCRIPTION
## Summary
Companion to the [private-repo fix](https://github.com/jklewa/data-with-babish-private/pull/2). Makes the workflow self-contained by declaring \`checks: write\` and \`pull-requests: write\` (which \`EnricoMi/publish-unit-test-result-action@v2\` needs) instead of relying on the repo's default \`GITHUB_TOKEN\` permissions. No-op on this repo today, but it documents the requirement and survives any future repo-settings change.

## Test plan
- [ ] CI run on this PR succeeds