### PR TITLE
Reorganize data/ to sharded layout with per-field provenance

### DIFF
--- a/data/episodes/_/episode-0001-10-levels-chicken-noodle-soup/data.yml
+++ b/data/episodes/_/episode-0001-10-levels-chicken-noodle-soup/data.yml
@@ -20,7 +20,15 @@ tags:
 - tag-0031
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1467
+- recipe-1468
+- recipe-1469
+- recipe-1470
+- recipe-1471
+- recipe-1472
+- recipe-1473
+- recipe-1474
 _lookup:
   slug: 10-levels-chicken-noodle-soup
   babish_internal_id: 0en4gcpRl2JqIbk96XNh

--- a/data/episodes/_/episode-0001-10-levels-chicken-noodle-soup/meta.yml
+++ b/data/episodes/_/episode-0001-10-levels-chicken-noodle-soup/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/_/episode-0002-10-levels-of-cheesesteak/data.yml
+++ b/data/episodes/_/episode-0002-10-levels-of-cheesesteak/data.yml
@@ -15,7 +15,12 @@ tags:
 - tag-0031
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1458
+- recipe-1459
+- recipe-1460
+- recipe-1461
+- recipe-1462
 _lookup:
   slug: 10-levels-of-cheesesteak
   babish_internal_id: X7BNzvl0C2ztjszyVnTr

--- a/data/episodes/_/episode-0002-10-levels-of-cheesesteak/meta.yml
+++ b/data/episodes/_/episode-0002-10-levels-of-cheesesteak/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/_/episode-0003-10-levels-of-chocolate-chip-cookies-or-with-babish/meta.yml
+++ b/data/episodes/_/episode-0003-10-levels-of-chocolate-chip-cookies-or-with-babish/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/_/episode-0004-10-levels-of-mac-and-cheese/data.yml
+++ b/data/episodes/_/episode-0004-10-levels-of-mac-and-cheese/data.yml
@@ -16,7 +16,16 @@ tags:
 - tag-0031
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1536
+- recipe-1537
+- recipe-1538
+- recipe-1539
+- recipe-1540
+- recipe-1541
+- recipe-1542
+- recipe-1543
+- recipe-1544
 _lookup:
   slug: 10-levels-of-mac-and-cheese
   babish_internal_id: ThBNwwCm8wKOjJ7NjzPj

--- a/data/episodes/_/episode-0004-10-levels-of-mac-and-cheese/meta.yml
+++ b/data/episodes/_/episode-0004-10-levels-of-mac-and-cheese/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/_/episode-0005-18-pound-giant-fried-chicken-bowl/meta.yml
+++ b/data/episodes/_/episode-0005-18-pound-giant-fried-chicken-bowl/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/_/episode-0006-2024oscarsspecial/data.yml
+++ b/data/episodes/_/episode-0006-2024oscarsspecial/data.yml
@@ -13,7 +13,8 @@ tags:
 - tag-0017
 - tag-0032
 guests: []
-inspired_by: []
+inspired_by:
+- reference-0318
 recipes:
 - recipe-1290
 _lookup:

--- a/data/episodes/_/episode-0006-2024oscarsspecial/meta.yml
+++ b/data/episodes/_/episode-0006-2024oscarsspecial/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/_/episode-0007-28-layer-chocolate-cake/meta.yml
+++ b/data/episodes/_/episode-0007-28-layer-chocolate-cake/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/_/episode-0008-324-layer-croissant-inspired-by-yakitate-japan/meta.yml
+++ b/data/episodes/_/episode-0008-324-layer-croissant-inspired-by-yakitate-japan/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/_/episode-0009-3-course-dinner-inspired-by-drop/data.yml
+++ b/data/episodes/_/episode-0009-3-course-dinner-inspired-by-drop/data.yml
@@ -18,7 +18,13 @@ tags:
 guests: []
 inspired_by:
 - reference-0250
-recipes: []
+recipes:
+- recipe-1557
+- recipe-1558
+- recipe-1559
+- recipe-1560
+- recipe-1561
+- recipe-1562
 _lookup:
   slug: 3-course-dinner-inspired-by-drop
   babish_internal_id: esYnxlp9rOSO9OFN5UH6

--- a/data/episodes/_/episode-0009-3-course-dinner-inspired-by-drop/meta.yml
+++ b/data/episodes/_/episode-0009-3-course-dinner-inspired-by-drop/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/_/episode-0010-3daypotatosalad/meta.yml
+++ b/data/episodes/_/episode-0010-3daypotatosalad/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/_/episode-0011-4-cheese-lasagna-inspired-by-one-piece/meta.yml
+++ b/data/episodes/_/episode-0011-4-cheese-lasagna-inspired-by-one-piece/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/_/episode-0012-5-levels-of-spaghetti-or-with-babish/data.yml
+++ b/data/episodes/_/episode-0012-5-levels-of-spaghetti-or-with-babish/data.yml
@@ -20,7 +20,15 @@ tags:
 - tag-0032
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1483
+- recipe-1484
+- recipe-1485
+- recipe-1486
+- recipe-1487
+- recipe-1488
+- recipe-1489
+- recipe-1490
 _lookup:
   slug: 5-levels-of-spaghetti-or-with-babish
   babish_internal_id: frdZ8HGenRhPL4tboP18

--- a/data/episodes/_/episode-0012-5-levels-of-spaghetti-or-with-babish/meta.yml
+++ b/data/episodes/_/episode-0012-5-levels-of-spaghetti-or-with-babish/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/_/episode-0014-5-weeknight-recipes-for-pork-tenderloin/data.yml
+++ b/data/episodes/_/episode-0014-5-weeknight-recipes-for-pork-tenderloin/data.yml
@@ -15,7 +15,13 @@ tags:
 - tag-0031
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1563
+- recipe-1564
+- recipe-1565
+- recipe-1566
+- recipe-1567
+- recipe-1568
 _lookup:
   slug: 5-weeknight-recipes-for-pork-tenderloin
   babish_internal_id: pSL1iT88rxsiFUadxlvv

--- a/data/episodes/_/episode-0014-5-weeknight-recipes-for-pork-tenderloin/meta.yml
+++ b/data/episodes/_/episode-0014-5-weeknight-recipes-for-pork-tenderloin/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0015-a5-wagyu-roti-don-inspired-by-food-wars/meta.yml
+++ b/data/episodes/a/episode-0015-a5-wagyu-roti-don-inspired-by-food-wars/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0016-advanced-grilled-cheese/meta.yml
+++ b/data/episodes/a/episode-0016-advanced-grilled-cheese/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0017-adventure-time-sandwich/meta.yml
+++ b/data/episodes/a/episode-0017-adventure-time-sandwich/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0018-adventuretimespecial/meta.yml
+++ b/data/episodes/a/episode-0018-adventuretimespecial/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0019-aglioeolio/meta.yml
+++ b/data/episodes/a/episode-0019-aglioeolio/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0020-agua-de-jamaica-granita/meta.yml
+++ b/data/episodes/a/episode-0020-agua-de-jamaica-granita/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0021-alwayssunny/meta.yml
+++ b/data/episodes/a/episode-0021-alwayssunny/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0022-amatriciana-eat-pray-love/meta.yml
+++ b/data/episodes/a/episode-0022-amatriciana-eat-pray-love/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0023-andrewsohlathanksgiving/meta.yml
+++ b/data/episodes/a/episode-0023-andrewsohlathanksgiving/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0024-angel-food-cake-groundhog-day/meta.yml
+++ b/data/episodes/a/episode-0024-angel-food-cake-groundhog-day/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0025-apple-and-brie-galette/meta.yml
+++ b/data/episodes/a/episode-0025-apple-and-brie-galette/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0026-apple-cider-donuts/meta.yml
+++ b/data/episodes/a/episode-0026-apple-cider-donuts/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0027-applefritters/meta.yml
+++ b/data/episodes/a/episode-0027-applefritters/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0028-applepie/meta.yml
+++ b/data/episodes/a/episode-0028-applepie/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0029-applepiesmoothie/meta.yml
+++ b/data/episodes/a/episode-0029-applepiesmoothie/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0030-apple-snaps-mrfox/meta.yml
+++ b/data/episodes/a/episode-0030-apple-snaps-mrfox/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0031-arancini/meta.yml
+++ b/data/episodes/a/episode-0031-arancini/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0032-archer-margarita/meta.yml
+++ b/data/episodes/a/episode-0032-archer-margarita/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0033-arc-raiders/meta.yml
+++ b/data/episodes/a/episode-0033-arc-raiders/meta.yml
@@ -1,43 +1,44 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: overridden
     by: enrich-agent
     at: '2026-05-05'
-    scraper_proposed: []
+    scraper_proposed:
+    - reference-0312
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0034-arepas-con-queso-encanto/meta.yml
+++ b/data/episodes/a/episode-0034-arepas-con-queso-encanto/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0035-aristocats/meta.yml
+++ b/data/episodes/a/episode-0035-aristocats/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0036-arresteddevelopmentspecial/meta.yml
+++ b/data/episodes/a/episode-0036-arresteddevelopmentspecial/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0037-arroz-con-pollo-spiderman-spiderverse/meta.yml
+++ b/data/episodes/a/episode-0037-arroz-con-pollo-spiderman-spiderverse/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0038-aunt-petunias-pudding-harry-potter/meta.yml
+++ b/data/episodes/a/episode-0038-aunt-petunias-pudding-harry-potter/meta.yml
@@ -1,43 +1,44 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: overridden
     by: enrich-agent
     at: '2026-05-05'
-    scraper_proposed: []
+    scraper_proposed:
+    - reference-0073
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0039-avatar-fire-flakes/meta.yml
+++ b/data/episodes/a/episode-0039-avatar-fire-flakes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/a/episode-0040-avengersicecream/meta.yml
+++ b/data/episodes/a/episode-0040-avengersicecream/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0041-babishpaniniwinner/meta.yml
+++ b/data/episodes/b/episode-0041-babishpaniniwinner/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0042-babish-s-ultimate-chicken-parm/meta.yml
+++ b/data/episodes/b/episode-0042-babish-s-ultimate-chicken-parm/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0043-babish-s-ultimate-fried-chicken/meta.yml
+++ b/data/episodes/b/episode-0043-babish-s-ultimate-fried-chicken/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0044-babka-inspired-by-seinfeld/meta.yml
+++ b/data/episodes/b/episode-0044-babka-inspired-by-seinfeld/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0045-bachelor-chow-futurama/meta.yml
+++ b/data/episodes/b/episode-0045-bachelor-chow-futurama/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0046-back-to-school-sandwich/meta.yml
+++ b/data/episodes/b/episode-0046-back-to-school-sandwich/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0047-bacon/meta.yml
+++ b/data/episodes/b/episode-0047-bacon/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0048-bagels/meta.yml
+++ b/data/episodes/b/episode-0048-bagels/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0049-bagelsandwiches/meta.yml
+++ b/data/episodes/b/episode-0049-bagelsandwiches/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0050-bagelwithlox/data.yml
+++ b/data/episodes/b/episode-0050-bagelwithlox/data.yml
@@ -20,7 +20,8 @@ tags:
 - tag-0031
 - tag-0032
 guests: []
-inspired_by: []
+inspired_by:
+- reference-0317
 recipes:
 - recipe-1287
 _lookup:

--- a/data/episodes/b/episode-0050-bagelwithlox/meta.yml
+++ b/data/episodes/b/episode-0050-bagelwithlox/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0051-baklava/meta.yml
+++ b/data/episodes/b/episode-0051-baklava/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0052-bananapuddingpizza/meta.yml
+++ b/data/episodes/b/episode-0052-bananapuddingpizza/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0053-banoffeepie/meta.yml
+++ b/data/episodes/b/episode-0053-banoffeepie/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0054-baobuns/meta.yml
+++ b/data/episodes/b/episode-0054-baobuns/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0055-barbacoa-de-res/meta.yml
+++ b/data/episodes/b/episode-0055-barbacoa-de-res/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0056-barbecueporkchops/meta.yml
+++ b/data/episodes/b/episode-0056-barbecueporkchops/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0057-baressentials/meta.yml
+++ b/data/episodes/b/episode-0057-baressentials/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0058-baressentials-7xwwz/meta.yml
+++ b/data/episodes/b/episode-0058-baressentials-7xwwz/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0059-bearstew/meta.yml
+++ b/data/episodes/b/episode-0059-bearstew/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0060-beef-wellington-or-with-babish/data.yml
+++ b/data/episodes/b/episode-0060-beef-wellington-or-with-babish/data.yml
@@ -16,7 +16,14 @@ tags:
 - tag-0032
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1503
+- recipe-1504
+- recipe-1505
+- recipe-1506
+- recipe-1507
+- recipe-1508
+- recipe-1509
 _lookup:
   slug: beef-wellington-or-with-babish
   babish_internal_id: IwKsR7cgq05GSJd6V1bj

--- a/data/episodes/b/episode-0060-beef-wellington-or-with-babish/meta.yml
+++ b/data/episodes/b/episode-0060-beef-wellington-or-with-babish/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0061-beer-can-chicken/meta.yml
+++ b/data/episodes/b/episode-0061-beer-can-chicken/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0062-beer-steamed-chili-dogs/meta.yml
+++ b/data/episodes/b/episode-0062-beer-steamed-chili-dogs/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0063-beetandacorncookies/meta.yml
+++ b/data/episodes/b/episode-0063-beetandacorncookies/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0064-beignetsfromchef/meta.yml
+++ b/data/episodes/b/episode-0064-beignetsfromchef/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0071-bell-peppers-and-beef-inspired-by-cowboy-bebop/meta.yml
+++ b/data/episodes/b/episode-0071-bell-peppers-and-beef-inspired-by-cowboy-bebop/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0072-ben-wyatt-calzones/meta.yml
+++ b/data/episodes/b/episode-0072-ben-wyatt-calzones/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0073-big-bang-burger-inspired-by-persona-5/meta.yml
+++ b/data/episodes/b/episode-0073-big-bang-burger-inspired-by-persona-5/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0074-biggamesnacks/meta.yml
+++ b/data/episodes/b/episode-0074-biggamesnacks/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0075-bigkahunaburger/meta.yml
+++ b/data/episodes/b/episode-0075-bigkahunaburger/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0076-birria-tacos/meta.yml
+++ b/data/episodes/b/episode-0076-birria-tacos/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0077-biscotti/meta.yml
+++ b/data/episodes/b/episode-0077-biscotti/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0078-biscuits-and-gravy/meta.yml
+++ b/data/episodes/b/episode-0078-biscuits-and-gravy/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0079-biscuits-ted-lasso/meta.yml
+++ b/data/episodes/b/episode-0079-biscuits-ted-lasso/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0080-black-and-white-cookies-seinfeld/meta.yml
+++ b/data/episodes/b/episode-0080-black-and-white-cookies-seinfeld/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0081-blendersoups/meta.yml
+++ b/data/episodes/b/episode-0081-blendersoups/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0082-blood-pie-inspired-by-game-of-thrones/meta.yml
+++ b/data/episodes/b/episode-0082-blood-pie-inspired-by-game-of-thrones/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0083-blooming-fish-inspired-by-cinderella-chef/meta.yml
+++ b/data/episodes/b/episode-0083-blooming-fish-inspired-by-cinderella-chef/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0084-blue-noodles-andor/meta.yml
+++ b/data/episodes/b/episode-0084-blue-noodles-andor/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0085-bluey-duck-cake/data.yml
+++ b/data/episodes/b/episode-0085-bluey-duck-cake/data.yml
@@ -11,7 +11,8 @@ yield_unit: servings
 tags:
 - tag-0004
 guests: []
-inspired_by: []
+inspired_by:
+- reference-0319
 recipes:
 - recipe-1295
 _lookup:

--- a/data/episodes/b/episode-0085-bluey-duck-cake/meta.yml
+++ b/data/episodes/b/episode-0085-bluey-duck-cake/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0086-bobbys-cookies-king-of-the-hill/meta.yml
+++ b/data/episodes/b/episode-0086-bobbys-cookies-king-of-the-hill/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0087-bobsburgers/meta.yml
+++ b/data/episodes/b/episode-0087-bobsburgers/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0088-bobsburgers-potato-lasagna/data.yml
+++ b/data/episodes/b/episode-0088-bobsburgers-potato-lasagna/data.yml
@@ -17,7 +17,8 @@ tags:
 - tag-0030
 - tag-0032
 guests: []
-inspired_by: []
+inspired_by:
+- reference-0013
 recipes:
 - recipe-1293
 _lookup:

--- a/data/episodes/b/episode-0088-bobsburgers-potato-lasagna/meta.yml
+++ b/data/episodes/b/episode-0088-bobsburgers-potato-lasagna/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0089-boeufbourguignon/meta.yml
+++ b/data/episodes/b/episode-0089-boeufbourguignon/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0090-bolognese/meta.yml
+++ b/data/episodes/b/episode-0090-bolognese/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0091-bone-broth/meta.yml
+++ b/data/episodes/b/episode-0091-bone-broth/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0092-bop-egg-sandwich/meta.yml
+++ b/data/episodes/b/episode-0092-bop-egg-sandwich/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0093-braciole/meta.yml
+++ b/data/episodes/b/episode-0093-braciole/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0094-bread/meta.yml
+++ b/data/episodes/b/episode-0094-bread/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0095-breakfast-uncrustable/meta.yml
+++ b/data/episodes/b/episode-0095-breakfast-uncrustable/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0096-breakingbadspecial/meta.yml
+++ b/data/episodes/b/episode-0096-breakingbadspecial/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0097-brie-butter-baguette-twin-peaks/meta.yml
+++ b/data/episodes/b/episode-0097-brie-butter-baguette-twin-peaks/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0098-brocksdonuts/meta.yml
+++ b/data/episodes/b/episode-0098-brocksdonuts/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0099-brocksonigiri/meta.yml
+++ b/data/episodes/b/episode-0099-brocksonigiri/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0100-broodwich-aqua-teen-hunger-force/meta.yml
+++ b/data/episodes/b/episode-0100-broodwich-aqua-teen-hunger-force/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0101-browned-butter-hojicha-rice-krispies-treats/meta.yml
+++ b/data/episodes/b/episode-0101-browned-butter-hojicha-rice-krispies-treats/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0102-brownies/meta.yml
+++ b/data/episodes/b/episode-0102-brownies/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0103-bubbashrimp2/meta.yml
+++ b/data/episodes/b/episode-0103-bubbashrimp2/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0104-bubblebass/meta.yml
+++ b/data/episodes/b/episode-0104-bubblebass/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0105-bunnicorn-pizza/meta.yml
+++ b/data/episodes/b/episode-0105-bunnicorn-pizza/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0106-burgers/meta.yml
+++ b/data/episodes/b/episode-0106-burgers/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0107-butterednoodles-community/meta.yml
+++ b/data/episodes/b/episode-0107-butterednoodles-community/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/b/episode-0108-buttermilk-pancakes-inspired-by-twin-peaks/meta.yml
+++ b/data/episodes/b/episode-0108-buttermilk-pancakes-inspired-by-twin-peaks/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0110-cajunfood/meta.yml
+++ b/data/episodes/c/episode-0110-cajunfood/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0111-cake-pops/meta.yml
+++ b/data/episodes/c/episode-0111-cake-pops/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0112-calistyle-burrito/meta.yml
+++ b/data/episodes/c/episode-0112-calistyle-burrito/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0113-carbonara/meta.yml
+++ b/data/episodes/c/episode-0113-carbonara/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0114-carbonara-anything/meta.yml
+++ b/data/episodes/c/episode-0114-carbonara-anything/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0115-carnitas/meta.yml
+++ b/data/episodes/c/episode-0115-carnitas/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0116-carpanini/meta.yml
+++ b/data/episodes/c/episode-0116-carpanini/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0117-ccourtesan-au-chocolat/meta.yml
+++ b/data/episodes/c/episode-0117-ccourtesan-au-chocolat/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0118-challah/meta.yml
+++ b/data/episodes/c/episode-0118-challah/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0119-charcuterieandcheeseboards/meta.yml
+++ b/data/episodes/c/episode-0119-charcuterieandcheeseboards/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0120-charliebrownthanksgiving/meta.yml
+++ b/data/episodes/c/episode-0120-charliebrownthanksgiving/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0121-chateaubriandsteak/meta.yml
+++ b/data/episodes/c/episode-0121-chateaubriandsteak/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0122-cheesdips/meta.yml
+++ b/data/episodes/c/episode-0122-cheesdips/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0123-cheeseburger-the-menu/meta.yml
+++ b/data/episodes/c/episode-0123-cheeseburger-the-menu/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0124-cheesecake-inspired-by-junior-s-cheesecakes/data.yml
+++ b/data/episodes/c/episode-0124-cheesecake-inspired-by-junior-s-cheesecakes/data.yml
@@ -16,7 +16,17 @@ tags:
 guests: []
 inspired_by:
 - reference-0253
-recipes: []
+recipes:
+- recipe-1575
+- recipe-1576
+- recipe-1577
+- recipe-1578
+- recipe-1579
+- recipe-1580
+- recipe-1581
+- recipe-1582
+- recipe-1583
+- recipe-1584
 _lookup:
   slug: cheesecake-inspired-by-junior's-cheesecakes
   babish_internal_id: AJj7K1c1XrsbNYERmLL8

--- a/data/episodes/c/episode-0124-cheesecake-inspired-by-junior-s-cheesecakes/meta.yml
+++ b/data/episodes/c/episode-0124-cheesecake-inspired-by-junior-s-cheesecakes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0125-cheese-fondue/meta.yml
+++ b/data/episodes/c/episode-0125-cheese-fondue/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0126-cheesesteak/meta.yml
+++ b/data/episodes/c/episode-0126-cheesesteak/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0127-cheesyblasters/meta.yml
+++ b/data/episodes/c/episode-0127-cheesyblasters/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0128-chefs-choice-platter-monster-hunter-world/meta.yml
+++ b/data/episodes/c/episode-0128-chefs-choice-platter-monster-hunter-world/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0129-chicago-deep-dish-the-bear/meta.yml
+++ b/data/episodes/c/episode-0129-chicago-deep-dish-the-bear/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0130-chicago-style-italian-beef-inspired-by-the-bear/meta.yml
+++ b/data/episodes/c/episode-0130-chicago-style-italian-beef-inspired-by-the-bear/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0131-chicken-fingers-community/meta.yml
+++ b/data/episodes/c/episode-0131-chicken-fingers-community/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0132-chicken-kiev-mad-men/meta.yml
+++ b/data/episodes/c/episode-0132-chicken-kiev-mad-men/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0133-chicken-meatball-hotpot-inspired-by-jujutsu-kaisen/data.yml
+++ b/data/episodes/c/episode-0133-chicken-meatball-hotpot-inspired-by-jujutsu-kaisen/data.yml
@@ -12,7 +12,8 @@ tags:
 - tag-0002
 - tag-0010
 guests: []
-inspired_by: []
+inspired_by:
+- reference-0272
 recipes:
 - recipe-1246
 _lookup:

