### PR TITLE
Curate episodes 0060-0060

### DIFF
--- a/data/episodes/b/episode-0060-beef-wellington-or-with-babish/data.yml
+++ b/data/episodes/b/episode-0060-beef-wellington-or-with-babish/data.yml
@@ -1,7 +1,7 @@
 babish_id: episode-0060
-name: Beef Wellington | With Babish
+name: $20 vs $200 Beef Wellington | With Babish
 slug: beef-wellington-or-with-babish
-published_date: 2026-01-14
+published_date: '2025-12-23'
 youtube_link: https://www.youtube.com/watch?v=A-Qb0ExQc-I
 official_link: https://www.babi.sh/recipes/beef-wellington-or-with-babish
 image_link: https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp

--- a/data/episodes/b/episode-0060-beef-wellington-or-with-babish/meta.yml
+++ b/data/episodes/b/episode-0060-beef-wellington-or-with-babish/meta.yml
@@ -1,19 +1,26 @@
 fields:
   name:
-    state: scraped
-    last_seen: '2026-05-06'
+    state: overridden
+    by: curate-agent
+    at: '2026-05-06'
+    scraper_proposed: Beef Wellington | With Babish
   slug:
-    state: scraped
-    last_seen: '2026-05-06'
+    state: confirmed
+    by: curate-agent
+    at: '2026-05-06'
   published_date:
-    state: scraped
-    last_seen: '2026-05-06'
+    state: overridden
+    by: curate-agent
+    at: '2026-05-06'
+    scraper_proposed: 2026-01-14
   youtube_link:
-    state: scraped
-    last_seen: '2026-05-06'
+    state: confirmed
+    by: curate-agent
+    at: '2026-05-06'
   official_link:
-    state: scraped
-    last_seen: '2026-05-06'
+    state: confirmed
+    by: curate-agent
+    at: '2026-05-06'
   image_link:
     state: scraped
     last_seen: '2026-05-06'

--- a/data/recipes/b/recipe-1506-beef-prep-20-wellington/data.yml
+++ b/data/recipes/b/recipe-1506-beef-prep-20-wellington/data.yml
@@ -1,0 +1,6 @@
+babish_id: recipe-1506
+name: beef prep ($20 wellington)
+raw_ingredient_list: ''
+episode: episode-0060
+_lookup:
+  episode_and_section: episode-0060::beef prep

--- a/data/recipes/b/recipe-1506-beef-prep-20-wellington/meta.yml
+++ b/data/recipes/b/recipe-1506-beef-prep-20-wellington/meta.yml
@@ -1,0 +1,13 @@
+fields:
+  name:
+    state: overridden
+    by: curate-agent
+    at: '2026-05-06'
+    scraper_proposed: beef prep
+  raw_ingredient_list:
+    state: scraped
+    last_seen: '2026-05-06'
+  episode:
+    state: scraped
+    last_seen: '2026-05-06'
+rejected: {}


### PR DESCRIPTION
**1 episodes** · 6 actions (3 ✓ confirm · 3 ~ override · 0 - reject · 0 + add) · 10 notes

| Episode | | Actions | Notes |
|---|:-:|---:|---:|
| $20 vs $200 Beef Wellington | With Babish (`episode-0060`) | 🚨 | 6 | 10 |

### 🚨 $20 vs $200 Beef Wellington | With Babish
`episode-0060` · [▶ Watch](https://www.youtube.com/watch?v=A-Qb0ExQc-I)

✓ Confirmed: `slug` · `youtube_link` · `official_link`

```diff
@@ episodes/episode-0060 @@
-name: "Beef Wellington | With Babish"
+name: "$20 vs $200 Beef Wellington | With Babish"
-published_date: datetime.date(2026, 1, 14)
+published_date: "2025-12-23"
@@ recipes/recipe-1506 @@
-name: "beef prep"
+name: "beef prep ($20 wellington)"
```

Notes:
- recipe-1507 duplicate (manual merge): recipe-1507 ('mushroom duxelle') and recipe-1504 ('mushroom duxelles') are functionally the same di…
- Date mismatch: YAML published_date 2026-01-14 is ~3 weeks after YouTube upload 2025-12-23, possibly babi.sh page publish vs YouTube upload date.
- Date convention check: If project tracks YouTube upload date, override to 2025-12-23; if babi.sh page date, verify against the babi.sh page directly.
- Dual difficulty tags: Episode has both tag-0031 (Beginner) and tag-0032 (Experienced), unusual and possibly reflecting $20 vs $200 version split.
- Difficulty plausibility: $20 version uses specialist equipment (sous vide, chamber sealer, koji), so 'Beginner' seems optimistic but cannot reject without checking babi.sh axis values.
- Recipe stub cleanup: 'beef prep' stub (recipe-1506) and near-duplicate 'mushroom duxelle(s)' stubs represent a scraper section-header artifact issue.
- Recipe decision needed: Human should decide whether to reject recipe-1506/1507 for better-named stubs or keep them with improved names.
- Mushroom duxelle naming: The two mushroom duxelle recipes are ingredient-distinct but need unique names to be useful.
- Unnamed questioner: Captions contain dialogue with an unnamed person asking comedic questions, likely crew or off-camera personality, not a named guest.
- Sponsor check: Challenge Dairy is the episode sponsor per description link and captions, correctly absent from guests[] as sponsors are not guests.

---
Generated by `ibdb.curate_workflow.pr`. Reviews from cached `tmp/curate/reviews/`.