### PR TITLE
Finish guest-id-collision repair (PR #117 follow-up)

### DIFF
--- a/data/episodes/a/episode-0032-archer-margarita/data.yml
+++ b/data/episodes/a/episode-0032-archer-margarita/data.yml
@@ -12,7 +12,7 @@ tags:
 - tag-0004
 - tag-0012
 guests:
-- guest-0026
+- guest-0031
 inspired_by:
 - reference-0022
 recipes:

--- a/data/episodes/b/episode-0068-being-with-babish-4/data.yml
+++ b/data/episodes/b/episode-0068-being-with-babish-4/data.yml
@@ -11,7 +11,7 @@ yield_unit: null
 tags: []
 guests:
 - guest-0024
-- guest-0026
+- guest-0030
 inspired_by:
 - reference-0238
 recipes: []

--- a/data/episodes/c/episode-0112-calistyle-burrito/data.yml
+++ b/data/episodes/c/episode-0112-calistyle-burrito/data.yml
@@ -15,7 +15,7 @@ tags:
 - tag-0030
 - tag-0031
 guests:
-- guest-0026
+- guest-0032
 inspired_by: []
 recipes:
 - recipe-1106

--- a/data/episodes/c/episode-0147-chocolate-cake-milkshake-inspired-by-portillo-s/data.yml
+++ b/data/episodes/c/episode-0147-chocolate-cake-milkshake-inspired-by-portillo-s/data.yml
@@ -15,7 +15,7 @@ tags:
 - tag-0018
 - tag-0031
 guests:
-- guest-0026
+- guest-0027
 inspired_by:
 - reference-0248
 recipes:

--- a/data/episodes/c/episode-0154-christmas-turkey-inspired-by-national-lampoon-s-christmas-va/data.yml
+++ b/data/episodes/c/episode-0154-christmas-turkey-inspired-by-national-lampoon-s-christmas-va/data.yml
@@ -15,7 +15,7 @@ tags:
 - tag-0030
 - tag-0032
 guests:
-- guest-0027
+- guest-0033
 inspired_by:
 - reference-0234
 recipes:

--- a/data/episodes/c/episode-0158-classic-fettucine-alfredo/data.yml
+++ b/data/episodes/c/episode-0158-classic-fettucine-alfredo/data.yml
@@ -16,7 +16,7 @@ tags:
 - tag-0030
 - tag-0031
 guests:
-- guest-0026
+- guest-0027
 inspired_by:
 - reference-0325
 recipes:

--- a/data/episodes/c/episode-0160-clayroastedthigh/data.yml
+++ b/data/episodes/c/episode-0160-clayroastedthigh/data.yml
@@ -16,7 +16,7 @@ tags:
 - tag-0030
 - tag-0033
 guests:
-- guest-0027
+- guest-0034
 inspired_by:
 - reference-0077
 recipes:

--- a/data/episodes/c/episode-0173-copy-cat-spicy-vodka-rigatoni/data.yml
+++ b/data/episodes/c/episode-0173-copy-cat-spicy-vodka-rigatoni/data.yml
@@ -16,7 +16,7 @@ tags:
 - tag-0030
 - tag-0031
 guests:
-- guest-0026
+- guest-0027
 inspired_by: []
 recipes:
 - recipe-1215

--- a/data/episodes/c/episode-0181-creme-caramel/data.yml
+++ b/data/episodes/c/episode-0181-creme-caramel/data.yml
@@ -12,7 +12,7 @@ tags:
 - tag-0013
 - tag-0018
 guests:
-- guest-0028
+- guest-0035
 inspired_by: []
 recipes:
 - recipe-0966

--- a/data/guests/c/guest-0030-chris-parnell/data.yml
+++ b/data/guests/c/guest-0030-chris-parnell/data.yml
@@ -1,4 +1,4 @@
-babish_id: guest-0026
+babish_id: guest-0030
 name: Chris Parnell
 _lookup:
   canonical_name: Chris Parnell

--- a/data/guests/d/guest-0035-dominique-ansel/data.yml
+++ b/data/guests/d/guest-0035-dominique-ansel/data.yml
@@ -1,4 +1,4 @@
-babish_id: guest-0028
+babish_id: guest-0035
 name: Dominique Ansel
 _lookup:
   canonical_name: Dominique Ansel

--- a/data/guests/h/guest-0031-h-jon-benjamin/data.yml
+++ b/data/guests/h/guest-0031-h-jon-benjamin/data.yml
@@ -1,4 +1,4 @@
-babish_id: guest-0026
+babish_id: guest-0031
 name: H. Jon Benjamin
 _lookup:
   canonical_name: H. Jon Benjamin

--- a/data/guests/j/guest-0032-jess/data.yml
+++ b/data/guests/j/guest-0032-jess/data.yml
@@ -1,4 +1,4 @@
-babish_id: guest-0026
+babish_id: guest-0032
 name: Jess
 _lookup:
   canonical_name: Jess

--- a/data/guests/o/guest-0033-olivia-tiedemann/data.yml
+++ b/data/guests/o/guest-0033-olivia-tiedemann/data.yml
@@ -1,4 +1,4 @@
-babish_id: guest-0027
+babish_id: guest-0033
 name: Olivia Tiedemann
 _lookup:
   canonical_name: Olivia Tiedemann

--- a/data/guests/y/guest-0034-you-suck-at-cooking/data.yml
+++ b/data/guests/y/guest-0034-you-suck-at-cooking/data.yml
@@ -1,4 +1,4 @@
-babish_id: guest-0027
+babish_id: guest-0034
 name: You Suck at Cooking
 _lookup:
   canonical_name: You Suck at Cooking


### PR DESCRIPTION
## Summary

PR #117 renamed the colliding guest bundle directories but missed the post-rename file edits — only the renames were staged before commit. Master is currently in a half-repaired state:

- 6 renamed bundles still carry the old (collided) `babish_id:` field internally — e.g. `data/guests/c/guest-0030-chris-parnell/data.yml` has `babish_id: guest-0026`.
- 9 episodes still reference the old ids (`- guest-0026`, `- guest-0027`, `- guest-0028`).

This PR lands the missed half. Working tree was preserved across the failed commit, so the diff exactly matches the intent described in #117.

## Diff (15 files, ±1 line each)

| Bundle | `babish_id` field |
|---|---|
| `guests/c/guest-0030-chris-parnell` | `guest-0026` → `guest-0030` |
| `guests/h/guest-0031-h-jon-benjamin` | `guest-0026` → `guest-0031` |
| `guests/j/guest-0032-jess` | `guest-0026` → `guest-0032` |
| `guests/o/guest-0033-olivia-tiedemann` | `guest-0027` → `guest-0033` |
| `guests/y/guest-0034-you-suck-at-cooking` | `guest-0027` → `guest-0034` |
| `guests/d/guest-0035-dominique-ansel` | `guest-0028` → `guest-0035` |

| Episode | Guest ref |
|---|---|
| ep-0032 (Archer Margarita) | `guest-0026` → `guest-0031` (H. Jon Benjamin) |
| ep-0068 (Being with Babish 4) | `guest-0026` → `guest-0030` (Chris Parnell) |
| ep-0112 (Calistyle Burrito) | `guest-0026` → `guest-0032` (Jess) |
| ep-0147 (Chocolate Cake Milkshake) | `guest-0026` → `guest-0027` (Alvin Zhou, dup collapse) |
| ep-0158 (Classic Fettuccine Alfredo) | `guest-0026` → `guest-0027` (Alvin Zhou) |
| ep-0173 (Vodka Rigatoni) | `guest-0026` → `guest-0027` (Alvin Zhou) |
| ep-0154 (Christmas Turkey) | `guest-0027` → `guest-0033` (Olivia Tiedemann) |
| ep-0160 (Clay-Roasted Thigh) | `guest-0027` → `guest-0034` (You Suck at Cooking) |
| ep-0181 (Crème Caramel) | `guest-0028` → `guest-0035` (Dominique Ansel) |

After merge: 35 unique guest ids, no dangling refs, all `babish_id` fields match bundle directory names (validated locally).

## Test plan

- [ ] `git diff master..fix-guest-id-collisions-followup` shows exactly 15 single-line edits
- [ ] After merge: `flask sync build export` produces a clean DB with one guest row per unique id