--- a/data/episodes/c/episode-0133-chicken-meatball-hotpot-inspired-by-jujutsu-kaisen/meta.yml
+++ b/data/episodes/c/episode-0133-chicken-meatball-hotpot-inspired-by-jujutsu-kaisen/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0134-chickenpaprikash/meta.yml
+++ b/data/episodes/c/episode-0134-chickenpaprikash/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0135-chicken-parmesan/meta.yml
+++ b/data/episodes/c/episode-0135-chicken-parmesan/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0136-chicken-piccata/meta.yml
+++ b/data/episodes/c/episode-0136-chicken-piccata/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0137-chicken-pot-pie/meta.yml
+++ b/data/episodes/c/episode-0137-chicken-pot-pie/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0138-chicken-schnitzel-with-kohlrabi-slaw/meta.yml
+++ b/data/episodes/c/episode-0138-chicken-schnitzel-with-kohlrabi-slaw/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0139-chickentikkamasala/meta.yml
+++ b/data/episodes/c/episode-0139-chickentikkamasala/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0140-chickpeas/meta.yml
+++ b/data/episodes/c/episode-0140-chickpeas/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0141-chilaquiles-divorciados-con-todo/meta.yml
+++ b/data/episodes/c/episode-0141-chilaquiles-divorciados-con-todo/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0142-chileanseabass/meta.yml
+++ b/data/episodes/c/episode-0142-chileanseabass/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0143-chiles-rellenos/meta.yml
+++ b/data/episodes/c/episode-0143-chiles-rellenos/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0144-chili-two-ways/meta.yml
+++ b/data/episodes/c/episode-0144-chili-two-ways/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0145-chimichangas/meta.yml
+++ b/data/episodes/c/episode-0145-chimichangas/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0146-chocolate-cake-inspired-by-matilda/meta.yml
+++ b/data/episodes/c/episode-0146-chocolate-cake-inspired-by-matilda/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0147-chocolate-cake-milkshake-inspired-by-portillo-s/meta.yml
+++ b/data/episodes/c/episode-0147-chocolate-cake-milkshake-inspired-by-portillo-s/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0148-chocolate-croissants-its-complicated/meta.yml
+++ b/data/episodes/c/episode-0148-chocolate-croissants-its-complicated/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0149-chocolatelavacakes/meta.yml
+++ b/data/episodes/c/episode-0149-chocolatelavacakes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0150-chocolate-pudding-rugrats/meta.yml
+++ b/data/episodes/c/episode-0150-chocolate-pudding-rugrats/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0151-chocolate-spongebob/meta.yml
+++ b/data/episodes/c/episode-0151-chocolate-spongebob/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0152-chopped-cheese/meta.yml
+++ b/data/episodes/c/episode-0152-chopped-cheese/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0153-chorizo-clam-pasta/meta.yml
+++ b/data/episodes/c/episode-0153-chorizo-clam-pasta/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0154-christmas-turkey-inspired-by-national-lampoon-s-christmas-va/meta.yml
+++ b/data/episodes/c/episode-0154-christmas-turkey-inspired-by-national-lampoon-s-christmas-va/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0155-churrons-broad-city/meta.yml
+++ b/data/episodes/c/episode-0155-churrons-broad-city/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0156-cinnamonrolls/meta.yml
+++ b/data/episodes/c/episode-0156-cinnamonrolls/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0157-cinnamon-rolls-3-ways-pumpkin-spice-strawberry-nutella-class/meta.yml
+++ b/data/episodes/c/episode-0157-cinnamon-rolls-3-ways-pumpkin-spice-strawberry-nutella-class/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0158-classic-fettucine-alfredo/meta.yml
+++ b/data/episodes/c/episode-0158-classic-fettucine-alfredo/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0159-classicpancakes/meta.yml
+++ b/data/episodes/c/episode-0159-classicpancakes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0160-clayroastedthigh/meta.yml
+++ b/data/episodes/c/episode-0160-clayroastedthigh/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0161-clementinecake/meta.yml
+++ b/data/episodes/c/episode-0161-clementinecake/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0162-cocktail-special/meta.yml
+++ b/data/episodes/c/episode-0162-cocktail-special/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0163-cocoa-krispies-oliver-and-company/meta.yml
+++ b/data/episodes/c/episode-0163-cocoa-krispies-oliver-and-company/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0164-coconut-tres-leches-cake-inspired-by-uncle-boon-sthai-diner/meta.yml
+++ b/data/episodes/c/episode-0164-coconut-tres-leches-cake-inspired-by-uncle-boon-sthai-diner/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0165-coffee/meta.yml
+++ b/data/episodes/c/episode-0165-coffee/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0166-coffeecake/meta.yml
+++ b/data/episodes/c/episode-0166-coffeecake/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0167-coffeejelly/meta.yml
+++ b/data/episodes/c/episode-0167-coffeejelly/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0168-cola-short-ribs-the-bear/meta.yml
+++ b/data/episodes/c/episode-0168-cola-short-ribs-the-bear/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0169-cold-cure/meta.yml
+++ b/data/episodes/c/episode-0169-cold-cure/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0170-cookie-cat-steven-universe/meta.yml
+++ b/data/episodes/c/episode-0170-cookie-cat-steven-universe/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0171-cookie-dough/meta.yml
+++ b/data/episodes/c/episode-0171-cookie-dough/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0172-cookie-nachos-sweet-tooth/meta.yml
+++ b/data/episodes/c/episode-0172-cookie-nachos-sweet-tooth/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0173-copy-cat-spicy-vodka-rigatoni/meta.yml
+++ b/data/episodes/c/episode-0173-copy-cat-spicy-vodka-rigatoni/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0174-coq-au-vin/data.yml
+++ b/data/episodes/c/episode-0174-coq-au-vin/data.yml
@@ -16,7 +16,15 @@ tags:
 - tag-0031
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1510
+- recipe-1511
+- recipe-1512
+- recipe-1513
+- recipe-1514
+- recipe-1515
+- recipe-1516
+- recipe-1517
 _lookup:
   slug: coq-au-vin
   babish_internal_id: HsGfP7x5CgUvgbSKAbBJ

--- a/data/episodes/c/episode-0174-coq-au-vin/meta.yml
+++ b/data/episodes/c/episode-0174-coq-au-vin/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0175-coqauvin/meta.yml
+++ b/data/episodes/c/episode-0175-coqauvin/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0176-cornbread/meta.yml
+++ b/data/episodes/c/episode-0176-cornbread/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0177-corn-dogs/meta.yml
+++ b/data/episodes/c/episode-0177-corn-dogs/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0178-corned-beef/meta.yml
+++ b/data/episodes/c/episode-0178-corned-beef/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0179-crab-bisque-seinfeld/meta.yml
+++ b/data/episodes/c/episode-0179-crab-bisque-seinfeld/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0180-cremebrule/meta.yml
+++ b/data/episodes/c/episode-0180-cremebrule/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0181-creme-caramel/meta.yml
+++ b/data/episodes/c/episode-0181-creme-caramel/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0182-crepessuzette/meta.yml
+++ b/data/episodes/c/episode-0182-crepessuzette/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0183-crispiest-sandwich-kidnapped-on-christmas/meta.yml
+++ b/data/episodes/c/episode-0183-crispiest-sandwich-kidnapped-on-christmas/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0184-croquemadame/meta.yml
+++ b/data/episodes/c/episode-0184-croquemadame/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0185-croque-madame-kringle/meta.yml
+++ b/data/episodes/c/episode-0185-croque-madame-kringle/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0186-croque-monsieur-brooklyn-nine-nine/meta.yml
+++ b/data/episodes/c/episode-0186-croque-monsieur-brooklyn-nine-nine/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0187-cubanos-inspired-by-chef/meta.yml
+++ b/data/episodes/c/episode-0187-cubanos-inspired-by-chef/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0188-curbyourenthusiasm/meta.yml
+++ b/data/episodes/c/episode-0188-curbyourenthusiasm/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/c/episode-0189-curry-risotto-omurice-inspired-by-food-wars/meta.yml
+++ b/data/episodes/c/episode-0189-curry-risotto-omurice-inspired-by-food-wars/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0190-dalgona-squid-games/meta.yml
+++ b/data/episodes/d/episode-0190-dalgona-squid-games/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0191-date-night/meta.yml
+++ b/data/episodes/d/episode-0191-date-night/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0192-date-night-2/data.yml
+++ b/data/episodes/d/episode-0192-date-night-2/data.yml
@@ -14,7 +14,17 @@ tags:
 - tag-0031
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1632
+- recipe-1633
+- recipe-1634
+- recipe-1635
+- recipe-1636
+- recipe-1637
+- recipe-1638
+- recipe-1639
+- recipe-1640
+- recipe-1641
 _lookup:
   slug: date-night-2
   babish_internal_id: wilrDSyBptiqkEoakxNU

--- a/data/episodes/d/episode-0192-date-night-2/meta.yml
+++ b/data/episodes/d/episode-0192-date-night-2/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0193-deadpoolpizza/meta.yml
+++ b/data/episodes/d/episode-0193-deadpoolpizza/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0194-deathsandwich/meta.yml
+++ b/data/episodes/d/episode-0194-deathsandwich/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0195-deepdishpizza/meta.yml
+++ b/data/episodes/d/episode-0195-deepdishpizza/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0196-deep-fried-burger-bomb/data.yml
+++ b/data/episodes/d/episode-0196-deep-fried-burger-bomb/data.yml
@@ -17,7 +17,13 @@ tags:
 - tag-0032
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1551
+- recipe-1552
+- recipe-1553
+- recipe-1554
+- recipe-1555
+- recipe-1556
 _lookup:
   slug: deep-fried-burger-bomb
   babish_internal_id: TWiioMDwLgLG8b7gm7v8

--- a/data/episodes/d/episode-0196-deep-fried-burger-bomb/meta.yml
+++ b/data/episodes/d/episode-0196-deep-fried-burger-bomb/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0197-demon-burger-inspired-by-dragon-ball-daima/meta.yml
+++ b/data/episodes/d/episode-0197-demon-burger-inspired-by-dragon-ball-daima/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0198-dessertdogs/meta.yml
+++ b/data/episodes/d/episode-0198-dessertdogs/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0199-dessertpasta/meta.yml
+++ b/data/episodes/d/episode-0199-dessertpasta/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0200-devil-fruit-inspired-by-one-piece/meta.yml
+++ b/data/episodes/d/episode-0200-devil-fruit-inspired-by-one-piece/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0201-dexter-key-lime-pie/meta.yml
+++ b/data/episodes/d/episode-0201-dexter-key-lime-pie/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0202-diablo-onigiri/meta.yml
+++ b/data/episodes/d/episode-0202-diablo-onigiri/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0203-dinner-wandavision/meta.yml
+++ b/data/episodes/d/episode-0203-dinner-wandavision/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0204-direwolfbread/meta.yml
+++ b/data/episodes/d/episode-0204-direwolfbread/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0205-dobladitas-con-salsa-verde/meta.yml
+++ b/data/episodes/d/episode-0205-dobladitas-con-salsa-verde/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0206-dollar300-a5-wagyu-sandwich-inspired-by-final-fantasy-xv/meta.yml
+++ b/data/episodes/d/episode-0206-dollar300-a5-wagyu-sandwich-inspired-by-final-fantasy-xv/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0207-donuts/meta.yml
+++ b/data/episodes/d/episode-0207-donuts/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0208-duck-fries-john-wick/meta.yml
+++ b/data/episodes/d/episode-0208-duck-fries-john-wick/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0209-dutchbaby/meta.yml
+++ b/data/episodes/d/episode-0209-dutchbaby/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/d/episode-0210-dutch-baby-with-cajeta-blueberry-sumac-compote/meta.yml
+++ b/data/episodes/d/episode-0210-dutch-baby-with-cajeta-blueberry-sumac-compote/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0211-egg-custard-tarts/meta.yml
+++ b/data/episodes/e/episode-0211-egg-custard-tarts/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0212-egginanest/meta.yml
+++ b/data/episodes/e/episode-0212-egginanest/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0213-eggnog-with-spiced-rum/meta.yml
+++ b/data/episodes/e/episode-0213-eggnog-with-spiced-rum/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0215-egg-salad-inspired-by-futurama/data.yml
+++ b/data/episodes/e/episode-0215-egg-salad-inspired-by-futurama/data.yml
@@ -19,7 +19,16 @@ tags:
 guests: []
 inspired_by:
 - reference-0211
-recipes: []
+recipes:
+- recipe-1585
+- recipe-1586
+- recipe-1587
+- recipe-1588
+- recipe-1589
+- recipe-1590
+- recipe-1591
+- recipe-1592
+- recipe-1593
 _lookup:
   slug: egg-salad-inspired-by-futurama
   babish_internal_id: C74tZp8HsAs2NNKhl7XE

--- a/data/episodes/e/episode-0215-egg-salad-inspired-by-futurama/meta.yml
+++ b/data/episodes/e/episode-0215-egg-salad-inspired-by-futurama/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0216-eggscellentchallenge/meta.yml
+++ b/data/episodes/e/episode-0216-eggscellentchallenge/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0217-eggsflorentine/meta.yml
+++ b/data/episodes/e/episode-0217-eggsflorentine/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0218-eggspart2/meta.yml
+++ b/data/episodes/e/episode-0218-eggspart2/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0219-eggswoodhouse/meta.yml
+++ b/data/episodes/e/episode-0219-eggswoodhouse/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0220-el-burdigato-teen-titans-go/meta.yml
+++ b/data/episodes/e/episode-0220-el-burdigato-teen-titans-go/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0221-elote-risotto-with-sauteed-octopus/meta.yml
+++ b/data/episodes/e/episode-0221-elote-risotto-with-sauteed-octopus/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0222-empanadas/meta.yml
+++ b/data/episodes/e/episode-0222-empanadas/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0223-enchiladas-schitts-creek/meta.yml
+++ b/data/episodes/e/episode-0223-enchiladas-schitts-creek/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0224-english-muffins/meta.yml
+++ b/data/episodes/e/episode-0224-english-muffins/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0225-espressodrinks/meta.yml
+++ b/data/episodes/e/episode-0225-espressodrinks/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0226-everymeatburrito/meta.yml
+++ b/data/episodes/e/episode-0226-everymeatburrito/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/e/episode-0227-everything-bagel-eeao/meta.yml
+++ b/data/episodes/e/episode-0227-everything-bagel-eeao/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0228-falafels/meta.yml
+++ b/data/episodes/f/episode-0228-falafels/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0229-fallout-fancy-lad-snack-cakes-inspired-by-fallout-76/data.yml
+++ b/data/episodes/f/episode-0229-fallout-fancy-lad-snack-cakes-inspired-by-fallout-76/data.yml
@@ -17,7 +17,16 @@ tags:
 guests: []
 inspired_by:
 - reference-0237
-recipes: []
+recipes:
+- recipe-1527
+- recipe-1528
+- recipe-1529
+- recipe-1530
+- recipe-1531
+- recipe-1532
+- recipe-1533
+- recipe-1534
+- recipe-1535
 _lookup:
   slug: fallout-fancy-lad-snack-cakes-inspired-by-fallout-76
   babish_internal_id: muwK2fn5SpJJMVRFNq0I

--- a/data/episodes/f/episode-0229-fallout-fancy-lad-snack-cakes-inspired-by-fallout-76/meta.yml
+++ b/data/episodes/f/episode-0229-fallout-fancy-lad-snack-cakes-inspired-by-fallout-76/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0230-feast-from-chef/meta.yml
+++ b/data/episodes/f/episode-0230-feast-from-chef/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0231-fettuccine-alfredo-the-office/meta.yml
+++ b/data/episodes/f/episode-0231-fettuccine-alfredo-the-office/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0232-fish/meta.yml
+++ b/data/episodes/f/episode-0232-fish/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0233-fish-fingers-custard-doctor-who/meta.yml
+++ b/data/episodes/f/episode-0233-fish-fingers-custard-doctor-who/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0234-fitz-sandwich/meta.yml
+++ b/data/episodes/f/episode-0234-fitz-sandwich/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0235-flandershotcocoa/meta.yml
+++ b/data/episodes/f/episode-0235-flandershotcocoa/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0236-flatbreads/meta.yml
+++ b/data/episodes/f/episode-0236-flatbreads/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0237-florentine-foccacia-sandwich-inspired-by/meta.yml
+++ b/data/episodes/f/episode-0237-florentine-foccacia-sandwich-inspired-by/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0238-footlong-taco-dogs-bobs-burgers/meta.yml
+++ b/data/episodes/f/episode-0238-footlong-taco-dogs-bobs-burgers/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0239-forrestgumpshrimp/meta.yml
+++ b/data/episodes/f/episode-0239-forrestgumpshrimp/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0240-four-horsemeal-eggporkalypse-parks-and-rec/meta.yml
+++ b/data/episodes/f/episode-0240-four-horsemeal-eggporkalypse-parks-and-rec/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0241-fraiserspecial/meta.yml
+++ b/data/episodes/f/episode-0241-fraiserspecial/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0242-freddys-ribs-inspired-by-house-of-cards/meta.yml
+++ b/data/episodes/f/episode-0242-freddys-ribs-inspired-by-house-of-cards/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0243-freezer-meals/meta.yml
+++ b/data/episodes/f/episode-0243-freezer-meals/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0244-frenchonionsoup/meta.yml
+++ b/data/episodes/f/episode-0244-frenchonionsoup/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0245-french-toast/meta.yml
+++ b/data/episodes/f/episode-0245-french-toast/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0246-friday-night-fish-fry/meta.yml
+++ b/data/episodes/f/episode-0246-friday-night-fish-fry/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0247-fried-bear-inspired-food-wars/meta.yml
+++ b/data/episodes/f/episode-0247-fried-bear-inspired-food-wars/meta.yml
@@ -1,43 +1,44 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: overridden
     by: enrich-agent
     at: '2026-05-05'
-    scraper_proposed: []
+    scraper_proposed:
+    - reference-0063
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0248-fried-chicken-inspired-by-legend-of-zelda-tears-of-the-kingd/meta.yml
+++ b/data/episodes/f/episode-0248-fried-chicken-inspired-by-legend-of-zelda-tears-of-the-kingd/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0249-fried-chicken-waffle-breakfast-lasagna-inspired-by-the-boond/meta.yml
+++ b/data/episodes/f/episode-0249-fried-chicken-waffle-breakfast-lasagna-inspired-by-the-boond/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0250-friedgreentomatoes/meta.yml
+++ b/data/episodes/f/episode-0250-friedgreentomatoes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0251-friedrice/meta.yml
+++ b/data/episodes/f/episode-0251-friedrice/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0252-fried-rice-2-ways/meta.yml
+++ b/data/episodes/f/episode-0252-fried-rice-2-ways/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/f/episode-0253-futurama-shrimp-popplers/data.yml
+++ b/data/episodes/f/episode-0253-futurama-shrimp-popplers/data.yml
@@ -15,7 +15,8 @@ tags:
 - tag-0023
 - tag-0031
 guests: []
-inspired_by: []
+inspired_by:
+- reference-0211
 recipes:
 - recipe-1302
 _lookup:

--- a/data/episodes/f/episode-0253-futurama-shrimp-popplers/meta.yml
+++ b/data/episodes/f/episode-0253-futurama-shrimp-popplers/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0254-game-day-snacks-part-2/meta.yml
+++ b/data/episodes/g/episode-0254-game-day-snacks-part-2/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0255-garbageplate/meta.yml
+++ b/data/episodes/g/episode-0255-garbageplate/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0256-garlic-bread-scott-pilgrim/meta.yml
+++ b/data/episodes/g/episode-0256-garlic-bread-scott-pilgrim/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0257-generaltsoschicken/meta.yml
+++ b/data/episodes/g/episode-0257-generaltsoschicken/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0258-giant-onigiri-inspired-by-cooking-from-valkyries/meta.yml
+++ b/data/episodes/g/episode-0258-giant-onigiri-inspired-by-cooking-from-valkyries/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0259-giant-red-bean-bun-inspired-by-spirited-away/meta.yml
+++ b/data/episodes/g/episode-0259-giant-red-bean-bun-inspired-by-spirited-away/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0260-glowing-popsicles-the-mandalorian/meta.yml
+++ b/data/episodes/g/episode-0260-glowing-popsicles-the-mandalorian/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0261-gluten-free-pasta/meta.yml
+++ b/data/episodes/g/episode-0261-gluten-free-pasta/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0262-gnocchi/meta.yml
+++ b/data/episodes/g/episode-0262-gnocchi/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0263-golden-fried-rice-inspired-by-kaguya-sama-love-is-war/meta.yml
+++ b/data/episodes/g/episode-0263-golden-fried-rice-inspired-by-kaguya-sama-love-is-war/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0264-goodfellasprisonsauce/meta.yml
+++ b/data/episodes/g/episode-0264-goodfellasprisonsauce/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0265-goodmorningburger/meta.yml
+++ b/data/episodes/g/episode-0265-goodmorningburger/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0266-gotcha-pork-roast-food-wars/meta.yml
+++ b/data/episodes/g/episode-0266-gotcha-pork-roast-food-wars/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0267-go-to-pasta/meta.yml
+++ b/data/episodes/g/episode-0267-go-to-pasta/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0268-gourmet-choco-taco/meta.yml
+++ b/data/episodes/g/episode-0268-gourmet-choco-taco/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0269-gourmet-meat-stew-inspired-by-breath-of-the-wild/meta.yml
+++ b/data/episodes/g/episode-0269-gourmet-meat-stew-inspired-by-breath-of-the-wild/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0270-green-goddess-egg-salad/meta.yml
+++ b/data/episodes/g/episode-0270-green-goddess-egg-salad/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0271-grilledcheesedeluxe/meta.yml
+++ b/data/episodes/g/episode-0271-grilledcheesedeluxe/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0273-grilled-feast/meta.yml
+++ b/data/episodes/g/episode-0273-grilled-feast/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0274-grilling-5j345/meta.yml
+++ b/data/episodes/g/episode-0274-grilling-5j345/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/g/episode-0275-grits-breakfast-my-cousin-vinny/meta.yml
+++ b/data/episodes/g/episode-0275-grits-breakfast-my-cousin-vinny/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0276-halloumi-sandwich/meta.yml
+++ b/data/episodes/h/episode-0276-halloumi-sandwich/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0277-harrypotterspecial/meta.yml
+++ b/data/episodes/h/episode-0277-harrypotterspecial/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0278-healthier-crunchwrap-supreme/meta.yml
+++ b/data/episodes/h/episode-0278-healthier-crunchwrap-supreme/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0279-healthymeals/meta.yml
+++ b/data/episodes/h/episode-0279-healthymeals/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0280-healthymeals2/meta.yml
+++ b/data/episodes/h/episode-0280-healthymeals2/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0281-healthy-meals-brown-rice/meta.yml
+++ b/data/episodes/h/episode-0281-healthy-meals-brown-rice/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0282-herring-and-pumpkin-pot-pie-inspired-by-kiki-s-delivery-serv/meta.yml
+++ b/data/episodes/h/episode-0282-herring-and-pumpkin-pot-pie-inspired-by-kiki-s-delivery-serv/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0283-holidaycocktails/meta.yml
+++ b/data/episodes/h/episode-0283-holidaycocktails/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0284-home-alone-special/meta.yml
+++ b/data/episodes/h/episode-0284-home-alone-special/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0285-homemade-mozzarella/meta.yml
+++ b/data/episodes/h/episode-0285-homemade-mozzarella/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0286-honey-toast-inspired-by-chainsaw-man/meta.yml
+++ b/data/episodes/h/episode-0286-honey-toast-inspired-by-chainsaw-man/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0287-hot-chicken/meta.yml
+++ b/data/episodes/h/episode-0287-hot-chicken/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0288-hot-dog-bowl-inspired-by-detroit-s/meta.yml
+++ b/data/episodes/h/episode-0288-hot-dog-bowl-inspired-by-detroit-s/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/h/episode-0289-huevosrancheros/meta.yml
+++ b/data/episodes/h/episode-0289-huevosrancheros/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0290-icecream/meta.yml
+++ b/data/episodes/i/episode-0290-icecream/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0291-ice-cream-cake/meta.yml
+++ b/data/episodes/i/episode-0291-ice-cream-cake/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0292-ice-cream-sandwiches/meta.yml
+++ b/data/episodes/i/episode-0292-ice-cream-sandwiches/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0293-ichiraku-ramen-inspired-by-naruto/meta.yml
+++ b/data/episodes/i/episode-0293-ichiraku-ramen-inspired-by-naruto/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0294-if-looks-could-kale/meta.yml
+++ b/data/episodes/i/episode-0294-if-looks-could-kale/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0295-iloveyoumanfishtacos/meta.yml
+++ b/data/episodes/i/episode-0295-iloveyoumanfishtacos/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0296-il-timpano-inspired-by-big-night/meta.yml
+++ b/data/episodes/i/episode-0296-il-timpano-inspired-by-big-night/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0297-imaginary-pie-hook/meta.yml
+++ b/data/episodes/i/episode-0297-imaginary-pie-hook/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0298-indianbreads/meta.yml
+++ b/data/episodes/i/episode-0298-indianbreads/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0299-infernowings/meta.yml
+++ b/data/episodes/i/episode-0299-infernowings/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0300-ingloriousbasterds/meta.yml
+++ b/data/episodes/i/episode-0300-ingloriousbasterds/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0301-instant-mac-cheese/meta.yml
+++ b/data/episodes/i/episode-0301-instant-mac-cheese/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0302-introductiontools/meta.yml
+++ b/data/episodes/i/episode-0302-introductiontools/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0303-isotope-dog-the-simpsons/meta.yml
+++ b/data/episodes/i/episode-0303-isotope-dog-the-simpsons/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/i/episode-0304-itsalwayssunnyspecial/meta.yml
+++ b/data/episodes/i/episode-0304-itsalwayssunnyspecial/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/j/episode-0305-jalapeno-popper-mac-and-cheese/meta.yml
+++ b/data/episodes/j/episode-0305-jalapeno-popper-mac-and-cheese/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/j/episode-0306-japanese-style-big-mac-inspired-by-weathering-with-you/data.yml
+++ b/data/episodes/j/episode-0306-japanese-style-big-mac-inspired-by-weathering-with-you/data.yml
@@ -20,7 +20,13 @@ tags:
 guests: []
 inspired_by:
 - reference-0251
-recipes: []
+recipes:
+- recipe-1569
+- recipe-1570
+- recipe-1571
+- recipe-1572
+- recipe-1573
+- recipe-1574
 _lookup:
   slug: japanese-style-big-mac-inspired-by-weathering-with-you
   babish_internal_id: lOS91tCjwsGh091l7cOv

--- a/data/episodes/j/episode-0306-japanese-style-big-mac-inspired-by-weathering-with-you/meta.yml
+++ b/data/episodes/j/episode-0306-japanese-style-big-mac-inspired-by-weathering-with-you/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/j/episode-0307-jell-o-cake-nuka-cola-and-cram-inspired-by-fallout/data.yml
+++ b/data/episodes/j/episode-0307-jell-o-cake-nuka-cola-and-cram-inspired-by-fallout/data.yml
@@ -15,7 +15,8 @@ tags:
 - tag-0021
 - tag-0033
 guests: []
-inspired_by: []
+inspired_by:
+- reference-0315
 recipes:
 - recipe-1277
 _lookup:

--- a/data/episodes/j/episode-0307-jell-o-cake-nuka-cola-and-cram-inspired-by-fallout/meta.yml
+++ b/data/episodes/j/episode-0307-jell-o-cake-nuka-cola-and-cram-inspired-by-fallout/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/j/episode-0308-jerk-chicken/meta.yml
+++ b/data/episodes/j/episode-0308-jerk-chicken/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/j/episode-0309-jerk-meat-platter-inspired-by-futurama/data.yml
+++ b/data/episodes/j/episode-0309-jerk-meat-platter-inspired-by-futurama/data.yml
@@ -16,7 +16,8 @@ tags:
 - tag-0030
 - tag-0033
 guests: []
-inspired_by: []
+inspired_by:
+- reference-0211
 recipes:
 - recipe-1284
 _lookup:

--- a/data/episodes/j/episode-0309-jerk-meat-platter-inspired-by-futurama/meta.yml
+++ b/data/episodes/j/episode-0309-jerk-meat-platter-inspired-by-futurama/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/j/episode-0310-jiggly-souffle-omelette-inspired-by-food-wars/meta.yml
+++ b/data/episodes/j/episode-0310-jiggly-souffle-omelette-inspired-by-food-wars/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/j/episode-0311-johnnycakes/meta.yml
+++ b/data/episodes/j/episode-0311-johnnycakes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/j/episode-0312-judys-hot-cocoa-santa-clause/meta.yml
+++ b/data/episodes/j/episode-0312-judys-hot-cocoa-santa-clause/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0313-katz-s-corned-beef-and-pastrami/meta.yml
+++ b/data/episodes/k/episode-0313-katz-s-corned-beef-and-pastrami/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0314-kelp-bar-spongebob/meta.yml
+++ b/data/episodes/k/episode-0314-kelp-bar-spongebob/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0315-kettle-corn-community/meta.yml
+++ b/data/episodes/k/episode-0315-kettle-corn-community/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0316-kevinschili/meta.yml
+++ b/data/episodes/k/episode-0316-kevinschili/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0317-kevin-s-snacks-inspired-by-the-office/meta.yml
+++ b/data/episodes/k/episode-0317-kevin-s-snacks-inspired-by-the-office/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0318-kfcmeal/meta.yml
+++ b/data/episodes/k/episode-0318-kfcmeal/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0319-kikufuku-mochi-inspired-by-jujutsu-kaisen/meta.yml
+++ b/data/episodes/k/episode-0319-kikufuku-mochi-inspired-by-jujutsu-kaisen/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0320-kimbap-and-lunchbox-inspired-by-squid-game-season-2/meta.yml
+++ b/data/episodes/k/episode-0320-kimbap-and-lunchbox-inspired-by-squid-game-season-2/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0321-kimchi/meta.yml
+++ b/data/episodes/k/episode-0321-kimchi/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0322-kingofthehillspecial/meta.yml
+++ b/data/episodes/k/episode-0322-kingofthehillspecial/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0323-kitchencare/meta.yml
+++ b/data/episodes/k/episode-0323-kitchencare/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0324-korean-cheese-corn-dogs/meta.yml
+++ b/data/episodes/k/episode-0324-korean-cheese-corn-dogs/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0325-korean-garlic-fried-chicken-inspired-by-korean-street-food/meta.yml
+++ b/data/episodes/k/episode-0325-korean-garlic-fried-chicken-inspired-by-korean-street-food/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0326-korean-pizza-toast/meta.yml
+++ b/data/episodes/k/episode-0326-korean-pizza-toast/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0327-korean-rice-cakes/meta.yml
+++ b/data/episodes/k/episode-0327-korean-rice-cakes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0328-kpop-demon-hunters-airplane-feast/data.yml
+++ b/data/episodes/k/episode-0328-kpop-demon-hunters-airplane-feast/data.yml
@@ -19,7 +19,11 @@ tags:
 guests: []
 inspired_by:
 - reference-0313
-recipes: []
+recipes:
+- recipe-1463
+- recipe-1464
+- recipe-1465
+- recipe-1466
 _lookup:
   slug: kpop-demon-hunters-airplane-feast
   babish_internal_id: BjVXG6rVceZAPCPdwZGN

--- a/data/episodes/k/episode-0328-kpop-demon-hunters-airplane-feast/meta.yml
+++ b/data/episodes/k/episode-0328-kpop-demon-hunters-airplane-feast/meta.yml
@@ -1,43 +1,44 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: overridden
     by: enrich-agent
     at: '2026-05-05'
-    scraper_proposed: []
+    scraper_proposed:
+    - reference-0313
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0329-krabby-patty-inspired-by-spongebob-squarepants/meta.yml
+++ b/data/episodes/k/episode-0329-krabby-patty-inspired-by-spongebob-squarepants/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0330-krabbysupreme/meta.yml
+++ b/data/episodes/k/episode-0330-krabbysupreme/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0331-kumandra-soup-raya-and-the-last-dragon/meta.yml
+++ b/data/episodes/k/episode-0331-kumandra-soup-raya-and-the-last-dragon/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/k/episode-0332-kung-pao-chicken-seinfeld/meta.yml
+++ b/data/episodes/k/episode-0332-kung-pao-chicken-seinfeld/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0333-la-bombe-eclair-the-simpsons/meta.yml
+++ b/data/episodes/l/episode-0333-la-bombe-eclair-the-simpsons/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0334-lamb-chops/meta.yml
+++ b/data/episodes/l/episode-0334-lamb-chops/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0335-land-octopus-elden-ring/meta.yml
+++ b/data/episodes/l/episode-0335-land-octopus-elden-ring/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0336-larbstickyrice/meta.yml
+++ b/data/episodes/l/episode-0336-larbstickyrice/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0337-lasagna/meta.yml
+++ b/data/episodes/l/episode-0337-lasagna/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0338-last-minute-thanksgiving/meta.yml
+++ b/data/episodes/l/episode-0338-last-minute-thanksgiving/meta.yml
@@ -1,43 +1,44 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: overridden
     by: enrich-agent
     at: '2026-05-05'
-    scraper_proposed: []
+    scraper_proposed:
+    - reference-0323
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0339-latkes/meta.yml
+++ b/data/episodes/l/episode-0339-latkes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0340-lava-chicken-inspired-by-a-minecraft-movie/meta.yml
+++ b/data/episodes/l/episode-0340-lava-chicken-inspired-by-a-minecraft-movie/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0341-layered-butter-toast-danish-creamery/meta.yml
+++ b/data/episodes/l/episode-0341-layered-butter-toast-danish-creamery/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0342-leftover-caviar-pasta/meta.yml
+++ b/data/episodes/l/episode-0342-leftover-caviar-pasta/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0343-lemon-cakes-inspired-by-game-of-thrones/meta.yml
+++ b/data/episodes/l/episode-0343-lemon-cakes-inspired-by-game-of-thrones/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0344-lemon-meringue-pie/meta.yml
+++ b/data/episodes/l/episode-0344-lemon-meringue-pie/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0345-lemon-pepper-wet/meta.yml
+++ b/data/episodes/l/episode-0345-lemon-pepper-wet/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0346-lentil-soup-moon-knight/meta.yml
+++ b/data/episodes/l/episode-0346-lentil-soup-moon-knight/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0347-let-s-make-french-onion-soup/meta.yml
+++ b/data/episodes/l/episode-0347-let-s-make-french-onion-soup/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0348-let-s-make-steak-and-eggs-au-poivre/meta.yml
+++ b/data/episodes/l/episode-0348-let-s-make-steak-and-eggs-au-poivre/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0349-level-9-babish-s-pbandj/meta.yml
+++ b/data/episodes/l/episode-0349-level-9-babish-s-pbandj/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0350-lilbits-rickandmorty/meta.yml
+++ b/data/episodes/l/episode-0350-lilbits-rickandmorty/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0351-lobster-salad-panzanella/meta.yml
+++ b/data/episodes/l/episode-0351-lobster-salad-panzanella/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0352-lobster-scrambled-eggs-seinfeld/meta.yml
+++ b/data/episodes/l/episode-0352-lobster-scrambled-eggs-seinfeld/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0353-looney-cake-succession/meta.yml
+++ b/data/episodes/l/episode-0353-looney-cake-succession/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0354-lotr-feast-special/meta.yml
+++ b/data/episodes/l/episode-0354-lotr-feast-special/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0355-louiefriedchicken/meta.yml
+++ b/data/episodes/l/episode-0355-louiefriedchicken/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/l/episode-0357-lunches-the-breakfast-club/meta.yml
+++ b/data/episodes/l/episode-0357-lunches-the-breakfast-club/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0358-macandcheese/meta.yml
+++ b/data/episodes/m/episode-0358-macandcheese/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0359-macarons-the-mandalorian/meta.yml
+++ b/data/episodes/m/episode-0359-macarons-the-mandalorian/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0360-madmen/meta.yml
+++ b/data/episodes/m/episode-0360-madmen/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0361-maisel-brisket/meta.yml
+++ b/data/episodes/m/episode-0361-maisel-brisket/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0362-marmalade/meta.yml
+++ b/data/episodes/m/episode-0362-marmalade/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0363-mashed-potatoes/meta.yml
+++ b/data/episodes/m/episode-0363-mashed-potatoes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0364-mayors-request-cloudy-with-a-chance-of-meatballs/meta.yml
+++ b/data/episodes/m/episode-0364-mayors-request-cloudy-with-a-chance-of-meatballs/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0365-mc1035-archer/meta.yml
+++ b/data/episodes/m/episode-0365-mc1035-archer/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0366-mean-girls-toaster-strudel/data.yml
+++ b/data/episodes/m/episode-0366-mean-girls-toaster-strudel/data.yml
@@ -15,7 +15,8 @@ tags:
 - tag-0028
 - tag-0032
 guests: []
-inspired_by: []
+inspired_by:
+- reference-0320
 recipes:
 - recipe-1298
 _lookup:

--- a/data/episodes/m/episode-0366-mean-girls-toaster-strudel/meta.yml
+++ b/data/episodes/m/episode-0366-mean-girls-toaster-strudel/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0367-meatballs-30rock/meta.yml
+++ b/data/episodes/m/episode-0367-meatballs-30rock/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0368-meatball-smashwich-with-babish/meta.yml
+++ b/data/episodes/m/episode-0368-meatball-smashwich-with-babish/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0369-meatghetti-spagballs-american-dad/meta.yml
+++ b/data/episodes/m/episode-0369-meatghetti-spagballs-american-dad/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0370-meatloaf/meta.yml
+++ b/data/episodes/m/episode-0370-meatloaf/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0371-meat-pies-sweeny-todd/meta.yml
+++ b/data/episodes/m/episode-0371-meat-pies-sweeny-todd/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0372-meat-tornado-parks-and-rec/meta.yml
+++ b/data/episodes/m/episode-0372-meat-tornado-parks-and-rec/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0373-mega-beef-bowl-inspired-by-persona-4/meta.yml
+++ b/data/episodes/m/episode-0373-mega-beef-bowl-inspired-by-persona-4/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0374-megs-dinner-family-guy/meta.yml
+++ b/data/episodes/m/episode-0374-megs-dinner-family-guy/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0375-michaelscottpretzel/meta.yml
+++ b/data/episodes/m/episode-0375-michaelscottpretzel/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0376-millionaires-shortbread/meta.yml
+++ b/data/episodes/m/episode-0376-millionaires-shortbread/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0377-minecraft-cake-inspired-by-minecraft/meta.yml
+++ b/data/episodes/m/episode-0377-minecraft-cake-inspired-by-minecraft/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0378-mirages-pork-chops/meta.yml
+++ b/data/episodes/m/episode-0378-mirages-pork-chops/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0379-miso-honey-butter-pancakes/meta.yml
+++ b/data/episodes/m/episode-0379-miso-honey-butter-pancakes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0380-mitarashi-dango-inspired-by-demon-slayer/meta.yml
+++ b/data/episodes/m/episode-0380-mitarashi-dango-inspired-by-demon-slayer/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0381-mochi-icecream/meta.yml
+++ b/data/episodes/m/episode-0381-mochi-icecream/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0382-mofongo/meta.yml
+++ b/data/episodes/m/episode-0382-mofongo/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0383-moistmaker/meta.yml
+++ b/data/episodes/m/episode-0383-moistmaker/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0384-monicas-candy-friends/meta.yml
+++ b/data/episodes/m/episode-0384-monicas-candy-friends/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0385-monkey-bread/meta.yml
+++ b/data/episodes/m/episode-0385-monkey-bread/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0386-monte-cristo-american-dad/meta.yml
+++ b/data/episodes/m/episode-0386-monte-cristo-american-dad/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0387-moonwaffles/meta.yml
+++ b/data/episodes/m/episode-0387-moonwaffles/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0388-moroccanpasta/meta.yml
+++ b/data/episodes/m/episode-0388-moroccanpasta/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0389-mostexpensiveshake/meta.yml
+++ b/data/episodes/m/episode-0389-mostexpensiveshake/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0390-mulancongee/meta.yml
+++ b/data/episodes/m/episode-0390-mulancongee/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0391-mushroom-pasta-super-mario-movie/meta.yml
+++ b/data/episodes/m/episode-0391-mushroom-pasta-super-mario-movie/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/m/episode-0392-my-top-5-easy-sexy-dishes/data.yml
+++ b/data/episodes/m/episode-0392-my-top-5-easy-sexy-dishes/data.yml
@@ -17,7 +17,15 @@ tags:
 - tag-0031
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1599
+- recipe-1600
+- recipe-1601
+- recipe-1602
+- recipe-1603
+- recipe-1604
+- recipe-1605
+- recipe-1606
 _lookup:
   slug: my-top-5-easy-sexy-dishes
   babish_internal_id: WnE7kh7sK7LnkKhQxb1f

--- a/data/episodes/m/episode-0392-my-top-5-easy-sexy-dishes/meta.yml
+++ b/data/episodes/m/episode-0392-my-top-5-easy-sexy-dishes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/n/episode-0393-nachos/meta.yml
+++ b/data/episodes/n/episode-0393-nachos/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/n/episode-0394-nipples-of-venus-amadeus/meta.yml
+++ b/data/episodes/n/episode-0394-nipples-of-venus-amadeus/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/n/episode-0395-nopal-katsu-sando/meta.yml
+++ b/data/episodes/n/episode-0395-nopal-katsu-sando/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/n/episode-0396-nypizzatmnt/meta.yml
+++ b/data/episodes/n/episode-0396-nypizzatmnt/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/o/episode-0397-okonomiyaki/meta.yml
+++ b/data/episodes/o/episode-0397-okonomiyaki/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/o/episode-0398-omelette-du-fromage-dexters-laboratory/meta.yml
+++ b/data/episodes/o/episode-0398-omelette-du-fromage-dexters-laboratory/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/o/episode-0399-one-piece-tuna-saute/data.yml
+++ b/data/episodes/o/episode-0399-one-piece-tuna-saute/data.yml
@@ -12,7 +12,8 @@ tags:
 - tag-0002
 - tag-0004
 guests: []
-inspired_by: []
+inspired_by:
+- reference-0244
 recipes:
 - recipe-1296
 _lookup:

--- a/data/episodes/o/episode-0399-one-piece-tuna-saute/meta.yml
+++ b/data/episodes/o/episode-0399-one-piece-tuna-saute/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/o/episode-0400-onepot-pasta/meta.yml
+++ b/data/episodes/o/episode-0400-onepot-pasta/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/o/episode-0401-orangemochafrapp/meta.yml
+++ b/data/episodes/o/episode-0401-orangemochafrapp/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/o/episode-0402-orangemochafrapp-fpm9l/meta.yml
+++ b/data/episodes/o/episode-0402-orangemochafrapp-fpm9l/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/o/episode-0403-ossobuco/meta.yml
+++ b/data/episodes/o/episode-0403-ossobuco/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/o/episode-0404-oyakodon/meta.yml
+++ b/data/episodes/o/episode-0404-oyakodon/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0405-pancontomate-crabcakes/meta.yml
+++ b/data/episodes/p/episode-0405-pancontomate-crabcakes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0406-panna-cotta-with-poached-pears/meta.yml
+++ b/data/episodes/p/episode-0406-panna-cotta-with-poached-pears/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0407-panpizza/meta.yml
+++ b/data/episodes/p/episode-0407-panpizza/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0408-pan-sauces/meta.yml
+++ b/data/episodes/p/episode-0408-pan-sauces/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0410-parksandrecburger/meta.yml
+++ b/data/episodes/p/episode-0410-parksandrecburger/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0411-parmhero/data.yml
+++ b/data/episodes/p/episode-0411-parmhero/data.yml
@@ -19,6 +19,7 @@ inspired_by:
 - reference-0020
 - reference-0042
 - reference-0076
+- reference-0324
 recipes:
 - recipe-0292
 _lookup:

--- a/data/episodes/p/episode-0411-parmhero/meta.yml
+++ b/data/episodes/p/episode-0411-parmhero/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0412-pasta2/meta.yml
+++ b/data/episodes/p/episode-0412-pasta2/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0413-pasta-al-limone/meta.yml
+++ b/data/episodes/p/episode-0413-pasta-al-limone/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0414-pasta-curry-inspired-by-pokemon-sword-and-shield/meta.yml
+++ b/data/episodes/p/episode-0414-pasta-curry-inspired-by-pokemon-sword-and-shield/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0415-pastaputtanesca/meta.yml
+++ b/data/episodes/p/episode-0415-pastaputtanesca/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0416-pasta-salad/meta.yml
+++ b/data/episodes/p/episode-0416-pasta-salad/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0417-pastrami/meta.yml
+++ b/data/episodes/p/episode-0417-pastrami/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0418-patricks-briefcase-spongebob/meta.yml
+++ b/data/episodes/p/episode-0418-patricks-briefcase-spongebob/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0419-paunch-burger-parks-and-rec/meta.yml
+++ b/data/episodes/p/episode-0419-paunch-burger-parks-and-rec/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0420-peachs-cake-mario-64/meta.yml
+++ b/data/episodes/p/episode-0420-peachs-cake-mario-64/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0421-pekingduck/meta.yml
+++ b/data/episodes/p/episode-0421-pekingduck/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0422-pesto/meta.yml
+++ b/data/episodes/p/episode-0422-pesto/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0423-phantomthread-l42pw/meta.yml
+++ b/data/episodes/p/episode-0423-phantomthread-l42pw/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0424-pho-carnitas-with-nuoc-cham/meta.yml
+++ b/data/episodes/p/episode-0424-pho-carnitas-with-nuoc-cham/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0425-picnic-food/meta.yml
+++ b/data/episodes/p/episode-0425-picnic-food/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0426-pierogis/data.yml
+++ b/data/episodes/p/episode-0426-pierogis/data.yml
@@ -13,7 +13,14 @@ tags:
 - tag-0019
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1625
+- recipe-1626
+- recipe-1627
+- recipe-1628
+- recipe-1629
+- recipe-1630
+- recipe-1631
 _lookup:
   slug: pierogis
   babish_internal_id: xaB9P5JjxOEMtv39AkH8

--- a/data/episodes/p/episode-0426-pierogis/meta.yml
+++ b/data/episodes/p/episode-0426-pierogis/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0427-pies/meta.yml
+++ b/data/episodes/p/episode-0427-pies/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0428-piesfromwaitress/meta.yml
+++ b/data/episodes/p/episode-0428-piesfromwaitress/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0429-pigeon-pie-with-wild-game-inspired-by-game-of-thrones/meta.yml
+++ b/data/episodes/p/episode-0429-pigeon-pie-with-wild-game-inspired-by-game-of-thrones/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0430-pigs-in-a-blanket-office/meta.yml
+++ b/data/episodes/p/episode-0430-pigs-in-a-blanket-office/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0431-pineapplecurryfriedrice/meta.yml
+++ b/data/episodes/p/episode-0431-pineapplecurryfriedrice/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0432-pistachio-cake-with-chocolate-ganache/meta.yml
+++ b/data/episodes/p/episode-0432-pistachio-cake-with-chocolate-ganache/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0433-pizzaball/meta.yml
+++ b/data/episodes/p/episode-0433-pizzaball/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0434-pizza-balls-mom/meta.yml
+++ b/data/episodes/p/episode-0434-pizza-balls-mom/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0435-pizza-dough/meta.yml
+++ b/data/episodes/p/episode-0435-pizza-dough/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0436-pizza-gyoza-tmnt/meta.yml
+++ b/data/episodes/p/episode-0436-pizza-gyoza-tmnt/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0437-pizza-in-a-cup-the-jerk/meta.yml
+++ b/data/episodes/p/episode-0437-pizza-in-a-cup-the-jerk/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0438-plum-pie-puss-in-boots/meta.yml
+++ b/data/episodes/p/episode-0438-plum-pie-puss-in-boots/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0439-poke-bowls/meta.yml
+++ b/data/episodes/p/episode-0439-poke-bowls/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0440-pollo-a-la-plancha/meta.yml
+++ b/data/episodes/p/episode-0440-pollo-a-la-plancha/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0441-pollos-hermanos-breaking-bad/meta.yml
+++ b/data/episodes/p/episode-0441-pollos-hermanos-breaking-bad/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0442-porchetta/meta.yml
+++ b/data/episodes/p/episode-0442-porchetta/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0443-pork-katsudon-inspired-by-yuri-on-ice/meta.yml
+++ b/data/episodes/p/episode-0443-pork-katsudon-inspired-by-yuri-on-ice/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0444-pork-picnic-sandwich-regular-show/meta.yml
+++ b/data/episodes/p/episode-0444-pork-picnic-sandwich-regular-show/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0445-portalcake/meta.yml
+++ b/data/episodes/p/episode-0445-portalcake/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0446-potato-chip-omelet-the-bear/meta.yml
+++ b/data/episodes/p/episode-0446-potato-chip-omelet-the-bear/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0447-potato-hash/meta.yml
+++ b/data/episodes/p/episode-0447-potato-hash/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0448-potroast/meta.yml
+++ b/data/episodes/p/episode-0448-potroast/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0449-potsticker-pizza/meta.yml
+++ b/data/episodes/p/episode-0449-potsticker-pizza/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0450-potstickers/meta.yml
+++ b/data/episodes/p/episode-0450-potstickers/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0451-poutine/meta.yml
+++ b/data/episodes/p/episode-0451-poutine/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0452-pretty-patties-spongebob/meta.yml
+++ b/data/episodes/p/episode-0452-pretty-patties-spongebob/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0453-protein-pizza/meta.yml
+++ b/data/episodes/p/episode-0453-protein-pizza/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0454-puerco-pibil/meta.yml
+++ b/data/episodes/p/episode-0454-puerco-pibil/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0455-pullednoodles/meta.yml
+++ b/data/episodes/p/episode-0455-pullednoodles/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0456-pulledpork/meta.yml
+++ b/data/episodes/p/episode-0456-pulledpork/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/p/episode-0457-puppy-paw-hashbrowns/meta.yml
+++ b/data/episodes/p/episode-0457-puppy-paw-hashbrowns/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/q/episode-0458-quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv/data.yml
+++ b/data/episodes/q/episode-0458-quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv/data.yml
@@ -22,7 +22,13 @@ tags:
 guests: []
 inspired_by:
 - reference-0243
-recipes: []
+recipes:
+- recipe-1545
+- recipe-1546
+- recipe-1547
+- recipe-1548
+- recipe-1549
+- recipe-1550
 _lookup:
   slug: quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv
   babish_internal_id: 5LHvJD6Zg8CpDl1eqs9Z

--- a/data/episodes/q/episode-0458-quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv/meta.yml
+++ b/data/episodes/q/episode-0458-quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/q/episode-0459-quatroquesodosfritos/meta.yml
+++ b/data/episodes/q/episode-0459-quatroquesodosfritos/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/q/episode-0460-quesadillas/meta.yml
+++ b/data/episodes/q/episode-0460-quesadillas/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/q/episode-0461-quiche/meta.yml
+++ b/data/episodes/q/episode-0461-quiche/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0463-rabbit-last-of-us/meta.yml
+++ b/data/episodes/r/episode-0463-rabbit-last-of-us/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0464-rabbit-sopranos/meta.yml
+++ b/data/episodes/r/episode-0464-rabbit-sopranos/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0465-racheltrifle/meta.yml
+++ b/data/episodes/r/episode-0465-racheltrifle/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0466-raisinets/meta.yml
+++ b/data/episodes/r/episode-0466-raisinets/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0467-ram-don-parasite/meta.yml
+++ b/data/episodes/r/episode-0467-ram-don-parasite/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0468-ramen-hacks/meta.yml
+++ b/data/episodes/r/episode-0468-ramen-hacks/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0469-raspberry-danish-ant-man-and-the-wasp/meta.yml
+++ b/data/episodes/r/episode-0469-raspberry-danish-ant-man-and-the-wasp/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0470-ratatouille/meta.yml
+++ b/data/episodes/r/episode-0470-ratatouille/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0471-regular-show-mississippi-queen/meta.yml
+++ b/data/episodes/r/episode-0471-regular-show-mississippi-queen/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0472-remys-soup-ratatouille/meta.yml
+++ b/data/episodes/r/episode-0472-remys-soup-ratatouille/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0473-renaissance-wrap-inspired-by-shrek-2/data.yml
+++ b/data/episodes/r/episode-0473-renaissance-wrap-inspired-by-shrek-2/data.yml
@@ -15,7 +15,8 @@ tags:
 - tag-0032
 - tag-0033
 guests: []
-inspired_by: []
+inspired_by:
+- reference-0316
 recipes:
 - recipe-1278
 _lookup:

--- a/data/episodes/r/episode-0473-renaissance-wrap-inspired-by-shrek-2/meta.yml
+++ b/data/episodes/r/episode-0473-renaissance-wrap-inspired-by-shrek-2/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0474-restaurant-wars-steven-universe/meta.yml
+++ b/data/episodes/r/episode-0474-restaurant-wars-steven-universe/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0475-reversesearsteak/meta.yml
+++ b/data/episodes/r/episode-0475-reversesearsteak/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0476-ribwich/meta.yml
+++ b/data/episodes/r/episode-0476-ribwich/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0477-rick-and-morty-every-burger/meta.yml
+++ b/data/episodes/r/episode-0477-rick-and-morty-every-burger/meta.yml
@@ -1,43 +1,46 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: overridden
     by: enrich-agent
     at: '2026-05-05'
-    scraper_proposed: []
+    scraper_proposed:
+    - reference-0081
+    - reference-0321
+    - reference-0322
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0478-risotto/meta.yml
+++ b/data/episodes/r/episode-0478-risotto/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0479-risotto-tricolore-big-night/meta.yml
+++ b/data/episodes/r/episode-0479-risotto-tricolore-big-night/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0480-roastbeast/meta.yml
+++ b/data/episodes/r/episode-0480-roastbeast/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0481-roast-beef-inspired-by-attack-on-titan/meta.yml
+++ b/data/episodes/r/episode-0481-roast-beef-inspired-by-attack-on-titan/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0482-root-beer-noodles-the-simpsons/meta.yml
+++ b/data/episodes/r/episode-0482-root-beer-noodles-the-simpsons/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/r/episode-0483-rumfrenchtoast/meta.yml
+++ b/data/episodes/r/episode-0483-rumfrenchtoast/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0484-salad-nb7s3-3jkft/meta.yml
+++ b/data/episodes/s/episode-0484-salad-nb7s3-3jkft/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0485-sandyfryesappetizers/meta.yml
+++ b/data/episodes/s/episode-0485-sandyfryesappetizers/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0486-sanji-s-seafood-risotto/meta.yml
+++ b/data/episodes/s/episode-0486-sanji-s-seafood-risotto/meta.yml
@@ -1,43 +1,44 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: overridden
     by: enrich-agent
     at: '2026-05-05'
-    scraper_proposed: []
+    scraper_proposed:
+    - reference-0244
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0487-sauces/meta.yml
+++ b/data/episodes/s/episode-0487-sauces/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0488-sauces-9w5tm/meta.yml
+++ b/data/episodes/s/episode-0488-sauces-9w5tm/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0489-sauces-9w5tm-2njph/meta.yml
+++ b/data/episodes/s/episode-0489-sauces-9w5tm-2njph/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0490-sauces-9w5tm-2njph-5ahwj/meta.yml
+++ b/data/episodes/s/episode-0490-sauces-9w5tm-2njph-5ahwj/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0491-sauces-9w5tm-2njph-5ahwj-hsl7s/meta.yml
+++ b/data/episodes/s/episode-0491-sauces-9w5tm-2njph-5ahwj-hsl7s/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0492-sauces-9w5tm-2njph-5ahwj-hsl7s-fh6cr/meta.yml
+++ b/data/episodes/s/episode-0492-sauces-9w5tm-2njph-5ahwj-hsl7s-fh6cr/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0493-sauces-9w5tm-2njph-5ahwj-hsl7s-fh6cr-6r8lw/meta.yml
+++ b/data/episodes/s/episode-0493-sauces-9w5tm-2njph-5ahwj-hsl7s-fh6cr-6r8lw/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0494-sauces-9w5tm-2njph-5ahwj-hsl7s-fh6cr-dfapr/meta.yml
+++ b/data/episodes/s/episode-0494-sauces-9w5tm-2njph-5ahwj-hsl7s-fh6cr-dfapr/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0495-sausage-inspired-by-god-of-war/meta.yml
+++ b/data/episodes/s/episode-0495-sausage-inspired-by-god-of-war/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0496-sausages-ragnarok/meta.yml
+++ b/data/episodes/s/episode-0496-sausages-ragnarok/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0497-savory-cannoli-the-bear/meta.yml
+++ b/data/episodes/s/episode-0497-savory-cannoli-the-bear/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0498-scallion-noodles-eeaao/meta.yml
+++ b/data/episodes/s/episode-0498-scallion-noodles-eeaao/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0499-schweddy-balls-snl/meta.yml
+++ b/data/episodes/s/episode-0499-schweddy-balls-snl/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0500-seafood-paella-parks-and-rec/meta.yml
+++ b/data/episodes/s/episode-0500-seafood-paella-parks-and-rec/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0501-seasalticecream/meta.yml
+++ b/data/episodes/s/episode-0501-seasalticecream/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0502-seinfeldcalzone-z38zn/meta.yml
+++ b/data/episodes/s/episode-0502-seinfeldcalzone-z38zn/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0503-seinfeldspecial2/meta.yml
+++ b/data/episodes/s/episode-0503-seinfeldspecial2/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0504-seven-layer-salad-himym/meta.yml
+++ b/data/episodes/s/episode-0504-seven-layer-salad-himym/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0505-sf-style-vietnamese-spaghetti-with-clams/meta.yml
+++ b/data/episodes/s/episode-0505-sf-style-vietnamese-spaghetti-with-clams/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0506-shakshuka/meta.yml
+++ b/data/episodes/s/episode-0506-shakshuka/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0507-shawarma/meta.yml
+++ b/data/episodes/s/episode-0507-shawarma/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0508-shepherdspie/meta.yml
+++ b/data/episodes/s/episode-0508-shepherdspie/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0509-short-ribs/meta.yml
+++ b/data/episodes/s/episode-0509-short-ribs/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0510-shrimp-7-ways/data.yml
+++ b/data/episodes/s/episode-0510-shrimp-7-ways/data.yml
@@ -17,7 +17,12 @@ tags:
 - tag-0031
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1594
+- recipe-1595
+- recipe-1596
+- recipe-1597
+- recipe-1598
 _lookup:
   slug: shrimp-7-ways
   babish_internal_id: mY1OCiuvecLrTae1Ebwk

--- a/data/episodes/s/episode-0510-shrimp-7-ways/meta.yml
+++ b/data/episodes/s/episode-0510-shrimp-7-ways/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0512-shrimp-scampi-basics/meta.yml
+++ b/data/episodes/s/episode-0512-shrimp-scampi-basics/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0513-skinnersstew/meta.yml
+++ b/data/episodes/s/episode-0513-skinnersstew/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0514-sliders-three-ways/meta.yml
+++ b/data/episodes/s/episode-0514-sliders-three-ways/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0515-sloppy-joes-billy-madison/meta.yml
+++ b/data/episodes/s/episode-0515-sloppy-joes-billy-madison/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0516-sloppy-steaks-i-think-you-should-leave/meta.yml
+++ b/data/episodes/s/episode-0516-sloppy-steaks-i-think-you-should-leave/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0517-smash-burgers/meta.yml
+++ b/data/episodes/s/episode-0517-smash-burgers/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0518-smokedribs/meta.yml
+++ b/data/episodes/s/episode-0518-smokedribs/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0519-snl-overnight-salad/meta.yml
+++ b/data/episodes/s/episode-0519-snl-overnight-salad/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0520-souffle-pancakes-inspired-by-food-wars/meta.yml
+++ b/data/episodes/s/episode-0520-souffle-pancakes-inspired-by-food-wars/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0521-sourdough-bread/meta.yml
+++ b/data/episodes/s/episode-0521-sourdough-bread/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0522-sourdough-broccoli-pizza-inside-out/meta.yml
+++ b/data/episodes/s/episode-0522-sourdough-broccoli-pizza-inside-out/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0523-sousvide-nb7s3/meta.yml
+++ b/data/episodes/s/episode-0523-sousvide-nb7s3/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0524-southparkspecial/meta.yml
+++ b/data/episodes/s/episode-0524-southparkspecial/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0525-souvlaki/meta.yml
+++ b/data/episodes/s/episode-0525-souvlaki/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0526-space-cake-high-maintenance/meta.yml
+++ b/data/episodes/s/episode-0526-space-cake-high-maintenance/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0527-spaghetti-all-assassina-inspired-by-claudia-romeo/meta.yml
+++ b/data/episodes/s/episode-0527-spaghetti-all-assassina-inspired-by-claudia-romeo/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0528-spaghetti-carbonara-inspired-by-master-of-none/meta.yml
+++ b/data/episodes/s/episode-0528-spaghetti-carbonara-inspired-by-master-of-none/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0529-spaghettitaco/meta.yml
+++ b/data/episodes/s/episode-0529-spaghettitaco/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0530-spanakopita-galettes/meta.yml
+++ b/data/episodes/s/episode-0530-spanakopita-galettes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0531-spanish-tortilla-with-leek/meta.yml
+++ b/data/episodes/s/episode-0531-spanish-tortilla-with-leek/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0532-spiced-rum-tarte-tatin/meta.yml
+++ b/data/episodes/s/episode-0532-spiced-rum-tarte-tatin/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0533-spicy-rum-chicken-curry-inspired-by-super-smash-bros/meta.yml
+++ b/data/episodes/s/episode-0533-spicy-rum-chicken-curry-inspired-by-super-smash-bros/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0534-spidermanbackpackrecipes/meta.yml
+++ b/data/episodes/s/episode-0534-spidermanbackpackrecipes/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0535-spiderverse-beef-patty/meta.yml
+++ b/data/episodes/s/episode-0535-spiderverse-beef-patty/meta.yml
@@ -1,43 +1,45 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: overridden
     by: enrich-agent
     at: '2026-05-05'
-    scraper_proposed: []
+    scraper_proposed:
+    - reference-0206
+    - reference-0311
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0536-spiedini-alla-romana/meta.yml
+++ b/data/episodes/s/episode-0536-spiedini-alla-romana/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0537-spinachpuffs/meta.yml
+++ b/data/episodes/s/episode-0537-spinachpuffs/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0538-spongebob-and-patrick-ice-cream/meta.yml
+++ b/data/episodes/s/episode-0538-spongebob-and-patrick-ice-cream/meta.yml
@@ -1,43 +1,44 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: overridden
     by: enrich-agent
     at: '2026-05-05'
-    scraper_proposed: []
+    scraper_proposed:
+    - reference-0020
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0539-squash-and-beef-its-always-sunny-in-philadelphia/meta.yml
+++ b/data/episodes/s/episode-0539-squash-and-beef-its-always-sunny-in-philadelphia/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0540-squidinkpasta/meta.yml
+++ b/data/episodes/s/episode-0540-squidinkpasta/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0541-squid-ink-ravioli-inspired-by-stardew-valley/meta.yml
+++ b/data/episodes/s/episode-0541-squid-ink-ravioli-inspired-by-stardew-valley/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0542-steak/data.yml
+++ b/data/episodes/s/episode-0542-steak/data.yml
@@ -16,7 +16,16 @@ tags:
 - tag-0030
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1518
+- recipe-1519
+- recipe-1520
+- recipe-1521
+- recipe-1522
+- recipe-1523
+- recipe-1524
+- recipe-1525
+- recipe-1526
 _lookup:
   slug: steak
   babish_internal_id: ATlcqrasg8ceDCOT6zvu

--- a/data/episodes/s/episode-0542-steak/meta.yml
+++ b/data/episodes/s/episode-0542-steak/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0543-steak-au-poivre/meta.yml
+++ b/data/episodes/s/episode-0543-steak-au-poivre/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0544-steak-eggs-gravy-twister/meta.yml
+++ b/data/episodes/s/episode-0544-steak-eggs-gravy-twister/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0545-steakhouse-burgers/meta.yml
+++ b/data/episodes/s/episode-0545-steakhouse-burgers/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0546-steak-pinwheels/meta.yml
+++ b/data/episodes/s/episode-0546-steak-pinwheels/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0547-sticky-buns/meta.yml
+++ b/data/episodes/s/episode-0547-sticky-buns/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0548-sticky-toffee-coffee-cake/meta.yml
+++ b/data/episodes/s/episode-0548-sticky-toffee-coffee-cake/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0549-stollen/meta.yml
+++ b/data/episodes/s/episode-0549-stollen/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0550-strata-family-stone/meta.yml
+++ b/data/episodes/s/episode-0550-strata-family-stone/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0551-strawberry-shortcake-inspired-by-death-note/meta.yml
+++ b/data/episodes/s/episode-0551-strawberry-shortcake-inspired-by-death-note/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0552-struggle-meals/meta.yml
+++ b/data/episodes/s/episode-0552-struggle-meals/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0553-sugar-chicken-rick-and-morty/meta.yml
+++ b/data/episodes/s/episode-0553-sugar-chicken-rick-and-morty/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0554-sumbitches/meta.yml
+++ b/data/episodes/s/episode-0554-sumbitches/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0555-sundae-spongebob/meta.yml
+++ b/data/episodes/s/episode-0555-sundae-spongebob/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0556-super-bowl-snacks-for-the-win-or-with-babish/data.yml
+++ b/data/episodes/s/episode-0556-super-bowl-snacks-for-the-win-or-with-babish/data.yml
@@ -16,7 +16,15 @@ tags:
 - tag-0021
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1475
+- recipe-1476
+- recipe-1477
+- recipe-1478
+- recipe-1479
+- recipe-1480
+- recipe-1481
+- recipe-1482
 _lookup:
   slug: super-bowl-snacks-for-the-win-or-with-babish
   babish_internal_id: bVdoMZyA8oYOP1tVG2xu

--- a/data/episodes/s/episode-0556-super-bowl-snacks-for-the-win-or-with-babish/meta.yml
+++ b/data/episodes/s/episode-0556-super-bowl-snacks-for-the-win-or-with-babish/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0557-super-hot-n-spicy-burger-inspired-by-boruto-naruto-next-gene/meta.yml
+++ b/data/episodes/s/episode-0557-super-hot-n-spicy-burger-inspired-by-boruto-naruto-next-gene/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0558-super-stretchy-nachos/meta.yml
+++ b/data/episodes/s/episode-0558-super-stretchy-nachos/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0559-swedish-meatballs/meta.yml
+++ b/data/episodes/s/episode-0559-swedish-meatballs/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0560-sweet-and-savory-babka/meta.yml
+++ b/data/episodes/s/episode-0560-sweet-and-savory-babka/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0561-sweet-potato-casserole-friends/meta.yml
+++ b/data/episodes/s/episode-0561-sweet-potato-casserole-friends/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0562-sweetrolls-skyrim/meta.yml
+++ b/data/episodes/s/episode-0562-sweetrolls-skyrim/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0563-szechuansauce/meta.yml
+++ b/data/episodes/s/episode-0563-szechuansauce/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/s/episode-0564-szechuansaucerevisited/meta.yml
+++ b/data/episodes/s/episode-0564-szechuansaucerevisited/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0565-tacos/meta.yml
+++ b/data/episodes/t/episode-0565-tacos/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0566-taco-town/meta.yml
+++ b/data/episodes/t/episode-0566-taco-town/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0567-takoyaki/meta.yml
+++ b/data/episodes/t/episode-0567-takoyaki/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0568-tamales/meta.yml
+++ b/data/episodes/t/episode-0568-tamales/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0569-tamalesfromcoco/meta.yml
+++ b/data/episodes/t/episode-0569-tamalesfromcoco/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0570-tampoporamen/meta.yml
+++ b/data/episodes/t/episode-0570-tampoporamen/meta.yml
@@ -1,43 +1,44 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: overridden
     by: enrich-agent
     at: '2026-05-05'
-    scraper_proposed: []
+    scraper_proposed:
+    - reference-0314
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0571-tater-tots-breaking-bad/meta.yml
+++ b/data/episodes/t/episode-0571-tater-tots-breaking-bad/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0572-teamstersandwich/meta.yml
+++ b/data/episodes/t/episode-0572-teamstersandwich/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0573-teddybrulee/meta.yml
+++ b/data/episodes/t/episode-0573-teddybrulee/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0574-tex-mex-enchiladas/meta.yml
+++ b/data/episodes/t/episode-0574-tex-mex-enchiladas/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0575-thanksgiving-balls-psych/meta.yml
+++ b/data/episodes/t/episode-0575-thanksgiving-balls-psych/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0576-thanksgivingleftovers/meta.yml
+++ b/data/episodes/t/episode-0576-thanksgivingleftovers/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0577-thanksgivingsides/meta.yml
+++ b/data/episodes/t/episode-0577-thanksgivingsides/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0578-thanksgiving-stuffings/meta.yml
+++ b/data/episodes/t/episode-0578-thanksgiving-stuffings/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0579-the-best-barbecue-chicken/meta.yml
+++ b/data/episodes/t/episode-0579-the-best-barbecue-chicken/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0580-the-coagulator-inspired-by-the-simpsons/meta.yml
+++ b/data/episodes/t/episode-0580-the-coagulator-inspired-by-the-simpsons/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0581-the-egg-bar-inspired-by-severance/data.yml
+++ b/data/episodes/t/episode-0581-the-egg-bar-inspired-by-severance/data.yml
@@ -18,7 +18,15 @@ tags:
 guests: []
 inspired_by:
 - reference-0254
-recipes: []
+recipes:
+- recipe-1607
+- recipe-1608
+- recipe-1609
+- recipe-1610
+- recipe-1611
+- recipe-1612
+- recipe-1613
+- recipe-1614
 _lookup:
   slug: the-egg-bar-inspired-by-severance
   babish_internal_id: iGAkSr7a3TTrM7agkoVI

--- a/data/episodes/t/episode-0581-the-egg-bar-inspired-by-severance/meta.yml
+++ b/data/episodes/t/episode-0581-the-egg-bar-inspired-by-severance/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0582-thegodfathercannolis/meta.yml
+++ b/data/episodes/t/episode-0582-thegodfathercannolis/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0583-thegoodplace/meta.yml
+++ b/data/episodes/t/episode-0583-thegoodplace/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0584-thegreystuff/meta.yml
+++ b/data/episodes/t/episode-0584-thegreystuff/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0585-the-liz-lemon-30-rock/meta.yml
+++ b/data/episodes/t/episode-0585-the-liz-lemon-30-rock/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0586-the-naco/meta.yml
+++ b/data/episodes/t/episode-0586-the-naco/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0587-the-perfect-bite/meta.yml
+++ b/data/episodes/t/episode-0587-the-perfect-bite/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0588-the-sims-special/meta.yml
+++ b/data/episodes/t/episode-0588-the-sims-special/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0589-thesloppyjessica/meta.yml
+++ b/data/episodes/t/episode-0589-thesloppyjessica/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0590-theswanson/meta.yml
+++ b/data/episodes/t/episode-0590-theswanson/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0591-the-ultimate-marry-me-meals/meta.yml
+++ b/data/episodes/t/episode-0591-the-ultimate-marry-me-meals/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0592-the-ultimate-steak-sandwich/meta.yml
+++ b/data/episodes/t/episode-0592-the-ultimate-steak-sandwich/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0593-thewirespecial/meta.yml
+++ b/data/episodes/t/episode-0593-thewirespecial/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0594-tiramisu/meta.yml
+++ b/data/episodes/t/episode-0594-tiramisu/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0595-tiramisu-basics/meta.yml
+++ b/data/episodes/t/episode-0595-tiramisu-basics/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0596-together-breakfast-steven-universe/meta.yml
+++ b/data/episodes/t/episode-0596-together-breakfast-steven-universe/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0597-tomate-du-saltambique-inspired-by-the-west-wing/meta.yml
+++ b/data/episodes/t/episode-0597-tomate-du-saltambique-inspired-by-the-west-wing/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0598-tomato-confit-ricotta-toast-simple-salad-pasta-with-calabria/meta.yml
+++ b/data/episodes/t/episode-0598-tomato-confit-ricotta-toast-simple-salad-pasta-with-calabria/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0599-tom-cruise-coconut-cake-inspired-by-hacks/meta.yml
+++ b/data/episodes/t/episode-0599-tom-cruise-coconut-cake-inspired-by-hacks/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0600-tom-yum-tomato-cream-pasta/meta.yml
+++ b/data/episodes/t/episode-0600-tom-yum-tomato-cream-pasta/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0601-tonkotsuramen/meta.yml
+++ b/data/episodes/t/episode-0601-tonkotsuramen/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0602-tortilla-sombero-despicable-me-2/meta.yml
+++ b/data/episodes/t/episode-0602-tortilla-sombero-despicable-me-2/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0603-transforming-furikake-gohan-inspired-by-food-wars/meta.yml
+++ b/data/episodes/t/episode-0603-transforming-furikake-gohan-inspired-by-food-wars/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0604-trenette-el-pesto-luca/meta.yml
+++ b/data/episodes/t/episode-0604-trenette-el-pesto-luca/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0605-treslechescake/meta.yml
+++ b/data/episodes/t/episode-0605-treslechescake/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0606-tripledeckereggo/meta.yml
+++ b/data/episodes/t/episode-0606-tripledeckereggo/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0607-triple-deluxe-dog-hot-dog-detective/meta.yml
+++ b/data/episodes/t/episode-0607-triple-deluxe-dog-hot-dog-detective/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0608-triple-gooberberry-sunrise-spongebob-squarespace/meta.yml
+++ b/data/episodes/t/episode-0608-triple-gooberberry-sunrise-spongebob-squarespace/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0609-trollhunters-meatloaf-sandwich/meta.yml
+++ b/data/episodes/t/episode-0609-trollhunters-meatloaf-sandwich/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0610-troyscasserole-community/meta.yml
+++ b/data/episodes/t/episode-0610-troyscasserole-community/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0611-truffle-pasta-broad-city/meta.yml
+++ b/data/episodes/t/episode-0611-truffle-pasta-broad-city/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0612-turf-n-turf/meta.yml
+++ b/data/episodes/t/episode-0612-turf-n-turf/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0613-turkey-5-ways/meta.yml
+++ b/data/episodes/t/episode-0613-turkey-5-ways/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0614-turkey-and-caviar-inspired-by-star-trek-the-next-generation/meta.yml
+++ b/data/episodes/t/episode-0614-turkey-and-caviar-inspired-by-star-trek-the-next-generation/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0615-turturkeykey/meta.yml
+++ b/data/episodes/t/episode-0615-turturkeykey/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0616-twinkie-weiner-sandwich/meta.yml
+++ b/data/episodes/t/episode-0616-twinkie-weiner-sandwich/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/t/episode-0617-tylers-bull-the-menu/meta.yml
+++ b/data/episodes/t/episode-0617-tylers-bull-the-menu/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/u/episode-0618-uberollcake/meta.yml
+++ b/data/episodes/u/episode-0618-uberollcake/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/u/episode-0619-ultimate-cookie/meta.yml
+++ b/data/episodes/u/episode-0619-ultimate-cookie/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/u/episode-0620-ultimate-french-toast-or-with-babish/data.yml
+++ b/data/episodes/u/episode-0620-ultimate-french-toast-or-with-babish/data.yml
@@ -17,7 +17,14 @@ tags:
 - tag-0031
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1491
+- recipe-1492
+- recipe-1493
+- recipe-1494
+- recipe-1495
+- recipe-1496
+- recipe-1497
 _lookup:
   slug: ultimate-french-toast-or-with-babish
   babish_internal_id: T5Nm7dK86bxu3jyhr2Vb

--- a/data/episodes/u/episode-0620-ultimate-french-toast-or-with-babish/meta.yml
+++ b/data/episodes/u/episode-0620-ultimate-french-toast-or-with-babish/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/u/episode-0621-ultimate-pot-roast-or-with-babish/data.yml
+++ b/data/episodes/u/episode-0621-ultimate-pot-roast-or-with-babish/data.yml
@@ -16,7 +16,12 @@ tags:
 - tag-0032
 guests: []
 inspired_by: []
-recipes: []
+recipes:
+- recipe-1498
+- recipe-1499
+- recipe-1500
+- recipe-1501
+- recipe-1502
 _lookup:
   slug: ultimate-pot-roast-or-with-babish
   babish_internal_id: PSBfG70SuI6ykYc1GOTX

--- a/data/episodes/u/episode-0621-ultimate-pot-roast-or-with-babish/meta.yml
+++ b/data/episodes/u/episode-0621-ultimate-pot-roast-or-with-babish/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/u/episode-0622-ultimeatum/meta.yml
+++ b/data/episodes/u/episode-0622-ultimeatum/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/u/episode-0623-underwear-bread-inspired-by-asteroid-in-love/meta.yml
+++ b/data/episodes/u/episode-0623-underwear-bread-inspired-by-asteroid-in-love/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/v/episode-0624-vodka-pasta/meta.yml
+++ b/data/episodes/v/episode-0624-vodka-pasta/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/w/episode-0625-wasabi-buffalo-wings-the-simpsons/meta.yml
+++ b/data/episodes/w/episode-0625-wasabi-buffalo-wings-the-simpsons/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/w/episode-0626-water-tribe-noodles-inspired-by-the-legend-of-korra/meta.yml
+++ b/data/episodes/w/episode-0626-water-tribe-noodles-inspired-by-the-legend-of-korra/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/w/episode-0627-weeknightmeals-ahmph/meta.yml
+++ b/data/episodes/w/episode-0627-weeknightmeals-ahmph/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/w/episode-0628-whimsical-parfait-inspired-by-darker-than-black/data.yml
+++ b/data/episodes/w/episode-0628-whimsical-parfait-inspired-by-darker-than-black/data.yml
@@ -14,7 +14,17 @@ tags:
 guests: []
 inspired_by:
 - reference-0264
-recipes: []
+recipes:
+- recipe-1615
+- recipe-1616
+- recipe-1617
+- recipe-1618
+- recipe-1619
+- recipe-1620
+- recipe-1621
+- recipe-1622
+- recipe-1623
+- recipe-1624
 _lookup:
   slug: whimsical-parfait-inspired-by-darker-than-black
   babish_internal_id: e9SBLKW0jcJr1mQ1tBcJ

--- a/data/episodes/w/episode-0628-whimsical-parfait-inspired-by-darker-than-black/meta.yml
+++ b/data/episodes/w/episode-0628-whimsical-parfait-inspired-by-darker-than-black/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/w/episode-0629-whitecastlesliders/meta.yml
+++ b/data/episodes/w/episode-0629-whitecastlesliders/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/w/episode-0630-wholeporkloin/meta.yml
+++ b/data/episodes/w/episode-0630-wholeporkloin/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/w/episode-0631-wild-mushroom-soup-inspired-by-seinfeld/meta.yml
+++ b/data/episodes/w/episode-0631-wild-mushroom-soup-inspired-by-seinfeld/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/w/episode-0632-willy-wonka-edible-teacup/meta.yml
+++ b/data/episodes/w/episode-0632-willy-wonka-edible-teacup/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/w/episode-0633-wings/meta.yml
+++ b/data/episodes/w/episode-0633-wings/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/w/episode-0634-worldsgreatestsandwich/meta.yml
+++ b/data/episodes/w/episode-0634-worldsgreatestsandwich/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/y/episode-0635-yorkshire-pudding/meta.yml
+++ b/data/episodes/y/episode-0635-yorkshire-pudding/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/z/episode-0636-zelda-monster-cake/meta.yml
+++ b/data/episodes/z/episode-0636-zelda-monster-cake/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/episodes/z/episode-0637-ziti-lasagna/meta.yml
+++ b/data/episodes/z/episode-0637-ziti-lasagna/meta.yml
@@ -1,41 +1,41 @@
 fields:
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   slug:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   published_date:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   youtube_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   official_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   image_link:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   time_to_cook:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_qty:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   yield_unit:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   tags:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   guests:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   inspired_by:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   recipes:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/recipes/_/recipe-1503-200-beef-wellington/data.yml
+++ b/data/recipes/_/recipe-1503-200-beef-wellington/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1503
+name: $200 beef wellington
+raw_ingredient_list: ''
+episode: episode-0060
+_lookup:
+  episode_and_section: episode-0060::$200 beef wellington

--- a/data/recipes/_/recipe-1503-200-beef-wellington/meta.yml
+++ b/data/recipes/_/recipe-1503-200-beef-wellington/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/_/recipe-1505-20-beef-wellington/data.yml
+++ b/data/recipes/_/recipe-1505-20-beef-wellington/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1505
+name: $20 beef wellington
+raw_ingredient_list: ''
+episode: episode-0060
+_lookup:
+  episode_and_section: episode-0060::$20 beef wellington

--- a/data/recipes/_/recipe-1505-20-beef-wellington/meta.yml
+++ b/data/recipes/_/recipe-1505-20-beef-wellington/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/a/recipe-1630-applesauce/data.yml
+++ b/data/recipes/a/recipe-1630-applesauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1630
+name: applesauce
+raw_ingredient_list: ''
+episode: episode-0426
+_lookup:
+  episode_and_section: episode-0426::applesauce

--- a/data/recipes/a/recipe-1630-applesauce/meta.yml
+++ b/data/recipes/a/recipe-1630-applesauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1498-beef-prep/data.yml
+++ b/data/recipes/b/recipe-1498-beef-prep/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1498
+name: beef prep
+raw_ingredient_list: ''
+episode: episode-0621
+_lookup:
+  episode_and_section: episode-0621::beef prep

--- a/data/recipes/b/recipe-1498-beef-prep/meta.yml
+++ b/data/recipes/b/recipe-1498-beef-prep/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1499-braised-vegetable-prep/data.yml
+++ b/data/recipes/b/recipe-1499-braised-vegetable-prep/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1499
+name: braised vegetable prep
+raw_ingredient_list: ''
+episode: episode-0621
+_lookup:
+  episode_and_section: episode-0621::braised vegetable prep

--- a/data/recipes/b/recipe-1499-braised-vegetable-prep/meta.yml
+++ b/data/recipes/b/recipe-1499-braised-vegetable-prep/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1500-bouquet-garni/data.yml
+++ b/data/recipes/b/recipe-1500-bouquet-garni/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1500
+name: bouquet garni
+raw_ingredient_list: ''
+episode: episode-0621
+_lookup:
+  episode_and_section: episode-0621::bouquet garni

--- a/data/recipes/b/recipe-1500-bouquet-garni/meta.yml
+++ b/data/recipes/b/recipe-1500-bouquet-garni/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1506-beef-prep/data.yml
+++ b/data/recipes/b/recipe-1506-beef-prep/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1506
+name: beef prep
+raw_ingredient_list: ''
+episode: episode-0060
+_lookup:
+  episode_and_section: episode-0060::beef prep

--- a/data/recipes/b/recipe-1506-beef-prep/meta.yml
+++ b/data/recipes/b/recipe-1506-beef-prep/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1508-butter-block/data.yml
+++ b/data/recipes/b/recipe-1508-butter-block/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1508
+name: butter block
+raw_ingredient_list: ''
+episode: episode-0060
+_lookup:
+  episode_and_section: episode-0060::butter block

--- a/data/recipes/b/recipe-1508-butter-block/meta.yml
+++ b/data/recipes/b/recipe-1508-butter-block/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1510-bacon/data.yml
+++ b/data/recipes/b/recipe-1510-bacon/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1510
+name: bacon
+raw_ingredient_list: ''
+episode: episode-0174
+_lookup:
+  episode_and_section: episode-0174::bacon

--- a/data/recipes/b/recipe-1510-bacon/meta.yml
+++ b/data/recipes/b/recipe-1510-bacon/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1512-bouquet-garni/data.yml
+++ b/data/recipes/b/recipe-1512-bouquet-garni/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1512
+name: bouquet garni
+raw_ingredient_list: ''
+episode: episode-0174
+_lookup:
+  episode_and_section: episode-0174::bouquet garni

--- a/data/recipes/b/recipe-1512-bouquet-garni/meta.yml
+++ b/data/recipes/b/recipe-1512-bouquet-garni/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1514-butter-mushrooms/data.yml
+++ b/data/recipes/b/recipe-1514-butter-mushrooms/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1514
+name: butter mushrooms
+raw_ingredient_list: ''
+episode: episode-0174
+_lookup:
+  episode_and_section: episode-0174::butter mushrooms

--- a/data/recipes/b/recipe-1514-butter-mushrooms/meta.yml
+++ b/data/recipes/b/recipe-1514-butter-mushrooms/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1516-buttered-noodles/data.yml
+++ b/data/recipes/b/recipe-1516-buttered-noodles/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1516
+name: buttered noodles
+raw_ingredient_list: ''
+episode: episode-0174
+_lookup:
+  episode_and_section: episode-0174::buttered noodles

--- a/data/recipes/b/recipe-1516-buttered-noodles/meta.yml
+++ b/data/recipes/b/recipe-1516-buttered-noodles/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1517-beurre-monte-sauce/data.yml
+++ b/data/recipes/b/recipe-1517-beurre-monte-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1517
+name: beurre monté sauce
+raw_ingredient_list: ''
+episode: episode-0174
+_lookup:
+  episode_and_section: episode-0174::beurre monté sauce

--- a/data/recipes/b/recipe-1517-beurre-monte-sauce/meta.yml
+++ b/data/recipes/b/recipe-1517-beurre-monte-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1520-boneless-short-ribs/data.yml
+++ b/data/recipes/b/recipe-1520-boneless-short-ribs/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1520
+name: boneless short ribs
+raw_ingredient_list: ''
+episode: episode-0542
+_lookup:
+  episode_and_section: episode-0542::boneless short ribs

--- a/data/recipes/b/recipe-1520-boneless-short-ribs/meta.yml
+++ b/data/recipes/b/recipe-1520-boneless-short-ribs/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1531-babish-version/data.yml
+++ b/data/recipes/b/recipe-1531-babish-version/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1531
+name: babish version
+raw_ingredient_list: ''
+episode: episode-0229
+_lookup:
+  episode_and_section: episode-0229::babish version

--- a/data/recipes/b/recipe-1531-babish-version/meta.yml
+++ b/data/recipes/b/recipe-1531-babish-version/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1552-burger-patties/data.yml
+++ b/data/recipes/b/recipe-1552-burger-patties/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1552
+name: burger patties
+raw_ingredient_list: ''
+episode: episode-0196
+_lookup:
+  episode_and_section: episode-0196::burger patties

--- a/data/recipes/b/recipe-1552-burger-patties/meta.yml
+++ b/data/recipes/b/recipe-1552-burger-patties/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1554-burgers/data.yml
+++ b/data/recipes/b/recipe-1554-burgers/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1554
+name: burgers
+raw_ingredient_list: ''
+episode: episode-0196
+_lookup:
+  episode_and_section: episode-0196::burgers

--- a/data/recipes/b/recipe-1554-burgers/meta.yml
+++ b/data/recipes/b/recipe-1554-burgers/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1565-bourbon-pan-sauce/data.yml
+++ b/data/recipes/b/recipe-1565-bourbon-pan-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1565
+name: bourbon pan sauce
+raw_ingredient_list: ''
+episode: episode-0014
+_lookup:
+  episode_and_section: episode-0014::bourbon pan sauce

--- a/data/recipes/b/recipe-1565-bourbon-pan-sauce/meta.yml
+++ b/data/recipes/b/recipe-1565-bourbon-pan-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1570-bun/data.yml
+++ b/data/recipes/b/recipe-1570-bun/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1570
+name: bun
+raw_ingredient_list: ''
+episode: episode-0306
+_lookup:
+  episode_and_section: episode-0306::bun

--- a/data/recipes/b/recipe-1570-bun/meta.yml
+++ b/data/recipes/b/recipe-1570-bun/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1572-beef-patties/data.yml
+++ b/data/recipes/b/recipe-1572-beef-patties/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1572
+name: beef patties
+raw_ingredient_list: ''
+episode: episode-0306
+_lookup:
+  episode_and_section: episode-0306::beef patties

--- a/data/recipes/b/recipe-1572-beef-patties/meta.yml
+++ b/data/recipes/b/recipe-1572-beef-patties/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1574-buns/data.yml
+++ b/data/recipes/b/recipe-1574-buns/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1574
+name: buns
+raw_ingredient_list: ''
+episode: episode-0306
+_lookup:
+  episode_and_section: episode-0306::buns

--- a/data/recipes/b/recipe-1574-buns/meta.yml
+++ b/data/recipes/b/recipe-1574-buns/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1585-basic-egg-salad-sandwich/data.yml
+++ b/data/recipes/b/recipe-1585-basic-egg-salad-sandwich/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1585
+name: basic egg salad sandwich
+raw_ingredient_list: ''
+episode: episode-0215
+_lookup:
+  episode_and_section: episode-0215::basic egg salad sandwich

--- a/data/recipes/b/recipe-1585-basic-egg-salad-sandwich/meta.yml
+++ b/data/recipes/b/recipe-1585-basic-egg-salad-sandwich/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1613-boiled-eggs/data.yml
+++ b/data/recipes/b/recipe-1613-boiled-eggs/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1613
+name: boiled eggs
+raw_ingredient_list: ''
+episode: episode-0581
+_lookup:
+  episode_and_section: episode-0581::boiled eggs

--- a/data/recipes/b/recipe-1613-boiled-eggs/meta.yml
+++ b/data/recipes/b/recipe-1613-boiled-eggs/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1628-beef-filling/data.yml
+++ b/data/recipes/b/recipe-1628-beef-filling/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1628
+name: beef filling
+raw_ingredient_list: ''
+episode: episode-0426
+_lookup:
+  episode_and_section: episode-0426::beef filling

--- a/data/recipes/b/recipe-1628-beef-filling/meta.yml
+++ b/data/recipes/b/recipe-1628-beef-filling/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1635-basil-oil/data.yml
+++ b/data/recipes/b/recipe-1635-basil-oil/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1635
+name: basil oil
+raw_ingredient_list: ''
+episode: episode-0192
+_lookup:
+  episode_and_section: episode-0192::basil oil

--- a/data/recipes/b/recipe-1635-basil-oil/meta.yml
+++ b/data/recipes/b/recipe-1635-basil-oil/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/b/recipe-1637-browned-butter-sage/data.yml
+++ b/data/recipes/b/recipe-1637-browned-butter-sage/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1637
+name: browned butter sage
+raw_ingredient_list: ''
+episode: episode-0192
+_lookup:
+  episode_and_section: episode-0192::browned butter sage

--- a/data/recipes/b/recipe-1637-browned-butter-sage/meta.yml
+++ b/data/recipes/b/recipe-1637-browned-butter-sage/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1496-creme-fraiche-chantilly/data.yml
+++ b/data/recipes/c/recipe-1496-creme-fraiche-chantilly/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1496
+name: crème fraîche chantilly
+raw_ingredient_list: ''
+episode: episode-0620
+_lookup:
+  episode_and_section: episode-0620::crème fraîche chantilly

--- a/data/recipes/c/recipe-1496-creme-fraiche-chantilly/meta.yml
+++ b/data/recipes/c/recipe-1496-creme-fraiche-chantilly/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1513-coq-au-vin-sauce/data.yml
+++ b/data/recipes/c/recipe-1513-coq-au-vin-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1513
+name: coq au vin sauce
+raw_ingredient_list: ''
+episode: episode-0174
+_lookup:
+  episode_and_section: episode-0174::coq au vin sauce

--- a/data/recipes/c/recipe-1513-coq-au-vin-sauce/meta.yml
+++ b/data/recipes/c/recipe-1513-coq-au-vin-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1528-cake/data.yml
+++ b/data/recipes/c/recipe-1528-cake/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1528
+name: cake
+raw_ingredient_list: ''
+episode: episode-0229
+_lookup:
+  episode_and_section: episode-0229::cake

--- a/data/recipes/c/recipe-1528-cake/meta.yml
+++ b/data/recipes/c/recipe-1528-cake/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1538-cheese-sauce/data.yml
+++ b/data/recipes/c/recipe-1538-cheese-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1538
+name: cheese sauce
+raw_ingredient_list: ''
+episode: episode-0004
+_lookup:
+  episode_and_section: episode-0004::cheese sauce

--- a/data/recipes/c/recipe-1538-cheese-sauce/meta.yml
+++ b/data/recipes/c/recipe-1538-cheese-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1553-cheese-sauce/data.yml
+++ b/data/recipes/c/recipe-1553-cheese-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1553
+name: cheese sauce
+raw_ingredient_list: ''
+episode: episode-0196
+_lookup:
+  episode_and_section: episode-0196::cheese sauce

--- a/data/recipes/c/recipe-1553-cheese-sauce/meta.yml
+++ b/data/recipes/c/recipe-1553-cheese-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1556-cheese-dough-balls/data.yml
+++ b/data/recipes/c/recipe-1556-cheese-dough-balls/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1556
+name: cheese dough balls
+raw_ingredient_list: ''
+episode: episode-0196
+_lookup:
+  episode_and_section: episode-0196::cheese dough balls

--- a/data/recipes/c/recipe-1556-cheese-dough-balls/meta.yml
+++ b/data/recipes/c/recipe-1556-cheese-dough-balls/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1576-cheesecake-batter/data.yml
+++ b/data/recipes/c/recipe-1576-cheesecake-batter/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1576
+name: cheesecake batter
+raw_ingredient_list: ''
+episode: episode-0124
+_lookup:
+  episode_and_section: episode-0124::cheesecake batter

--- a/data/recipes/c/recipe-1576-cheesecake-batter/meta.yml
+++ b/data/recipes/c/recipe-1576-cheesecake-batter/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1580-cheesecake/data.yml
+++ b/data/recipes/c/recipe-1580-cheesecake/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1580
+name: cheesecake
+raw_ingredient_list: ''
+episode: episode-0124
+_lookup:
+  episode_and_section: episode-0124::cheesecake

--- a/data/recipes/c/recipe-1580-cheesecake/meta.yml
+++ b/data/recipes/c/recipe-1580-cheesecake/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1597-cocktail-sauce/data.yml
+++ b/data/recipes/c/recipe-1597-cocktail-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1597
+name: cocktail sauce
+raw_ingredient_list: ''
+episode: episode-0510
+_lookup:
+  episode_and_section: episode-0510::cocktail sauce

--- a/data/recipes/c/recipe-1597-cocktail-sauce/meta.yml
+++ b/data/recipes/c/recipe-1597-cocktail-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1615-creme-anglaise/data.yml
+++ b/data/recipes/c/recipe-1615-creme-anglaise/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1615
+name: crème anglaise
+raw_ingredient_list: ''
+episode: episode-0628
+_lookup:
+  episode_and_section: episode-0628::crème anglaise

--- a/data/recipes/c/recipe-1615-creme-anglaise/meta.yml
+++ b/data/recipes/c/recipe-1615-creme-anglaise/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1617-chocolate-flavor/data.yml
+++ b/data/recipes/c/recipe-1617-chocolate-flavor/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1617
+name: chocolate flavor
+raw_ingredient_list: ''
+episode: episode-0628
+_lookup:
+  episode_and_section: episode-0628::chocolate flavor

--- a/data/recipes/c/recipe-1617-chocolate-flavor/meta.yml
+++ b/data/recipes/c/recipe-1617-chocolate-flavor/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1622-choux-pastry/data.yml
+++ b/data/recipes/c/recipe-1622-choux-pastry/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1622
+name: 'choux pastry :'
+raw_ingredient_list: ''
+episode: episode-0628
+_lookup:
+  episode_and_section: 'episode-0628::choux pastry :'

--- a/data/recipes/c/recipe-1622-choux-pastry/meta.yml
+++ b/data/recipes/c/recipe-1622-choux-pastry/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1634-confit-tomatoes/data.yml
+++ b/data/recipes/c/recipe-1634-confit-tomatoes/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1634
+name: confit tomatoes
+raw_ingredient_list: ''
+episode: episode-0192
+_lookup:
+  episode_and_section: episode-0192::confit tomatoes

--- a/data/recipes/c/recipe-1634-confit-tomatoes/meta.yml
+++ b/data/recipes/c/recipe-1634-confit-tomatoes/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1638-cornish-hen-sauces/data.yml
+++ b/data/recipes/c/recipe-1638-cornish-hen-sauces/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1638
+name: cornish hen & sauces
+raw_ingredient_list: ''
+episode: episode-0192
+_lookup:
+  episode_and_section: episode-0192::cornish hen & sauces

--- a/data/recipes/c/recipe-1638-cornish-hen-sauces/meta.yml
+++ b/data/recipes/c/recipe-1638-cornish-hen-sauces/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/c/recipe-1639-cornish-hen/data.yml
+++ b/data/recipes/c/recipe-1639-cornish-hen/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1639
+name: cornish hen
+raw_ingredient_list: ''
+episode: episode-0192
+_lookup:
+  episode_and_section: episode-0192::cornish hen

--- a/data/recipes/c/recipe-1639-cornish-hen/meta.yml
+++ b/data/recipes/c/recipe-1639-cornish-hen/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/d/recipe-1465-dipping-sauce/data.yml
+++ b/data/recipes/d/recipe-1465-dipping-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1465
+name: dipping sauce
+raw_ingredient_list: ''
+episode: episode-0328
+_lookup:
+  episode_and_section: episode-0328::dipping sauce

--- a/data/recipes/d/recipe-1465-dipping-sauce/meta.yml
+++ b/data/recipes/d/recipe-1465-dipping-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/d/recipe-1551-deep-fried-burger-bomb/data.yml
+++ b/data/recipes/d/recipe-1551-deep-fried-burger-bomb/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1551
+name: deep fried burger bomb
+raw_ingredient_list: ''
+episode: episode-0196
+_lookup:
+  episode_and_section: episode-0196::deep fried burger bomb

--- a/data/recipes/d/recipe-1551-deep-fried-burger-bomb/meta.yml
+++ b/data/recipes/d/recipe-1551-deep-fried-burger-bomb/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/d/recipe-1557-duck-breast-salad/data.yml
+++ b/data/recipes/d/recipe-1557-duck-breast-salad/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1557
+name: duck breast salad
+raw_ingredient_list: ''
+episode: episode-0009
+_lookup:
+  episode_and_section: episode-0009::duck breast salad

--- a/data/recipes/d/recipe-1557-duck-breast-salad/meta.yml
+++ b/data/recipes/d/recipe-1557-duck-breast-salad/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/d/recipe-1558-duck/data.yml
+++ b/data/recipes/d/recipe-1558-duck/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1558
+name: duck
+raw_ingredient_list: ''
+episode: episode-0009
+_lookup:
+  episode_and_section: episode-0009::duck

--- a/data/recipes/d/recipe-1558-duck/meta.yml
+++ b/data/recipes/d/recipe-1558-duck/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/d/recipe-1607-deviled-eggs/data.yml
+++ b/data/recipes/d/recipe-1607-deviled-eggs/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1607
+name: deviled eggs
+raw_ingredient_list: ''
+episode: episode-0581
+_lookup:
+  episode_and_section: episode-0581::deviled eggs

--- a/data/recipes/d/recipe-1607-deviled-eggs/meta.yml
+++ b/data/recipes/d/recipe-1607-deviled-eggs/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/d/recipe-1636-deconstructed-pesto/data.yml
+++ b/data/recipes/d/recipe-1636-deconstructed-pesto/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1636
+name: deconstructed pesto
+raw_ingredient_list: ''
+episode: episode-0192
+_lookup:
+  episode_and_section: episode-0192::deconstructed pesto

--- a/data/recipes/d/recipe-1636-deconstructed-pesto/meta.yml
+++ b/data/recipes/d/recipe-1636-deconstructed-pesto/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/e/recipe-1463-eomuk-guk/data.yml
+++ b/data/recipes/e/recipe-1463-eomuk-guk/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1463
+name: eomuk guk
+raw_ingredient_list: ''
+episode: episode-0328
+_lookup:
+  episode_and_section: episode-0328::eomuk guk

--- a/data/recipes/e/recipe-1463-eomuk-guk/meta.yml
+++ b/data/recipes/e/recipe-1463-eomuk-guk/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/e/recipe-1547-eggplant-sandwich/data.yml
+++ b/data/recipes/e/recipe-1547-eggplant-sandwich/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1547
+name: eggplant sandwich
+raw_ingredient_list: ''
+episode: episode-0458
+_lookup:
+  episode_and_section: episode-0458::eggplant sandwich

--- a/data/recipes/e/recipe-1547-eggplant-sandwich/meta.yml
+++ b/data/recipes/e/recipe-1547-eggplant-sandwich/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/e/recipe-1579-egg-whites-mixture/data.yml
+++ b/data/recipes/e/recipe-1579-egg-whites-mixture/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1579
+name: egg whites mixture
+raw_ingredient_list: ''
+episode: episode-0124
+_lookup:
+  episode_and_section: episode-0124::egg whites mixture

--- a/data/recipes/e/recipe-1579-egg-whites-mixture/meta.yml
+++ b/data/recipes/e/recipe-1579-egg-whites-mixture/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/e/recipe-1587-egg-salad/data.yml
+++ b/data/recipes/e/recipe-1587-egg-salad/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1587
+name: egg salad
+raw_ingredient_list: ''
+episode: episode-0215
+_lookup:
+  episode_and_section: episode-0215::egg salad

--- a/data/recipes/e/recipe-1587-egg-salad/meta.yml
+++ b/data/recipes/e/recipe-1587-egg-salad/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/f/recipe-1497-french-toast-custard/data.yml
+++ b/data/recipes/f/recipe-1497-french-toast-custard/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1497
+name: french toast custard
+raw_ingredient_list: ''
+episode: episode-0620
+_lookup:
+  episode_and_section: episode-0620::french toast custard

--- a/data/recipes/f/recipe-1497-french-toast-custard/meta.yml
+++ b/data/recipes/f/recipe-1497-french-toast-custard/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/f/recipe-1525-filet-mignon-steak-tartare/data.yml
+++ b/data/recipes/f/recipe-1525-filet-mignon-steak-tartare/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1525
+name: 'filet mignon: steak tartare'
+raw_ingredient_list: ''
+episode: episode-0542
+_lookup:
+  episode_and_section: 'episode-0542::filet mignon: steak tartare'

--- a/data/recipes/f/recipe-1525-filet-mignon-steak-tartare/meta.yml
+++ b/data/recipes/f/recipe-1525-filet-mignon-steak-tartare/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/f/recipe-1527-fallout-the-vault-dweller-s-official-cookbook/data.yml
+++ b/data/recipes/f/recipe-1527-fallout-the-vault-dweller-s-official-cookbook/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1527
+name: 'fallout: the vault dweller''s official cookbook'
+raw_ingredient_list: ''
+episode: episode-0229
+_lookup:
+  episode_and_section: 'episode-0229::fallout: the vault dweller''s official cookbook'

--- a/data/recipes/f/recipe-1527-fallout-the-vault-dweller-s-official-cookbook/meta.yml
+++ b/data/recipes/f/recipe-1527-fallout-the-vault-dweller-s-official-cookbook/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/f/recipe-1535-fondant-coating/data.yml
+++ b/data/recipes/f/recipe-1535-fondant-coating/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1535
+name: fondant coating
+raw_ingredient_list: ''
+episode: episode-0229
+_lookup:
+  episode_and_section: episode-0229::fondant coating

--- a/data/recipes/f/recipe-1535-fondant-coating/meta.yml
+++ b/data/recipes/f/recipe-1535-fondant-coating/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/f/recipe-1605-fennel-salad/data.yml
+++ b/data/recipes/f/recipe-1605-fennel-salad/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1605
+name: fennel salad
+raw_ingredient_list: ''
+episode: episode-0392
+_lookup:
+  episode_and_section: episode-0392::fennel salad

--- a/data/recipes/f/recipe-1605-fennel-salad/meta.yml
+++ b/data/recipes/f/recipe-1605-fennel-salad/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/f/recipe-1606-filet-mignon-with-chimichurri/data.yml
+++ b/data/recipes/f/recipe-1606-filet-mignon-with-chimichurri/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1606
+name: filet mignon with chimichurri
+raw_ingredient_list: ''
+episode: episode-0392
+_lookup:
+  episode_and_section: episode-0392::filet mignon with chimichurri

--- a/data/recipes/f/recipe-1606-filet-mignon-with-chimichurri/meta.yml
+++ b/data/recipes/f/recipe-1606-filet-mignon-with-chimichurri/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/g/recipe-1466-gimbap/data.yml
+++ b/data/recipes/g/recipe-1466-gimbap/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1466
+name: gimbap
+raw_ingredient_list: ''
+episode: episode-0328
+_lookup:
+  episode_and_section: episode-0328::gimbap

--- a/data/recipes/g/recipe-1466-gimbap/meta.yml
+++ b/data/recipes/g/recipe-1466-gimbap/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/g/recipe-1477-garlic-butter/data.yml
+++ b/data/recipes/g/recipe-1477-garlic-butter/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1477
+name: garlic butter
+raw_ingredient_list: ''
+episode: episode-0556
+_lookup:
+  episode_and_section: episode-0556::garlic butter

--- a/data/recipes/g/recipe-1477-garlic-butter/meta.yml
+++ b/data/recipes/g/recipe-1477-garlic-butter/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/g/recipe-1592-gourmet-egg-salad/data.yml
+++ b/data/recipes/g/recipe-1592-gourmet-egg-salad/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1592
+name: gourmet egg salad
+raw_ingredient_list: ''
+episode: episode-0215
+_lookup:
+  episode_and_section: episode-0215::gourmet egg salad

--- a/data/recipes/g/recipe-1592-gourmet-egg-salad/meta.yml
+++ b/data/recipes/g/recipe-1592-gourmet-egg-salad/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/g/recipe-1641-gremolata/data.yml
+++ b/data/recipes/g/recipe-1641-gremolata/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1641
+name: gremolata
+raw_ingredient_list: ''
+episode: episode-0192
+_lookup:
+  episode_and_section: episode-0192::gremolata

--- a/data/recipes/g/recipe-1641-gremolata/meta.yml
+++ b/data/recipes/g/recipe-1641-gremolata/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/h/recipe-1479-homemade-mayo/data.yml
+++ b/data/recipes/h/recipe-1479-homemade-mayo/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1479
+name: homemade mayo
+raw_ingredient_list: ''
+episode: episode-0556
+_lookup:
+  episode_and_section: episode-0556::homemade mayo

--- a/data/recipes/h/recipe-1479-homemade-mayo/meta.yml
+++ b/data/recipes/h/recipe-1479-homemade-mayo/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/h/recipe-1521-hot-jus/data.yml
+++ b/data/recipes/h/recipe-1521-hot-jus/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1521
+name: hot jus
+raw_ingredient_list: ''
+episode: episode-0542
+_lookup:
+  episode_and_section: episode-0542::hot jus

--- a/data/recipes/h/recipe-1521-hot-jus/meta.yml
+++ b/data/recipes/h/recipe-1521-hot-jus/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/h/recipe-1524-hanger-steak/data.yml
+++ b/data/recipes/h/recipe-1524-hanger-steak/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1524
+name: hanger steak
+raw_ingredient_list: ''
+episode: episode-0542
+_lookup:
+  episode_and_section: episode-0542::hanger steak

--- a/data/recipes/h/recipe-1524-hanger-steak/meta.yml
+++ b/data/recipes/h/recipe-1524-hanger-steak/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/h/recipe-1548-ham-sweet-potato-sandwich/data.yml
+++ b/data/recipes/h/recipe-1548-ham-sweet-potato-sandwich/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1548
+name: ham & sweet potato sandwich
+raw_ingredient_list: ''
+episode: episode-0458
+_lookup:
+  episode_and_section: episode-0458::ham & sweet potato sandwich

--- a/data/recipes/h/recipe-1548-ham-sweet-potato-sandwich/meta.yml
+++ b/data/recipes/h/recipe-1548-ham-sweet-potato-sandwich/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/h/recipe-1591-homemade-yolk-mayo/data.yml
+++ b/data/recipes/h/recipe-1591-homemade-yolk-mayo/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1591
+name: homemade yolk mayo
+raw_ingredient_list: ''
+episode: episode-0215
+_lookup:
+  episode_and_section: episode-0215::homemade yolk mayo

--- a/data/recipes/h/recipe-1591-homemade-yolk-mayo/meta.yml
+++ b/data/recipes/h/recipe-1591-homemade-yolk-mayo/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/h/recipe-1608-hard-boiled-eggs/data.yml
+++ b/data/recipes/h/recipe-1608-hard-boiled-eggs/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1608
+name: hard boiled eggs
+raw_ingredient_list: ''
+episode: episode-0581
+_lookup:
+  episode_and_section: episode-0581::hard boiled eggs

--- a/data/recipes/h/recipe-1608-hard-boiled-eggs/meta.yml
+++ b/data/recipes/h/recipe-1608-hard-boiled-eggs/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/h/recipe-1609-homemade-mayo/data.yml
+++ b/data/recipes/h/recipe-1609-homemade-mayo/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1609
+name: homemade mayo
+raw_ingredient_list: ''
+episode: episode-0581
+_lookup:
+  episode_and_section: episode-0581::homemade mayo

--- a/data/recipes/h/recipe-1609-homemade-mayo/meta.yml
+++ b/data/recipes/h/recipe-1609-homemade-mayo/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/h/recipe-1621-hot-fudge-sauce/data.yml
+++ b/data/recipes/h/recipe-1621-hot-fudge-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1621
+name: hot fudge sauce
+raw_ingredient_list: ''
+episode: episode-0628
+_lookup:
+  episode_and_section: episode-0628::hot fudge sauce

--- a/data/recipes/h/recipe-1621-hot-fudge-sauce/meta.yml
+++ b/data/recipes/h/recipe-1621-hot-fudge-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/h/recipe-1631-homemade-sour-cream/data.yml
+++ b/data/recipes/h/recipe-1631-homemade-sour-cream/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1631
+name: homemade sour cream
+raw_ingredient_list: ''
+episode: episode-0426
+_lookup:
+  episode_and_section: episode-0426::homemade sour cream

--- a/data/recipes/h/recipe-1631-homemade-sour-cream/meta.yml
+++ b/data/recipes/h/recipe-1631-homemade-sour-cream/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/i/recipe-1616-ice-cream-flavors/data.yml
+++ b/data/recipes/i/recipe-1616-ice-cream-flavors/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1616
+name: 'ice cream flavors:'
+raw_ingredient_list: ''
+episode: episode-0628
+_lookup:
+  episode_and_section: 'episode-0628::ice cream flavors:'

--- a/data/recipes/i/recipe-1616-ice-cream-flavors/meta.yml
+++ b/data/recipes/i/recipe-1616-ice-cream-flavors/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/j/recipe-1569-japanese-style-big-mac/data.yml
+++ b/data/recipes/j/recipe-1569-japanese-style-big-mac/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1569
+name: japanese-style big mac
+raw_ingredient_list: ''
+episode: episode-0306
+_lookup:
+  episode_and_section: episode-0306::japanese-style big mac

--- a/data/recipes/j/recipe-1569-japanese-style-big-mac/meta.yml
+++ b/data/recipes/j/recipe-1569-japanese-style-big-mac/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/j/recipe-1588-japanese-inspired-egg-salad-sandwich/data.yml
+++ b/data/recipes/j/recipe-1588-japanese-inspired-egg-salad-sandwich/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1588
+name: japanese-inspired egg salad sandwich
+raw_ingredient_list: ''
+episode: episode-0215
+_lookup:
+  episode_and_section: episode-0215::japanese-inspired egg salad sandwich

--- a/data/recipes/j/recipe-1588-japanese-inspired-egg-salad-sandwich/meta.yml
+++ b/data/recipes/j/recipe-1588-japanese-inspired-egg-salad-sandwich/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1458-level-4-cheesesteak-kit-style/data.yml
+++ b/data/recipes/l/recipe-1458-level-4-cheesesteak-kit-style/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1458
+name: 'level 4: cheesesteak kit style'
+raw_ingredient_list: ''
+episode: episode-0002
+_lookup:
+  episode_and_section: 'episode-0002::level 4: cheesesteak kit style'

--- a/data/recipes/l/recipe-1458-level-4-cheesesteak-kit-style/meta.yml
+++ b/data/recipes/l/recipe-1458-level-4-cheesesteak-kit-style/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1459-level-5-classic-homemade-cheesesteak/data.yml
+++ b/data/recipes/l/recipe-1459-level-5-classic-homemade-cheesesteak/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1459
+name: 'level 5: classic homemade cheesesteak'
+raw_ingredient_list: ''
+episode: episode-0002
+_lookup:
+  episode_and_section: 'episode-0002::level 5: classic homemade cheesesteak'

--- a/data/recipes/l/recipe-1459-level-5-classic-homemade-cheesesteak/meta.yml
+++ b/data/recipes/l/recipe-1459-level-5-classic-homemade-cheesesteak/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1460-level-6-chicken-cheesesteak/data.yml
+++ b/data/recipes/l/recipe-1460-level-6-chicken-cheesesteak/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1460
+name: 'level 6: chicken cheesesteak'
+raw_ingredient_list: ''
+episode: episode-0002
+_lookup:
+  episode_and_section: 'episode-0002::level 6: chicken cheesesteak'

--- a/data/recipes/l/recipe-1460-level-6-chicken-cheesesteak/meta.yml
+++ b/data/recipes/l/recipe-1460-level-6-chicken-cheesesteak/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1461-level-7-proper-homemade-cheesesteak/data.yml
+++ b/data/recipes/l/recipe-1461-level-7-proper-homemade-cheesesteak/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1461
+name: 'level 7: proper homemade cheesesteak'
+raw_ingredient_list: ''
+episode: episode-0002
+_lookup:
+  episode_and_section: 'episode-0002::level 7: proper homemade cheesesteak'

--- a/data/recipes/l/recipe-1461-level-7-proper-homemade-cheesesteak/meta.yml
+++ b/data/recipes/l/recipe-1461-level-7-proper-homemade-cheesesteak/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1462-level-8-shop-style-ribeye-cheesesteak/data.yml
+++ b/data/recipes/l/recipe-1462-level-8-shop-style-ribeye-cheesesteak/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1462
+name: 'level 8: shop-style ribeye cheesesteak'
+raw_ingredient_list: ''
+episode: episode-0002
+_lookup:
+  episode_and_section: 'episode-0002::level 8: shop-style ribeye cheesesteak'

--- a/data/recipes/l/recipe-1462-level-8-shop-style-ribeye-cheesesteak/meta.yml
+++ b/data/recipes/l/recipe-1462-level-8-shop-style-ribeye-cheesesteak/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1467-level-6-no-prep-chicken-noodle-soup/data.yml
+++ b/data/recipes/l/recipe-1467-level-6-no-prep-chicken-noodle-soup/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1467
+name: 'level 6: no prep chicken noodle soup'
+raw_ingredient_list: ''
+episode: episode-0001
+_lookup:
+  episode_and_section: 'episode-0001::level 6: no prep chicken noodle soup'

--- a/data/recipes/l/recipe-1467-level-6-no-prep-chicken-noodle-soup/meta.yml
+++ b/data/recipes/l/recipe-1467-level-6-no-prep-chicken-noodle-soup/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1468-level-7-simple-from-scratch/data.yml
+++ b/data/recipes/l/recipe-1468-level-7-simple-from-scratch/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1468
+name: 'level 7: simple from-scratch'
+raw_ingredient_list: ''
+episode: episode-0001
+_lookup:
+  episode_and_section: 'episode-0001::level 7: simple from-scratch'

--- a/data/recipes/l/recipe-1468-level-7-simple-from-scratch/meta.yml
+++ b/data/recipes/l/recipe-1468-level-7-simple-from-scratch/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1471-level-8-matzo-ball-soup/data.yml
+++ b/data/recipes/l/recipe-1471-level-8-matzo-ball-soup/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1471
+name: 'level 8: matzo ball soup'
+raw_ingredient_list: ''
+episode: episode-0001
+_lookup:
+  episode_and_section: 'episode-0001::level 8: matzo ball soup'

--- a/data/recipes/l/recipe-1471-level-8-matzo-ball-soup/meta.yml
+++ b/data/recipes/l/recipe-1471-level-8-matzo-ball-soup/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1472-level-9-avgolemono/data.yml
+++ b/data/recipes/l/recipe-1472-level-9-avgolemono/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1472
+name: 'level 9: avgolemono'
+raw_ingredient_list: ''
+episode: episode-0001
+_lookup:
+  episode_and_section: 'episode-0001::level 9: avgolemono'

--- a/data/recipes/l/recipe-1472-level-9-avgolemono/meta.yml
+++ b/data/recipes/l/recipe-1472-level-9-avgolemono/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1473-level-10-fine-dining-chicken-noodle-soup/data.yml
+++ b/data/recipes/l/recipe-1473-level-10-fine-dining-chicken-noodle-soup/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1473
+name: 'level 10: fine dining chicken noodle soup'
+raw_ingredient_list: ''
+episode: episode-0001
+_lookup:
+  episode_and_section: 'episode-0001::level 10: fine dining chicken noodle soup'

--- a/data/recipes/l/recipe-1473-level-10-fine-dining-chicken-noodle-soup/meta.yml
+++ b/data/recipes/l/recipe-1473-level-10-fine-dining-chicken-noodle-soup/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1483-level-1/data.yml
+++ b/data/recipes/l/recipe-1483-level-1/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1483
+name: level 1
+raw_ingredient_list: ''
+episode: episode-0012
+_lookup:
+  episode_and_section: episode-0012::level 1

--- a/data/recipes/l/recipe-1483-level-1/meta.yml
+++ b/data/recipes/l/recipe-1483-level-1/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1484-lentil-meatball-mixture/data.yml
+++ b/data/recipes/l/recipe-1484-lentil-meatball-mixture/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1484
+name: lentil meatball mixture
+raw_ingredient_list: ''
+episode: episode-0012
+_lookup:
+  episode_and_section: episode-0012::lentil meatball mixture

--- a/data/recipes/l/recipe-1484-lentil-meatball-mixture/meta.yml
+++ b/data/recipes/l/recipe-1484-lentil-meatball-mixture/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1486-lentil-meatballs/data.yml
+++ b/data/recipes/l/recipe-1486-lentil-meatballs/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1486
+name: lentil meatballs
+raw_ingredient_list: ''
+episode: episode-0012
+_lookup:
+  episode_and_section: episode-0012::lentil meatballs

--- a/data/recipes/l/recipe-1486-lentil-meatballs/meta.yml
+++ b/data/recipes/l/recipe-1486-lentil-meatballs/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1487-level-2/data.yml
+++ b/data/recipes/l/recipe-1487-level-2/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1487
+name: level 2
+raw_ingredient_list: ''
+episode: episode-0012
+_lookup:
+  episode_and_section: episode-0012::level 2

--- a/data/recipes/l/recipe-1487-level-2/meta.yml
+++ b/data/recipes/l/recipe-1487-level-2/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1489-level-3/data.yml
+++ b/data/recipes/l/recipe-1489-level-3/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1489
+name: level 3
+raw_ingredient_list: ''
+episode: episode-0012
+_lookup:
+  episode_and_section: episode-0012::level 3

--- a/data/recipes/l/recipe-1489-level-3/meta.yml
+++ b/data/recipes/l/recipe-1489-level-3/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1490-level-4/data.yml
+++ b/data/recipes/l/recipe-1490-level-4/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1490
+name: level 4
+raw_ingredient_list: ''
+episode: episode-0012
+_lookup:
+  episode_and_section: episode-0012::level 4

--- a/data/recipes/l/recipe-1490-level-4/meta.yml
+++ b/data/recipes/l/recipe-1490-level-4/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1522-london-broil/data.yml
+++ b/data/recipes/l/recipe-1522-london-broil/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1522
+name: london broil
+raw_ingredient_list: ''
+episode: episode-0542
+_lookup:
+  episode_and_section: episode-0542::london broil

--- a/data/recipes/l/recipe-1522-london-broil/meta.yml
+++ b/data/recipes/l/recipe-1522-london-broil/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1536-level-3-blue-box/data.yml
+++ b/data/recipes/l/recipe-1536-level-3-blue-box/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1536
+name: 'level 3: blue box'
+raw_ingredient_list: ''
+episode: episode-0004
+_lookup:
+  episode_and_section: 'episode-0004::level 3: blue box'

--- a/data/recipes/l/recipe-1536-level-3-blue-box/meta.yml
+++ b/data/recipes/l/recipe-1536-level-3-blue-box/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1539-level-4-evaporated-milk/data.yml
+++ b/data/recipes/l/recipe-1539-level-4-evaporated-milk/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1539
+name: 'level 4: evaporated milk'
+raw_ingredient_list: ''
+episode: episode-0004
+_lookup:
+  episode_and_section: 'episode-0004::level 4: evaporated milk'

--- a/data/recipes/l/recipe-1539-level-4-evaporated-milk/meta.yml
+++ b/data/recipes/l/recipe-1539-level-4-evaporated-milk/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1540-level-5-one-pot-inspired-by-america-s-test-kitchen/data.yml
+++ b/data/recipes/l/recipe-1540-level-5-one-pot-inspired-by-america-s-test-kitchen/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1540
+name: 'level 5: one pot inspired by america''s test kitchen'
+raw_ingredient_list: ''
+episode: episode-0004
+_lookup:
+  episode_and_section: 'episode-0004::level 5: one pot inspired by america''s test kitchen'

--- a/data/recipes/l/recipe-1540-level-5-one-pot-inspired-by-america-s-test-kitchen/meta.yml
+++ b/data/recipes/l/recipe-1540-level-5-one-pot-inspired-by-america-s-test-kitchen/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1541-level-6-deep-fried-mac-cheese/data.yml
+++ b/data/recipes/l/recipe-1541-level-6-deep-fried-mac-cheese/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1541
+name: 'level 6: deep fried mac & cheese'
+raw_ingredient_list: ''
+episode: episode-0004
+_lookup:
+  episode_and_section: 'episode-0004::level 6: deep fried mac & cheese'

--- a/data/recipes/l/recipe-1541-level-6-deep-fried-mac-cheese/meta.yml
+++ b/data/recipes/l/recipe-1541-level-6-deep-fried-mac-cheese/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1542-level-7-classic-mornay/data.yml
+++ b/data/recipes/l/recipe-1542-level-7-classic-mornay/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1542
+name: 'level 7: classic mornay'
+raw_ingredient_list: ''
+episode: episode-0004
+_lookup:
+  episode_and_section: 'episode-0004::level 7: classic mornay'

--- a/data/recipes/l/recipe-1542-level-7-classic-mornay/meta.yml
+++ b/data/recipes/l/recipe-1542-level-7-classic-mornay/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1543-level-8-molecular-gastronomy-sodium-citrate/data.yml
+++ b/data/recipes/l/recipe-1543-level-8-molecular-gastronomy-sodium-citrate/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1543
+name: 'level 8: molecular gastronomy - sodium citrate'
+raw_ingredient_list: ''
+episode: episode-0004
+_lookup:
+  episode_and_section: 'episode-0004::level 8: molecular gastronomy - sodium citrate'

--- a/data/recipes/l/recipe-1543-level-8-molecular-gastronomy-sodium-citrate/meta.yml
+++ b/data/recipes/l/recipe-1543-level-8-molecular-gastronomy-sodium-citrate/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1544-level-9-sparing-no-expense/data.yml
+++ b/data/recipes/l/recipe-1544-level-9-sparing-no-expense/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1544
+name: 'level 9: sparing no expense'
+raw_ingredient_list: ''
+episode: episode-0004
+_lookup:
+  episode_and_section: 'episode-0004::level 9: sparing no expense'

--- a/data/recipes/l/recipe-1544-level-9-sparing-no-expense/meta.yml
+++ b/data/recipes/l/recipe-1544-level-9-sparing-no-expense/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/l/recipe-1549-lettuce-honey-ham-sandwich/data.yml
+++ b/data/recipes/l/recipe-1549-lettuce-honey-ham-sandwich/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1549
+name: lettuce & honey ham sandwich
+raw_ingredient_list: ''
+episode: episode-0458
+_lookup:
+  episode_and_section: episode-0458::lettuce & honey ham sandwich

--- a/data/recipes/l/recipe-1549-lettuce-honey-ham-sandwich/meta.yml
+++ b/data/recipes/l/recipe-1549-lettuce-honey-ham-sandwich/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1476-monkey-bread/data.yml
+++ b/data/recipes/m/recipe-1476-monkey-bread/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1476
+name: monkey bread
+raw_ingredient_list: ''
+episode: episode-0556
+_lookup:
+  episode_and_section: episode-0556::monkey bread

--- a/data/recipes/m/recipe-1476-monkey-bread/meta.yml
+++ b/data/recipes/m/recipe-1476-monkey-bread/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1482-million-dollar-deviled-eggs/data.yml
+++ b/data/recipes/m/recipe-1482-million-dollar-deviled-eggs/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1482
+name: million dollar deviled eggs
+raw_ingredient_list: ''
+episode: episode-0556
+_lookup:
+  episode_and_section: episode-0556::million dollar deviled eggs

--- a/data/recipes/m/recipe-1482-million-dollar-deviled-eggs/meta.yml
+++ b/data/recipes/m/recipe-1482-million-dollar-deviled-eggs/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1488-meatballs/data.yml
+++ b/data/recipes/m/recipe-1488-meatballs/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1488
+name: meatballs
+raw_ingredient_list: ''
+episode: episode-0012
+_lookup:
+  episode_and_section: episode-0012::meatballs

--- a/data/recipes/m/recipe-1488-meatballs/meta.yml
+++ b/data/recipes/m/recipe-1488-meatballs/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1501-mashed-potatoes/data.yml
+++ b/data/recipes/m/recipe-1501-mashed-potatoes/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1501
+name: mashed potatoes
+raw_ingredient_list: ''
+episode: episode-0621
+_lookup:
+  episode_and_section: episode-0621::mashed potatoes

--- a/data/recipes/m/recipe-1501-mashed-potatoes/meta.yml
+++ b/data/recipes/m/recipe-1501-mashed-potatoes/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1504-mushroom-duxelles/data.yml
+++ b/data/recipes/m/recipe-1504-mushroom-duxelles/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1504
+name: mushroom duxelles
+raw_ingredient_list: ''
+episode: episode-0060
+_lookup:
+  episode_and_section: episode-0060::mushroom duxelles

--- a/data/recipes/m/recipe-1504-mushroom-duxelles/meta.yml
+++ b/data/recipes/m/recipe-1504-mushroom-duxelles/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1507-mushroom-duxelle/data.yml
+++ b/data/recipes/m/recipe-1507-mushroom-duxelle/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1507
+name: mushroom duxelle
+raw_ingredient_list: ''
+episode: episode-0060
+_lookup:
+  episode_and_section: episode-0060::mushroom duxelle

--- a/data/recipes/m/recipe-1507-mushroom-duxelle/meta.yml
+++ b/data/recipes/m/recipe-1507-mushroom-duxelle/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1529-marshmallow-cream-cheese-frosting/data.yml
+++ b/data/recipes/m/recipe-1529-marshmallow-cream-cheese-frosting/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1529
+name: marshmallow cream cheese frosting
+raw_ingredient_list: ''
+episode: episode-0229
+_lookup:
+  episode_and_section: episode-0229::marshmallow cream cheese frosting

--- a/data/recipes/m/recipe-1529-marshmallow-cream-cheese-frosting/meta.yml
+++ b/data/recipes/m/recipe-1529-marshmallow-cream-cheese-frosting/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1537-mac/data.yml
+++ b/data/recipes/m/recipe-1537-mac/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1537
+name: mac
+raw_ingredient_list: ''
+episode: episode-0004
+_lookup:
+  episode_and_section: episode-0004::mac

--- a/data/recipes/m/recipe-1537-mac/meta.yml
+++ b/data/recipes/m/recipe-1537-mac/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1560-mango-ginger-sauce/data.yml
+++ b/data/recipes/m/recipe-1560-mango-ginger-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1560
+name: mango ginger sauce
+raw_ingredient_list: ''
+episode: episode-0009
+_lookup:
+  episode_and_section: episode-0009::mango ginger sauce

--- a/data/recipes/m/recipe-1560-mango-ginger-sauce/meta.yml
+++ b/data/recipes/m/recipe-1560-mango-ginger-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1564-medallions/data.yml
+++ b/data/recipes/m/recipe-1564-medallions/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1564
+name: medallions
+raw_ingredient_list: ''
+episode: episode-0014
+_lookup:
+  episode_and_section: episode-0014::medallions

--- a/data/recipes/m/recipe-1564-medallions/meta.yml
+++ b/data/recipes/m/recipe-1564-medallions/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1619-matcha-flavor/data.yml
+++ b/data/recipes/m/recipe-1619-matcha-flavor/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1619
+name: matcha flavor
+raw_ingredient_list: ''
+episode: episode-0628
+_lookup:
+  episode_and_section: episode-0628::matcha flavor

--- a/data/recipes/m/recipe-1619-matcha-flavor/meta.yml
+++ b/data/recipes/m/recipe-1619-matcha-flavor/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1624-milk-mixture/data.yml
+++ b/data/recipes/m/recipe-1624-milk-mixture/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1624
+name: milk mixture
+raw_ingredient_list: ''
+episode: episode-0628
+_lookup:
+  episode_and_section: episode-0628::milk mixture

--- a/data/recipes/m/recipe-1624-milk-mixture/meta.yml
+++ b/data/recipes/m/recipe-1624-milk-mixture/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/m/recipe-1629-mushroom-sauerkraut-filling/data.yml
+++ b/data/recipes/m/recipe-1629-mushroom-sauerkraut-filling/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1629
+name: mushroom sauerkraut filling
+raw_ingredient_list: ''
+episode: episode-0426
+_lookup:
+  episode_and_section: episode-0426::mushroom sauerkraut filling

--- a/data/recipes/m/recipe-1629-mushroom-sauerkraut-filling/meta.yml
+++ b/data/recipes/m/recipe-1629-mushroom-sauerkraut-filling/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/n/recipe-1519-new-york-strip-steak/data.yml
+++ b/data/recipes/n/recipe-1519-new-york-strip-steak/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1519
+name: new york strip steak
+raw_ingredient_list: ''
+episode: episode-0542
+_lookup:
+  episode_and_section: episode-0542::new york strip steak

--- a/data/recipes/n/recipe-1519-new-york-strip-steak/meta.yml
+++ b/data/recipes/n/recipe-1519-new-york-strip-steak/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/n/recipe-1582-nilla-wafer-crust/data.yml
+++ b/data/recipes/n/recipe-1582-nilla-wafer-crust/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1582
+name: nilla wafer crust
+raw_ingredient_list: ''
+episode: episode-0124
+_lookup:
+  episode_and_section: episode-0124::nilla wafer crust

--- a/data/recipes/n/recipe-1582-nilla-wafer-crust/meta.yml
+++ b/data/recipes/n/recipe-1582-nilla-wafer-crust/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/n/recipe-1584-nilla-wafer-crumble/data.yml
+++ b/data/recipes/n/recipe-1584-nilla-wafer-crumble/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1584
+name: nilla wafer crumble
+raw_ingredient_list: ''
+episode: episode-0124
+_lookup:
+  episode_and_section: episode-0124::nilla wafer crumble

--- a/data/recipes/n/recipe-1584-nilla-wafer-crumble/meta.yml
+++ b/data/recipes/n/recipe-1584-nilla-wafer-crumble/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1474-pasta-dough/data.yml
+++ b/data/recipes/p/recipe-1474-pasta-dough/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1474
+name: pasta dough
+raw_ingredient_list: ''
+episode: episode-0001
+_lookup:
+  episode_and_section: episode-0001::pasta dough

--- a/data/recipes/p/recipe-1474-pasta-dough/meta.yml
+++ b/data/recipes/p/recipe-1474-pasta-dough/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1480-poutine-bites/data.yml
+++ b/data/recipes/p/recipe-1480-poutine-bites/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1480
+name: poutine bites
+raw_ingredient_list: ''
+episode: episode-0556
+_lookup:
+  episode_and_section: episode-0556::poutine bites

--- a/data/recipes/p/recipe-1480-poutine-bites/meta.yml
+++ b/data/recipes/p/recipe-1480-poutine-bites/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1481-potato-cups/data.yml
+++ b/data/recipes/p/recipe-1481-potato-cups/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1481
+name: potato cups
+raw_ingredient_list: ''
+episode: episode-0556
+_lookup:
+  episode_and_section: episode-0556::potato cups

--- a/data/recipes/p/recipe-1481-potato-cups/meta.yml
+++ b/data/recipes/p/recipe-1481-potato-cups/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1485-panade/data.yml
+++ b/data/recipes/p/recipe-1485-panade/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1485
+name: panade
+raw_ingredient_list: ''
+episode: episode-0012
+_lookup:
+  episode_and_section: episode-0012::panade

--- a/data/recipes/p/recipe-1485-panade/meta.yml
+++ b/data/recipes/p/recipe-1485-panade/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1492-pain-de-mie/data.yml
+++ b/data/recipes/p/recipe-1492-pain-de-mie/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1492
+name: pain de mie
+raw_ingredient_list: ''
+episode: episode-0620
+_lookup:
+  episode_and_section: episode-0620::pain de mie

--- a/data/recipes/p/recipe-1492-pain-de-mie/meta.yml
+++ b/data/recipes/p/recipe-1492-pain-de-mie/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1493-poolish/data.yml
+++ b/data/recipes/p/recipe-1493-poolish/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1493
+name: poolish
+raw_ingredient_list: ''
+episode: episode-0620
+_lookup:
+  episode_and_section: episode-0620::poolish

--- a/data/recipes/p/recipe-1493-poolish/meta.yml
+++ b/data/recipes/p/recipe-1493-poolish/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1494-preserved-lemon-blueberry-compote/data.yml
+++ b/data/recipes/p/recipe-1494-preserved-lemon-blueberry-compote/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1494
+name: preserved lemon blueberry compote
+raw_ingredient_list: ''
+episode: episode-0620
+_lookup:
+  episode_and_section: episode-0620::preserved lemon blueberry compote

--- a/data/recipes/p/recipe-1494-preserved-lemon-blueberry-compote/meta.yml
+++ b/data/recipes/p/recipe-1494-preserved-lemon-blueberry-compote/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1515-pearl-onions/data.yml
+++ b/data/recipes/p/recipe-1515-pearl-onions/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1515
+name: pearl onions
+raw_ingredient_list: ''
+episode: episode-0174
+_lookup:
+  episode_and_section: episode-0174::pearl onions

--- a/data/recipes/p/recipe-1515-pearl-onions/meta.yml
+++ b/data/recipes/p/recipe-1515-pearl-onions/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1559-pickled-red-onion/data.yml
+++ b/data/recipes/p/recipe-1559-pickled-red-onion/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1559
+name: pickled red onion
+raw_ingredient_list: ''
+episode: episode-0009
+_lookup:
+  episode_and_section: episode-0009::pickled red onion

--- a/data/recipes/p/recipe-1559-pickled-red-onion/meta.yml
+++ b/data/recipes/p/recipe-1559-pickled-red-onion/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1561-pomegranate-sauce/data.yml
+++ b/data/recipes/p/recipe-1561-pomegranate-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1561
+name: pomegranate sauce
+raw_ingredient_list: ''
+episode: episode-0009
+_lookup:
+  episode_and_section: episode-0009::pomegranate sauce

--- a/data/recipes/p/recipe-1561-pomegranate-sauce/meta.yml
+++ b/data/recipes/p/recipe-1561-pomegranate-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1563-pork-tenderloin-medallions-with-bourbon-sauce/data.yml
+++ b/data/recipes/p/recipe-1563-pork-tenderloin-medallions-with-bourbon-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1563
+name: pork tenderloin medallions with bourbon sauce
+raw_ingredient_list: ''
+episode: episode-0014
+_lookup:
+  episode_and_section: episode-0014::pork tenderloin medallions with bourbon sauce

--- a/data/recipes/p/recipe-1563-pork-tenderloin-medallions-with-bourbon-sauce/meta.yml
+++ b/data/recipes/p/recipe-1563-pork-tenderloin-medallions-with-bourbon-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1566-pork-schnitzel/data.yml
+++ b/data/recipes/p/recipe-1566-pork-schnitzel/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1566
+name: pork schnitzel
+raw_ingredient_list: ''
+episode: episode-0014
+_lookup:
+  episode_and_section: episode-0014::pork schnitzel

--- a/data/recipes/p/recipe-1566-pork-schnitzel/meta.yml
+++ b/data/recipes/p/recipe-1566-pork-schnitzel/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1567-pork-souvlaki/data.yml
+++ b/data/recipes/p/recipe-1567-pork-souvlaki/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1567
+name: pork souvlaki
+raw_ingredient_list: ''
+episode: episode-0014
+_lookup:
+  episode_and_section: episode-0014::pork souvlaki

--- a/data/recipes/p/recipe-1567-pork-souvlaki/meta.yml
+++ b/data/recipes/p/recipe-1567-pork-souvlaki/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1600-pasta-puttanesca/data.yml
+++ b/data/recipes/p/recipe-1600-pasta-puttanesca/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1600
+name: pasta puttanesca
+raw_ingredient_list: ''
+episode: episode-0392
+_lookup:
+  episode_and_section: episode-0392::pasta puttanesca

--- a/data/recipes/p/recipe-1600-pasta-puttanesca/meta.yml
+++ b/data/recipes/p/recipe-1600-pasta-puttanesca/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1601-puttanesca/data.yml
+++ b/data/recipes/p/recipe-1601-puttanesca/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1601
+name: puttanesca
+raw_ingredient_list: ''
+episode: episode-0392
+_lookup:
+  episode_and_section: episode-0392::puttanesca

--- a/data/recipes/p/recipe-1601-puttanesca/meta.yml
+++ b/data/recipes/p/recipe-1601-puttanesca/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1602-pork-tenderloin-with-romesco-saucerom/data.yml
+++ b/data/recipes/p/recipe-1602-pork-tenderloin-with-romesco-saucerom/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1602
+name: pork tenderloin with romesco saucerom
+raw_ingredient_list: ''
+episode: episode-0392
+_lookup:
+  episode_and_section: episode-0392::pork tenderloin with romesco saucerom

--- a/data/recipes/p/recipe-1602-pork-tenderloin-with-romesco-saucerom/meta.yml
+++ b/data/recipes/p/recipe-1602-pork-tenderloin-with-romesco-saucerom/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1604-pork-tenderloin/data.yml
+++ b/data/recipes/p/recipe-1604-pork-tenderloin/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1604
+name: pork tenderloin
+raw_ingredient_list: ''
+episode: episode-0392
+_lookup:
+  episode_and_section: episode-0392::pork tenderloin

--- a/data/recipes/p/recipe-1604-pork-tenderloin/meta.yml
+++ b/data/recipes/p/recipe-1604-pork-tenderloin/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1611-purple-deviled-eggs/data.yml
+++ b/data/recipes/p/recipe-1611-purple-deviled-eggs/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1611
+name: purple deviled eggs
+raw_ingredient_list: ''
+episode: episode-0581
+_lookup:
+  episode_and_section: episode-0581::purple deviled eggs

--- a/data/recipes/p/recipe-1611-purple-deviled-eggs/meta.yml
+++ b/data/recipes/p/recipe-1611-purple-deviled-eggs/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1623-pastry-cream/data.yml
+++ b/data/recipes/p/recipe-1623-pastry-cream/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1623
+name: pastry cream
+raw_ingredient_list: ''
+episode: episode-0628
+_lookup:
+  episode_and_section: episode-0628::pastry cream

--- a/data/recipes/p/recipe-1623-pastry-cream/meta.yml
+++ b/data/recipes/p/recipe-1623-pastry-cream/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1625-pierogoi-dough-assembly/data.yml
+++ b/data/recipes/p/recipe-1625-pierogoi-dough-assembly/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1625
+name: pierogoi dough & assembly
+raw_ingredient_list: ''
+episode: episode-0426
+_lookup:
+  episode_and_section: episode-0426::pierogoi dough & assembly

--- a/data/recipes/p/recipe-1625-pierogoi-dough-assembly/meta.yml
+++ b/data/recipes/p/recipe-1625-pierogoi-dough-assembly/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1626-pierogoi-dough/data.yml
+++ b/data/recipes/p/recipe-1626-pierogoi-dough/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1626
+name: pierogoi dough
+raw_ingredient_list: ''
+episode: episode-0426
+_lookup:
+  episode_and_section: episode-0426::pierogoi dough

--- a/data/recipes/p/recipe-1626-pierogoi-dough/meta.yml
+++ b/data/recipes/p/recipe-1626-pierogoi-dough/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/p/recipe-1627-potato-filling/data.yml
+++ b/data/recipes/p/recipe-1627-potato-filling/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1627
+name: potato filling
+raw_ingredient_list: ''
+episode: episode-0426
+_lookup:
+  episode_and_section: episode-0426::potato filling

--- a/data/recipes/p/recipe-1627-potato-filling/meta.yml
+++ b/data/recipes/p/recipe-1627-potato-filling/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/q/recipe-1545-quadruple-stacked-ham-sandwich/data.yml
+++ b/data/recipes/q/recipe-1545-quadruple-stacked-ham-sandwich/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1545
+name: quadruple stacked ham sandwich
+raw_ingredient_list: ''
+episode: episode-0458
+_lookup:
+  episode_and_section: episode-0458::quadruple stacked ham sandwich

--- a/data/recipes/q/recipe-1545-quadruple-stacked-ham-sandwich/meta.yml
+++ b/data/recipes/q/recipe-1545-quadruple-stacked-ham-sandwich/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/r/recipe-1495-red-miso-maple-syrup/data.yml
+++ b/data/recipes/r/recipe-1495-red-miso-maple-syrup/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1495
+name: red miso maple syrup
+raw_ingredient_list: ''
+episode: episode-0620
+_lookup:
+  episode_and_section: episode-0620::red miso maple syrup

--- a/data/recipes/r/recipe-1495-red-miso-maple-syrup/meta.yml
+++ b/data/recipes/r/recipe-1495-red-miso-maple-syrup/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/r/recipe-1502-roasted-vegetables/data.yml
+++ b/data/recipes/r/recipe-1502-roasted-vegetables/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1502
+name: roasted vegetables
+raw_ingredient_list: ''
+episode: episode-0621
+_lookup:
+  episode_and_section: episode-0621::roasted vegetables

--- a/data/recipes/r/recipe-1502-roasted-vegetables/meta.yml
+++ b/data/recipes/r/recipe-1502-roasted-vegetables/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/r/recipe-1509-red-miso-puff-pastry/data.yml
+++ b/data/recipes/r/recipe-1509-red-miso-puff-pastry/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1509
+name: red miso puff pastry
+raw_ingredient_list: ''
+episode: episode-0060
+_lookup:
+  episode_and_section: episode-0060::red miso puff pastry

--- a/data/recipes/r/recipe-1509-red-miso-puff-pastry/meta.yml
+++ b/data/recipes/r/recipe-1509-red-miso-puff-pastry/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/r/recipe-1523-ribeye/data.yml
+++ b/data/recipes/r/recipe-1523-ribeye/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1523
+name: ribeye
+raw_ingredient_list: ''
+episode: episode-0542
+_lookup:
+  episode_and_section: episode-0542::ribeye

--- a/data/recipes/r/recipe-1523-ribeye/meta.yml
+++ b/data/recipes/r/recipe-1523-ribeye/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/r/recipe-1603-romesco-sauce/data.yml
+++ b/data/recipes/r/recipe-1603-romesco-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1603
+name: romesco sauce
+raw_ingredient_list: ''
+episode: episode-0392
+_lookup:
+  episode_and_section: episode-0392::romesco sauce

--- a/data/recipes/r/recipe-1603-romesco-sauce/meta.yml
+++ b/data/recipes/r/recipe-1603-romesco-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/r/recipe-1610-regular-deviled-eggs/data.yml
+++ b/data/recipes/r/recipe-1610-regular-deviled-eggs/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1610
+name: regular deviled eggs
+raw_ingredient_list: ''
+episode: episode-0581
+_lookup:
+  episode_and_section: episode-0581::regular deviled eggs

--- a/data/recipes/r/recipe-1610-regular-deviled-eggs/meta.yml
+++ b/data/recipes/r/recipe-1610-regular-deviled-eggs/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1464-skewers/data.yml
+++ b/data/recipes/s/recipe-1464-skewers/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1464
+name: skewers
+raw_ingredient_list: ''
+episode: episode-0328
+_lookup:
+  episode_and_section: episode-0328::skewers

--- a/data/recipes/s/recipe-1464-skewers/meta.yml
+++ b/data/recipes/s/recipe-1464-skewers/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1469-stock/data.yml
+++ b/data/recipes/s/recipe-1469-stock/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1469
+name: stock
+raw_ingredient_list: ''
+episode: episode-0001
+_lookup:
+  episode_and_section: episode-0001::stock

--- a/data/recipes/s/recipe-1469-stock/meta.yml
+++ b/data/recipes/s/recipe-1469-stock/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1470-soup-base/data.yml
+++ b/data/recipes/s/recipe-1470-soup-base/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1470
+name: soup base
+raw_ingredient_list: ''
+episode: episode-0001
+_lookup:
+  episode_and_section: episode-0001::soup base

--- a/data/recipes/s/recipe-1470-soup-base/meta.yml
+++ b/data/recipes/s/recipe-1470-soup-base/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1475-spinach-artichoke-dip-monkey-bread/data.yml
+++ b/data/recipes/s/recipe-1475-spinach-artichoke-dip-monkey-bread/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1475
+name: spinach artichoke dip monkey bread
+raw_ingredient_list: ''
+episode: episode-0556
+_lookup:
+  episode_and_section: episode-0556::spinach artichoke dip monkey bread

--- a/data/recipes/s/recipe-1475-spinach-artichoke-dip-monkey-bread/meta.yml
+++ b/data/recipes/s/recipe-1475-spinach-artichoke-dip-monkey-bread/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1478-spinach-artichoke-dip/data.yml
+++ b/data/recipes/s/recipe-1478-spinach-artichoke-dip/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1478
+name: spinach artichoke dip
+raw_ingredient_list: ''
+episode: episode-0556
+_lookup:
+  episode_and_section: episode-0556::spinach artichoke dip

--- a/data/recipes/s/recipe-1478-spinach-artichoke-dip/meta.yml
+++ b/data/recipes/s/recipe-1478-spinach-artichoke-dip/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1518-steak-cuts-technique/data.yml
+++ b/data/recipes/s/recipe-1518-steak-cuts-technique/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1518
+name: 'steak cuts: technique'
+raw_ingredient_list: ''
+episode: episode-0542
+_lookup:
+  episode_and_section: 'episode-0542::steak cuts: technique'

--- a/data/recipes/s/recipe-1518-steak-cuts-technique/meta.yml
+++ b/data/recipes/s/recipe-1518-steak-cuts-technique/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1526-steak/data.yml
+++ b/data/recipes/s/recipe-1526-steak/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1526
+name: steak
+raw_ingredient_list: ''
+episode: episode-0542
+_lookup:
+  episode_and_section: episode-0542::steak

--- a/data/recipes/s/recipe-1526-steak/meta.yml
+++ b/data/recipes/s/recipe-1526-steak/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1532-sponge-cake-batter/data.yml
+++ b/data/recipes/s/recipe-1532-sponge-cake-batter/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1532
+name: sponge cake batter
+raw_ingredient_list: ''
+episode: episode-0229
+_lookup:
+  episode_and_section: episode-0229::sponge cake batter

--- a/data/recipes/s/recipe-1532-sponge-cake-batter/meta.yml
+++ b/data/recipes/s/recipe-1532-sponge-cake-batter/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1534-spiced-cake-soak/data.yml
+++ b/data/recipes/s/recipe-1534-spiced-cake-soak/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1534
+name: spiced cake soak
+raw_ingredient_list: ''
+episode: episode-0229
+_lookup:
+  episode_and_section: episode-0229::spiced cake soak

--- a/data/recipes/s/recipe-1534-spiced-cake-soak/meta.yml
+++ b/data/recipes/s/recipe-1534-spiced-cake-soak/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1546-scampi-shrimp/data.yml
+++ b/data/recipes/s/recipe-1546-scampi-shrimp/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1546
+name: scampi shrimp
+raw_ingredient_list: ''
+episode: episode-0458
+_lookup:
+  episode_and_section: episode-0458::scampi shrimp

--- a/data/recipes/s/recipe-1546-scampi-shrimp/meta.yml
+++ b/data/recipes/s/recipe-1546-scampi-shrimp/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1550-shrimp-avocado-sandwich/data.yml
+++ b/data/recipes/s/recipe-1550-shrimp-avocado-sandwich/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1550
+name: shrimp & avocado sandwich
+raw_ingredient_list: ''
+episode: episode-0458
+_lookup:
+  episode_and_section: episode-0458::shrimp & avocado sandwich

--- a/data/recipes/s/recipe-1550-shrimp-avocado-sandwich/meta.yml
+++ b/data/recipes/s/recipe-1550-shrimp-avocado-sandwich/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1555-short-rib-bones-snack/data.yml
+++ b/data/recipes/s/recipe-1555-short-rib-bones-snack/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1555
+name: short rib bones snack
+raw_ingredient_list: ''
+episode: episode-0196
+_lookup:
+  episode_and_section: episode-0196::short rib bones snack

--- a/data/recipes/s/recipe-1555-short-rib-bones-snack/meta.yml
+++ b/data/recipes/s/recipe-1555-short-rib-bones-snack/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1562-salad/data.yml
+++ b/data/recipes/s/recipe-1562-salad/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1562
+name: salad
+raw_ingredient_list: ''
+episode: episode-0009
+_lookup:
+  episode_and_section: episode-0009::salad

--- a/data/recipes/s/recipe-1562-salad/meta.yml
+++ b/data/recipes/s/recipe-1562-salad/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1568-souvlaki-spice-mix/data.yml
+++ b/data/recipes/s/recipe-1568-souvlaki-spice-mix/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1568
+name: souvlaki spice mix
+raw_ingredient_list: ''
+episode: episode-0014
+_lookup:
+  episode_and_section: episode-0014::souvlaki spice mix

--- a/data/recipes/s/recipe-1568-souvlaki-spice-mix/meta.yml
+++ b/data/recipes/s/recipe-1568-souvlaki-spice-mix/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1577-sponge-cake/data.yml
+++ b/data/recipes/s/recipe-1577-sponge-cake/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1577
+name: sponge cake
+raw_ingredient_list: ''
+episode: episode-0124
+_lookup:
+  episode_and_section: episode-0124::sponge cake

--- a/data/recipes/s/recipe-1577-sponge-cake/meta.yml
+++ b/data/recipes/s/recipe-1577-sponge-cake/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1578-sponge-cake-batter/data.yml
+++ b/data/recipes/s/recipe-1578-sponge-cake-batter/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1578
+name: sponge cake batter
+raw_ingredient_list: ''
+episode: episode-0124
+_lookup:
+  episode_and_section: episode-0124::sponge cake batter

--- a/data/recipes/s/recipe-1578-sponge-cake-batter/meta.yml
+++ b/data/recipes/s/recipe-1578-sponge-cake-batter/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1581-strawberry-cheesecake/data.yml
+++ b/data/recipes/s/recipe-1581-strawberry-cheesecake/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1581
+name: strawberry cheesecake
+raw_ingredient_list: ''
+episode: episode-0124
+_lookup:
+  episode_and_section: episode-0124::strawberry cheesecake

--- a/data/recipes/s/recipe-1581-strawberry-cheesecake/meta.yml
+++ b/data/recipes/s/recipe-1581-strawberry-cheesecake/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1583-strawberry-topping/data.yml
+++ b/data/recipes/s/recipe-1583-strawberry-topping/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1583
+name: strawberry topping
+raw_ingredient_list: ''
+episode: episode-0124
+_lookup:
+  episode_and_section: episode-0124::strawberry topping

--- a/data/recipes/s/recipe-1583-strawberry-topping/meta.yml
+++ b/data/recipes/s/recipe-1583-strawberry-topping/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1586-sandwich/data.yml
+++ b/data/recipes/s/recipe-1586-sandwich/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1586
+name: sandwich
+raw_ingredient_list: ''
+episode: episode-0215
+_lookup:
+  episode_and_section: episode-0215::sandwich

--- a/data/recipes/s/recipe-1586-sandwich/meta.yml
+++ b/data/recipes/s/recipe-1586-sandwich/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1589-shokupan-dough/data.yml
+++ b/data/recipes/s/recipe-1589-shokupan-dough/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1589
+name: shokupan dough
+raw_ingredient_list: ''
+episode: episode-0215
+_lookup:
+  episode_and_section: episode-0215::shokupan dough

--- a/data/recipes/s/recipe-1589-shokupan-dough/meta.yml
+++ b/data/recipes/s/recipe-1589-shokupan-dough/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1593-sandwich-assembly/data.yml
+++ b/data/recipes/s/recipe-1593-sandwich-assembly/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1593
+name: sandwich assembly
+raw_ingredient_list: ''
+episode: episode-0215
+_lookup:
+  episode_and_section: episode-0215::sandwich assembly

--- a/data/recipes/s/recipe-1593-sandwich-assembly/meta.yml
+++ b/data/recipes/s/recipe-1593-sandwich-assembly/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1594-shrimp-stock/data.yml
+++ b/data/recipes/s/recipe-1594-shrimp-stock/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1594
+name: shrimp stock
+raw_ingredient_list: ''
+episode: episode-0510
+_lookup:
+  episode_and_section: episode-0510::shrimp stock

--- a/data/recipes/s/recipe-1594-shrimp-stock/meta.yml
+++ b/data/recipes/s/recipe-1594-shrimp-stock/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1595-shrimp-cocktail/data.yml
+++ b/data/recipes/s/recipe-1595-shrimp-cocktail/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1595
+name: shrimp cocktail
+raw_ingredient_list: ''
+episode: episode-0510
+_lookup:
+  episode_and_section: episode-0510::shrimp cocktail

--- a/data/recipes/s/recipe-1595-shrimp-cocktail/meta.yml
+++ b/data/recipes/s/recipe-1595-shrimp-cocktail/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1596-shrimp/data.yml
+++ b/data/recipes/s/recipe-1596-shrimp/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1596
+name: shrimp
+raw_ingredient_list: ''
+episode: episode-0510
+_lookup:
+  episode_and_section: episode-0510::shrimp

--- a/data/recipes/s/recipe-1596-shrimp/meta.yml
+++ b/data/recipes/s/recipe-1596-shrimp/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1614-scotch-eggs/data.yml
+++ b/data/recipes/s/recipe-1614-scotch-eggs/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1614
+name: scotch eggs
+raw_ingredient_list: ''
+episode: episode-0581
+_lookup:
+  episode_and_section: episode-0581::scotch eggs

--- a/data/recipes/s/recipe-1614-scotch-eggs/meta.yml
+++ b/data/recipes/s/recipe-1614-scotch-eggs/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1620-strawberry-flavor/data.yml
+++ b/data/recipes/s/recipe-1620-strawberry-flavor/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1620
+name: strawberry flavor
+raw_ingredient_list: ''
+episode: episode-0628
+_lookup:
+  episode_and_section: episode-0628::strawberry flavor

--- a/data/recipes/s/recipe-1620-strawberry-flavor/meta.yml
+++ b/data/recipes/s/recipe-1620-strawberry-flavor/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/s/recipe-1640-simple-mustard-pan-sauce/data.yml
+++ b/data/recipes/s/recipe-1640-simple-mustard-pan-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1640
+name: simple mustard pan sauce
+raw_ingredient_list: ''
+episode: episode-0192
+_lookup:
+  episode_and_section: episode-0192::simple mustard pan sauce

--- a/data/recipes/s/recipe-1640-simple-mustard-pan-sauce/meta.yml
+++ b/data/recipes/s/recipe-1640-simple-mustard-pan-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/t/recipe-1491-toast/data.yml
+++ b/data/recipes/t/recipe-1491-toast/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1491
+name: toast
+raw_ingredient_list: ''
+episode: episode-0620
+_lookup:
+  episode_and_section: episode-0620::toast

--- a/data/recipes/t/recipe-1491-toast/meta.yml
+++ b/data/recipes/t/recipe-1491-toast/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/t/recipe-1571-tangzhong/data.yml
+++ b/data/recipes/t/recipe-1571-tangzhong/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1571
+name: tangzhong
+raw_ingredient_list: ''
+episode: episode-0306
+_lookup:
+  episode_and_section: episode-0306::tangzhong

--- a/data/recipes/t/recipe-1571-tangzhong/meta.yml
+++ b/data/recipes/t/recipe-1571-tangzhong/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/t/recipe-1573-teriyaki-sauce/data.yml
+++ b/data/recipes/t/recipe-1573-teriyaki-sauce/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1573
+name: teriyaki sauce
+raw_ingredient_list: ''
+episode: episode-0306
+_lookup:
+  episode_and_section: episode-0306::teriyaki sauce

--- a/data/recipes/t/recipe-1573-teriyaki-sauce/meta.yml
+++ b/data/recipes/t/recipe-1573-teriyaki-sauce/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/t/recipe-1575-traditional-cheesecake/data.yml
+++ b/data/recipes/t/recipe-1575-traditional-cheesecake/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1575
+name: traditional cheesecake
+raw_ingredient_list: ''
+episode: episode-0124
+_lookup:
+  episode_and_section: episode-0124::traditional cheesecake

--- a/data/recipes/t/recipe-1575-traditional-cheesecake/meta.yml
+++ b/data/recipes/t/recipe-1575-traditional-cheesecake/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/t/recipe-1590-tangzhong/data.yml
+++ b/data/recipes/t/recipe-1590-tangzhong/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1590
+name: tangzhong
+raw_ingredient_list: ''
+episode: episode-0215
+_lookup:
+  episode_and_section: episode-0215::tangzhong

--- a/data/recipes/t/recipe-1590-tangzhong/meta.yml
+++ b/data/recipes/t/recipe-1590-tangzhong/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/t/recipe-1598-thai-coconut-curry/data.yml
+++ b/data/recipes/t/recipe-1598-thai-coconut-curry/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1598
+name: thai coconut curry
+raw_ingredient_list: ''
+episode: episode-0510
+_lookup:
+  episode_and_section: episode-0510::thai coconut curry

--- a/data/recipes/t/recipe-1598-thai-coconut-curry/meta.yml
+++ b/data/recipes/t/recipe-1598-thai-coconut-curry/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/t/recipe-1599-tomato-confit/data.yml
+++ b/data/recipes/t/recipe-1599-tomato-confit/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1599
+name: tomato confit
+raw_ingredient_list: ''
+episode: episode-0392
+_lookup:
+  episode_and_section: episode-0392::tomato confit

--- a/data/recipes/t/recipe-1599-tomato-confit/meta.yml
+++ b/data/recipes/t/recipe-1599-tomato-confit/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/v/recipe-1511-vegetables/data.yml
+++ b/data/recipes/v/recipe-1511-vegetables/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1511
+name: vegetables
+raw_ingredient_list: ''
+episode: episode-0174
+_lookup:
+  episode_and_section: episode-0174::vegetables

--- a/data/recipes/v/recipe-1511-vegetables/meta.yml
+++ b/data/recipes/v/recipe-1511-vegetables/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/v/recipe-1618-vanilla-flavor/data.yml
+++ b/data/recipes/v/recipe-1618-vanilla-flavor/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1618
+name: vanilla flavor
+raw_ingredient_list: ''
+episode: episode-0628
+_lookup:
+  episode_and_section: episode-0628::vanilla flavor

--- a/data/recipes/v/recipe-1618-vanilla-flavor/meta.yml
+++ b/data/recipes/v/recipe-1618-vanilla-flavor/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/w/recipe-1530-white-chocolate-fondant-coating/data.yml
+++ b/data/recipes/w/recipe-1530-white-chocolate-fondant-coating/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1530
+name: white chocolate fondant coating
+raw_ingredient_list: ''
+episode: episode-0229
+_lookup:
+  episode_and_section: episode-0229::white chocolate fondant coating

--- a/data/recipes/w/recipe-1530-white-chocolate-fondant-coating/meta.yml
+++ b/data/recipes/w/recipe-1530-white-chocolate-fondant-coating/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/w/recipe-1533-whipped-white-chocolate-ganache/data.yml
+++ b/data/recipes/w/recipe-1533-whipped-white-chocolate-ganache/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1533
+name: whipped white chocolate ganache
+raw_ingredient_list: ''
+episode: episode-0229
+_lookup:
+  episode_and_section: episode-0229::whipped white chocolate ganache

--- a/data/recipes/w/recipe-1533-whipped-white-chocolate-ganache/meta.yml
+++ b/data/recipes/w/recipe-1533-whipped-white-chocolate-ganache/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/w/recipe-1612-waffle-soldiers/data.yml
+++ b/data/recipes/w/recipe-1612-waffle-soldiers/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1612
+name: waffle soldiers
+raw_ingredient_list: ''
+episode: episode-0581
+_lookup:
+  episode_and_section: episode-0581::waffle soldiers

--- a/data/recipes/w/recipe-1612-waffle-soldiers/meta.yml
+++ b/data/recipes/w/recipe-1612-waffle-soldiers/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/w/recipe-1632-whipped-ricotta-toppings/data.yml
+++ b/data/recipes/w/recipe-1632-whipped-ricotta-toppings/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1632
+name: whipped ricotta & toppings
+raw_ingredient_list: ''
+episode: episode-0192
+_lookup:
+  episode_and_section: episode-0192::whipped ricotta & toppings

--- a/data/recipes/w/recipe-1632-whipped-ricotta-toppings/meta.yml
+++ b/data/recipes/w/recipe-1632-whipped-ricotta-toppings/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/recipes/w/recipe-1633-whipped-ricotta/data.yml
+++ b/data/recipes/w/recipe-1633-whipped-ricotta/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1633
+name: whipped ricotta
+raw_ingredient_list: ''
+episode: episode-0192
+_lookup:
+  episode_and_section: episode-0192::whipped ricotta

--- a/data/recipes/w/recipe-1633-whipped-ricotta/meta.yml
+++ b/data/recipes/w/recipe-1633-whipped-ricotta/meta.yml
@@ -1,0 +1,11 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/references/_/reference-0318-2024-oscars/data.yml
+++ b/data/references/_/reference-0318-2024-oscars/data.yml
@@ -1,0 +1,4 @@
+babish_id: reference-0318
+name: 2024 Oscars
+_lookup:
+  canonical_name: 2024 Oscars

--- a/data/references/_/reference-0318-2024-oscars/meta.yml
+++ b/data/references/_/reference-0318-2024-oscars/meta.yml
@@ -1,0 +1,5 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/references/b/reference-0319-bluey/data.yml
+++ b/data/references/b/reference-0319-bluey/data.yml
@@ -1,0 +1,4 @@
+babish_id: reference-0319
+name: Bluey
+_lookup:
+  canonical_name: Bluey

--- a/data/references/b/reference-0319-bluey/meta.yml
+++ b/data/references/b/reference-0319-bluey/meta.yml
@@ -1,0 +1,5 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/references/f/reference-0315-fallout/data.yml
+++ b/data/references/f/reference-0315-fallout/data.yml
@@ -1,0 +1,4 @@
+babish_id: reference-0315
+name: Fallout
+_lookup:
+  canonical_name: Fallout

--- a/data/references/f/reference-0315-fallout/meta.yml
+++ b/data/references/f/reference-0315-fallout/meta.yml
@@ -1,0 +1,5 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/references/l/reference-0323-last-minute/data.yml
+++ b/data/references/l/reference-0323-last-minute/data.yml
@@ -1,0 +1,4 @@
+babish_id: reference-0323
+name: LAST-MINUTE
+_lookup:
+  canonical_name: LAST-MINUTE

--- a/data/references/l/reference-0323-last-minute/meta.yml
+++ b/data/references/l/reference-0323-last-minute/meta.yml
@@ -1,0 +1,5 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/references/l/reference-0324-lots-of-things/data.yml
+++ b/data/references/l/reference-0324-lots-of-things/data.yml
@@ -1,0 +1,4 @@
+babish_id: reference-0324
+name: Lots of Things
+_lookup:
+  canonical_name: Lots of Things

--- a/data/references/l/reference-0324-lots-of-things/meta.yml
+++ b/data/references/l/reference-0324-lots-of-things/meta.yml
@@ -1,0 +1,5 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/references/m/reference-0317-mr-mrs-smith/data.yml
+++ b/data/references/m/reference-0317-mr-mrs-smith/data.yml
@@ -1,0 +1,4 @@
+babish_id: reference-0317
+name: Mr. & Mrs. Smith
+_lookup:
+  canonical_name: Mr. & Mrs. Smith

--- a/data/references/m/reference-0317-mr-mrs-smith/meta.yml
+++ b/data/references/m/reference-0317-mr-mrs-smith/meta.yml
@@ -1,0 +1,5 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/references/m/reference-0320-mean-girls/data.yml
+++ b/data/references/m/reference-0320-mean-girls/data.yml
@@ -1,0 +1,4 @@
+babish_id: reference-0320
+name: Mean Girls
+_lookup:
+  canonical_name: Mean Girls

--- a/data/references/m/reference-0320-mean-girls/meta.yml
+++ b/data/references/m/reference-0320-mean-girls/meta.yml
@@ -1,0 +1,5 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/references/m/reference-0322-morty/data.yml
+++ b/data/references/m/reference-0322-morty/data.yml
@@ -1,0 +1,4 @@
+babish_id: reference-0322
+name: Morty
+_lookup:
+  canonical_name: Morty

--- a/data/references/m/reference-0322-morty/meta.yml
+++ b/data/references/m/reference-0322-morty/meta.yml
@@ -1,0 +1,5 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/references/r/reference-0321-rick/data.yml
+++ b/data/references/r/reference-0321-rick/data.yml
@@ -1,0 +1,4 @@
+babish_id: reference-0321
+name: Rick
+_lookup:
+  canonical_name: Rick

--- a/data/references/r/reference-0321-rick/meta.yml
+++ b/data/references/r/reference-0321-rick/meta.yml
@@ -1,0 +1,5 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/references/s/reference-0316-shrek-2/data.yml
+++ b/data/references/s/reference-0316-shrek-2/data.yml
@@ -1,0 +1,4 @@
+babish_id: reference-0316
+name: Shrek 2
+_lookup:
+  canonical_name: Shrek 2

--- a/data/references/s/reference-0316-shrek-2/meta.yml
+++ b/data/references/s/reference-0316-shrek-2/meta.yml
@@ -1,0 +1,5 @@
+fields:
+  name:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}

--- a/data/tags/c/tag-0014-category-pizza/meta.yml
+++ b/data/tags/c/tag-0014-category-pizza/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0015-category-quick/meta.yml
+++ b/data/tags/c/tag-0015-category-quick/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0016-category-baking/meta.yml
+++ b/data/tags/c/tag-0016-category-baking/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0017-category-outrageous/meta.yml
+++ b/data/tags/c/tag-0017-category-outrageous/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0018-category-dessert/meta.yml
+++ b/data/tags/c/tag-0018-category-dessert/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0019-category-side-dish/meta.yml
+++ b/data/tags/c/tag-0019-category-side-dish/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0020-category-sandwiches/meta.yml
+++ b/data/tags/c/tag-0020-category-sandwiches/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0021-category-meat/meta.yml
+++ b/data/tags/c/tag-0021-category-meat/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0022-category-pasta/meta.yml
+++ b/data/tags/c/tag-0022-category-pasta/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0023-category-seafood/meta.yml
+++ b/data/tags/c/tag-0023-category-seafood/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0024-category-soup/meta.yml
+++ b/data/tags/c/tag-0024-category-soup/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0025-category-vegetarian/meta.yml
+++ b/data/tags/c/tag-0025-category-vegetarian/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0026-category-healthy/meta.yml
+++ b/data/tags/c/tag-0026-category-healthy/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/c/tag-0027-category-noodles/meta.yml
+++ b/data/tags/c/tag-0027-category-noodles/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/d/tag-0031-difficulty-beginner/meta.yml
+++ b/data/tags/d/tag-0031-difficulty-beginner/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/d/tag-0032-difficulty-experienced/meta.yml
+++ b/data/tags/d/tag-0032-difficulty-experienced/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/d/tag-0033-difficulty-difficult/meta.yml
+++ b/data/tags/d/tag-0033-difficulty-difficult/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/m/tag-0028-meal-breakfast/meta.yml
+++ b/data/tags/m/tag-0028-meal-breakfast/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/m/tag-0029-meal-lunch/meta.yml
+++ b/data/tags/m/tag-0029-meal-lunch/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/m/tag-0030-meal-dinner/meta.yml
+++ b/data/tags/m/tag-0030-meal-dinner/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0001-source-website-exclusive/meta.yml
+++ b/data/tags/s/tag-0001-source-website-exclusive/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0002-source-anime/meta.yml
+++ b/data/tags/s/tag-0002-source-anime/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0003-source-video-game/meta.yml
+++ b/data/tags/s/tag-0003-source-video-game/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0004-source-tv-show/meta.yml
+++ b/data/tags/s/tag-0004-source-tv-show/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0005-source-movie/meta.yml
+++ b/data/tags/s/tag-0005-source-movie/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0006-series-with-babish/meta.yml
+++ b/data/tags/s/tag-0006-series-with-babish/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0007-series-shorts/meta.yml
+++ b/data/tags/s/tag-0007-series-shorts/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0008-series-cook-along/meta.yml
+++ b/data/tags/s/tag-0008-series-cook-along/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0009-series-arcade/meta.yml
+++ b/data/tags/s/tag-0009-series-arcade/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0010-series-anime/meta.yml
+++ b/data/tags/s/tag-0010-series-anime/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0011-series-anything/meta.yml
+++ b/data/tags/s/tag-0011-series-anything/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0012-series-binging/meta.yml
+++ b/data/tags/s/tag-0012-series-binging/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}

--- a/data/tags/s/tag-0013-series-basics/meta.yml
+++ b/data/tags/s/tag-0013-series-basics/meta.yml
@@ -1,8 +1,8 @@
 fields:
   axis:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
   name:
     state: scraped
-    last_seen: '2026-05-05'
+    last_seen: '2026-05-06'
 rejected: {}


### PR DESCRIPTION
Reorganize `data/` into a sharded directory layout with per-field provenance metadata, so curators can lock corrections that survive future automated updates.

## Shape

- Each entity is a directory `data/<type>/<letter>/<babish_id>-<slug>/{data,meta}.yml` — slug-driven directory names sharded one level deep for browseability; `babish_id` stable across regenerations.
- A new `_lookup` block on each entity carries the identity keys used to match an existing entity vs. minting a new one.
- Per-field provenance sidecar (`meta.yml`) tracks each field's state — `scraped` / `confirmed` / `overridden` — so a `confirmed` value blocks future automated changes and an `overridden` value records (but doesn't apply) any incoming proposal.
- Episode classification moves to `Tag` entries on a typed axis (Source / Series / Category / Meal / Difficulty).
- Recipe stubs without ingredient lists are preserved when they correspond to distinct dishes, filtered when they're generic structural labels (`prep`, `assembly`, etc.).

## Stats

1081 files changed, 11628 insertions(+), 8201 deletions(-).

## Scope

Only the rendered `data/` tree is proposed for review here. Curated corrections sit on top of this PR in three follow-up batch PRs.