### PR TITLE
Refresh datasets and db_dump.sql from curated YAML

### DIFF
--- a/datasets/ibdb.episodes.json
+++ b/datasets/ibdb.episodes.json
@@ -1,7 +1,7 @@
 [
   {
     "episode_id": "10-levels-of-cheesesteak",
-    "name": "10 Levels of Cheesesteak",
+    "name": "10 Levels of Philly Cheesesteak",
     "published_date": "2026-04-30",
     "youtube_link": "https://www.youtube.com/watch?v=jNan4FWeQEE",
     "official_link": "https://www.babi.sh/recipes/10-levels-of-cheesesteak",
@@ -19,19 +19,56 @@
           "name": "Sandwiches"
         },
         {
-          "tag_id": 31,
-          "axis": "Difficulty",
-          "name": "Beginner"
-        },
-        {
           "tag_id": 6,
           "axis": "Series",
           "name": "With Babish"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 75,
+          "name": "Brian Sa",
+          "image_link": null
+        }
+      ],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1477,
+          "name": "level 4: cheesesteak kit style",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1478,
+          "name": "level 5: classic homemade cheesesteak",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1479,
+          "name": "level 6: chicken cheesesteak",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1480,
+          "name": "level 7: proper homemade cheesesteak",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1481,
+          "name": "level 8: shop-style ribeye cheesesteak",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -90,12 +127,41 @@
           "image_link": null
         }
       ],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1484,
+          "name": "dipping sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1482,
+          "name": "eomuk guk",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1485,
+          "name": "gimbap",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1483,
+          "name": "skewers",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
     "episode_id": "10-levels-chicken-noodle-soup",
-    "name": "10 Levels Chicken Noodle Soup",
+    "name": "10 Levels of Chicken Noodle Soup",
     "published_date": "2026-03-28",
     "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
     "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
@@ -150,7 +216,64 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1492,
+          "name": "level 10: fine dining chicken noodle soup",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1486,
+          "name": "level 6: no prep chicken noodle soup",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1487,
+          "name": "level 7: simple from-scratch",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1490,
+          "name": "level 8: matzo ball soup",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1491,
+          "name": "level 9: avgolemono",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1493,
+          "name": "pasta dough",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1489,
+          "name": "soup base",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1488,
+          "name": "stock",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -284,12 +407,69 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1496,
+          "name": "garlic butter",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1498,
+          "name": "homemade mayo",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1501,
+          "name": "million dollar deviled eggs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1495,
+          "name": "monkey bread",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1500,
+          "name": "potato cups",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1499,
+          "name": "poutine bites",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1497,
+          "name": "spinach artichoke dip",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1494,
+          "name": "spinach artichoke dip monkey bread",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
     "episode_id": "5-levels-of-spaghetti-or-with-babish",
-    "name": "5 Levels of Spaghetti | With Babish",
+    "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
     "published_date": "2026-01-30",
     "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
     "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
@@ -344,7 +524,64 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1507,
+          "name": "$10 meatballs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1506,
+          "name": "$10 spaghetti and meatballs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1502,
+          "name": "$1 spaghetti and meatballs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1508,
+          "name": "$25 spaghetti and meatballs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1509,
+          "name": "$50 spaghetti and meatballs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1503,
+          "name": "lentil meatball mixture",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1505,
+          "name": "lentil meatballs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1504,
+          "name": "panade",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -389,7 +626,57 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1515,
+          "name": "cr\u00e8me fra\u00eeche chantilly",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1516,
+          "name": "french toast custard",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1511,
+          "name": "pain de mie",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1512,
+          "name": "poolish",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1513,
+          "name": "preserved lemon blueberry compote",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1514,
+          "name": "red miso maple syrup",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1510,
+          "name": "toast",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -429,47 +716,43 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
-    }
-  },
-  {
-    "episode_id": "beef-wellington-or-with-babish",
-    "name": "Beef Wellington | With Babish",
-    "published_date": "2026-01-14",
-    "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
-    "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
-    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp",
-    "related": {
-      "tags": [
+      "recipes": [
         {
-          "tag_id": 21,
-          "axis": "Category",
-          "name": "Meat"
+          "recipe_id": 1517,
+          "name": "beef prep",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
         },
         {
-          "tag_id": 31,
-          "axis": "Difficulty",
-          "name": "Beginner"
+          "recipe_id": 1519,
+          "name": "bouquet garni",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
         },
         {
-          "tag_id": 32,
-          "axis": "Difficulty",
-          "name": "Experienced"
+          "recipe_id": 1518,
+          "name": "braised vegetable prep",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
         },
         {
-          "tag_id": 30,
-          "axis": "Meal",
-          "name": "Dinner"
+          "recipe_id": 1520,
+          "name": "mashed potatoes",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
         },
         {
-          "tag_id": 6,
-          "axis": "Series",
-          "name": "With Babish"
+          "recipe_id": 1521,
+          "name": "roasted vegetables",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
         }
-      ],
-      "guests": [],
-      "inspired_by": [],
-      "recipes": []
+      ]
     }
   },
   {
@@ -525,6 +808,96 @@
           "name": "serving",
           "image_link": null,
           "raw_ingredient_list": "chicken stock",
+          "raw_procedure": ""
+        }
+      ]
+    }
+  },
+  {
+    "episode_id": "beef-wellington-or-with-babish",
+    "name": "$20 vs $200 Beef Wellington | With Babish",
+    "published_date": "2025-12-23",
+    "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
+    "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
+    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp",
+    "related": {
+      "tags": [
+        {
+          "tag_id": 21,
+          "axis": "Category",
+          "name": "Meat"
+        },
+        {
+          "tag_id": 31,
+          "axis": "Difficulty",
+          "name": "Beginner"
+        },
+        {
+          "tag_id": 32,
+          "axis": "Difficulty",
+          "name": "Experienced"
+        },
+        {
+          "tag_id": 30,
+          "axis": "Meal",
+          "name": "Dinner"
+        },
+        {
+          "tag_id": 6,
+          "axis": "Series",
+          "name": "With Babish"
+        }
+      ],
+      "guests": [],
+      "inspired_by": [],
+      "recipes": [
+        {
+          "recipe_id": 1522,
+          "name": "$200 beef wellington",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1524,
+          "name": "$20 beef wellington",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1525,
+          "name": "beef prep ($20 wellington)",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1527,
+          "name": "butter block",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1526,
+          "name": "mushroom duxelle",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1523,
+          "name": "mushroom duxelles",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1528,
+          "name": "red miso puff pastry",
+          "image_link": null,
+          "raw_ingredient_list": "",
           "raw_procedure": ""
         }
       ]
@@ -591,7 +964,7 @@
   {
     "episode_id": "christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
     "name": "Christmas Turkey inspired by National Lampoon's Christmas Vacation",
-    "published_date": "2025-11-26",
+    "published_date": "2025-11-29",
     "youtube_link": "https://youtube.com/watch?v=w0pZ7MWajW8&si=r2TmnS9oJhDHIbp5",
     "official_link": "https://www.babi.sh/recipes/christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1764189007/giyklwlgdj7x3nwbi38c.webp",
@@ -623,7 +996,13 @@
           "name": "Movie"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 82,
+          "name": "Olivia Tiedemann",
+          "image_link": null
+        }
+      ],
       "inspired_by": [
         {
           "reference_id": 558,
@@ -818,16 +1197,6 @@
           "name": "Meat"
         },
         {
-          "tag_id": 19,
-          "axis": "Category",
-          "name": "Side Dish"
-        },
-        {
-          "tag_id": 31,
-          "axis": "Difficulty",
-          "name": "Beginner"
-        },
-        {
           "tag_id": 30,
           "axis": "Meal",
           "name": "Dinner"
@@ -848,7 +1217,7 @@
       "recipes": [
         {
           "recipe_id": 1206,
-          "name": "batter dredge",
+          "name": "Babish's Ultimate Fried Chicken",
           "image_link": null,
           "raw_ingredient_list": "flour\nchicken broken down into ten pieces\nbuttermilk\nsalt\npotato starch\nwhite rice flour\nliquid egg whites",
           "raw_procedure": ""
@@ -893,7 +1262,64 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1529,
+          "name": "bacon",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1536,
+          "name": "beurre mont\u00e9 sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1531,
+          "name": "bouquet garni",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1535,
+          "name": "buttered noodles",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1533,
+          "name": "butter mushrooms",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1532,
+          "name": "coq au vin sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1534,
+          "name": "pearl onions",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1530,
+          "name": "vegetables",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -1057,7 +1483,71 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1539,
+          "name": "boneless short ribs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1544,
+          "name": "filet mignon: steak tartare",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1543,
+          "name": "hanger steak",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1540,
+          "name": "hot jus",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1541,
+          "name": "london broil",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1538,
+          "name": "new york strip steak",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1542,
+          "name": "ribeye",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1545,
+          "name": "steak",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1537,
+          "name": "steak cuts: technique",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -1106,7 +1596,71 @@
           "image_link": null
         }
       ],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1550,
+          "name": "babish version",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1547,
+          "name": "cake",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1546,
+          "name": "fallout: the vault dweller's official cookbook",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1554,
+          "name": "fondant coating",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1548,
+          "name": "marshmallow cream cheese frosting",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1553,
+          "name": "spiced cake soak",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1551,
+          "name": "sponge cake batter",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1552,
+          "name": "whipped white chocolate ganache",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1549,
+          "name": "white chocolate fondant coating",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -1198,7 +1752,71 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1557,
+          "name": "cheese sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1555,
+          "name": "level 3: blue box",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1558,
+          "name": "level 4: evaporated milk",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1559,
+          "name": "level 5: one pot inspired by america's test kitchen",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1560,
+          "name": "level 6: deep fried mac & cheese",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1561,
+          "name": "level 7: classic mornay",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1562,
+          "name": "level 8: molecular gastronomy - sodium citrate",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1563,
+          "name": "level 9: sparing no expense",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1556,
+          "name": "mac",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -1580,7 +2198,50 @@
           "image_link": null
         }
       ],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1566,
+          "name": "eggplant sandwich",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1567,
+          "name": "ham & sweet potato sandwich",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1568,
+          "name": "lettuce & honey ham sandwich",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1564,
+          "name": "quadruple stacked ham sandwich",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1565,
+          "name": "scampi shrimp",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1569,
+          "name": "shrimp & avocado sandwich",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -1633,7 +2294,13 @@
           "name": "Anime"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 76,
+          "name": "Alvin Zhou",
+          "image_link": null
+        }
+      ],
       "inspired_by": [
         {
           "reference_id": 568,
@@ -1647,7 +2314,7 @@
       "recipes": [
         {
           "recipe_id": 1216,
-          "name": "assembly",
+          "name": "4-Cheese Lasagna",
           "image_link": null,
           "raw_ingredient_list": "hot italian sausage casings removed\nsweet italian sausage casings removed\nmilk ricotta cheese\nno boil lasagna noodles for flat layers\nlow moisture mozzarella thinly\npecorino cheese\nparmesan",
           "raw_procedure": ""
@@ -1695,7 +2362,13 @@
           "name": "Anything"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 76,
+          "name": "Alvin Zhou",
+          "image_link": null
+        }
+      ],
       "inspired_by": [],
       "recipes": [
         {
@@ -2302,7 +2975,13 @@
           "name": "Anything"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 76,
+          "name": "Alvin Zhou",
+          "image_link": null
+        }
+      ],
       "inspired_by": [],
       "recipes": [
         {
@@ -2317,7 +2996,7 @@
   },
   {
     "episode_id": "classic-fettucine-alfredo",
-    "name": "Classic Fettucine Alfredo",
+    "name": "Classic Fettuccine Alfredo",
     "published_date": "2025-06-06",
     "youtube_link": "https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo",
     "official_link": "https://www.babi.sh/recipes/classic-fettucine-alfredo",
@@ -2355,12 +3034,27 @@
           "name": "Anything"
         }
       ],
-      "guests": [],
-      "inspired_by": [],
+      "guests": [
+        {
+          "guest_id": 76,
+          "name": "Alvin Zhou",
+          "image_link": null
+        }
+      ],
+      "inspired_by": [
+        {
+          "reference_id": 649,
+          "type": null,
+          "name": "Alfredo alla Scrofa",
+          "description": null,
+          "external_link": null,
+          "image_link": null
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1235,
-          "name": "fettucine alfredo",
+          "name": "fettuccine alfredo",
           "image_link": null,
           "raw_ingredient_list": "eggs\ndouble zero flour\nsemolina flour\ntwenty four month aged parmigiano reggiano\nunsalted high quality butter",
           "raw_procedure": ""
@@ -2408,7 +3102,13 @@
           "name": "Lunch"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 76,
+          "name": "Alvin Zhou",
+          "image_link": null
+        }
+      ],
       "inspired_by": [],
       "recipes": [
         {
@@ -2463,7 +3163,50 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1571,
+          "name": "burger patties",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1573,
+          "name": "burgers",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1575,
+          "name": "cheese dough balls",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1572,
+          "name": "cheese sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1570,
+          "name": "deep fried burger bomb",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1574,
+          "name": "short rib bones snack",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -2684,7 +3427,13 @@
           "name": "Anything"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 76,
+          "name": "Alvin Zhou",
+          "image_link": null
+        }
+      ],
       "inspired_by": [
         {
           "reference_id": 572,
@@ -2862,7 +3611,50 @@
           "image_link": null
         }
       ],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1577,
+          "name": "duck",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1576,
+          "name": "duck breast salad",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1579,
+          "name": "mango ginger sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1578,
+          "name": "pickled red onion",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1580,
+          "name": "pomegranate sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1581,
+          "name": "salad",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -2933,11 +3725,6 @@
           "name": "Dessert"
         },
         {
-          "tag_id": 19,
-          "axis": "Category",
-          "name": "Side Dish"
-        },
-        {
           "tag_id": 31,
           "axis": "Difficulty",
           "name": "Beginner"
@@ -2953,7 +3740,7 @@
       "recipes": [
         {
           "recipe_id": 1242,
-          "name": "serving",
+          "name": "Agua de Jamaica Granita",
           "image_link": null,
           "raw_ingredient_list": "dried sorrel\ncinnamon orange peel, or a few cloves,\nheavy cream\nsweetened condensed milk",
           "raw_procedure": ""
@@ -3089,7 +3876,50 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1584,
+          "name": "bourbon pan sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1583,
+          "name": "medallions",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1585,
+          "name": "pork schnitzel",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1586,
+          "name": "pork souvlaki",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1582,
+          "name": "pork tenderloin medallions with bourbon sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1587,
+          "name": "souvlaki spice mix",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -3271,7 +4101,50 @@
           "image_link": null
         }
       ],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1591,
+          "name": "beef patties",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1589,
+          "name": "bun",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1593,
+          "name": "buns",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1588,
+          "name": "japanese-style big mac",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1590,
+          "name": "tangzhong",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1592,
+          "name": "teriyaki sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -3414,7 +4287,13 @@
           "name": "Anything"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 76,
+          "name": "Alvin Zhou",
+          "image_link": null
+        }
+      ],
       "inspired_by": [
         {
           "reference_id": 577,
@@ -3425,7 +4304,78 @@
           "image_link": null
         }
       ],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1599,
+          "name": "cheesecake",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1595,
+          "name": "cheesecake batter",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1598,
+          "name": "egg whites mixture",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1603,
+          "name": "nilla wafer crumble",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1601,
+          "name": "nilla wafer crust",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1596,
+          "name": "sponge cake",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1597,
+          "name": "sponge cake batter",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1600,
+          "name": "strawberry cheesecake",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1602,
+          "name": "strawberry topping",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1594,
+          "name": "traditional cheesecake",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -3484,7 +4434,71 @@
           "image_link": null
         }
       ],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1604,
+          "name": "basic egg salad sandwich",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1606,
+          "name": "egg salad",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1611,
+          "name": "gourmet egg salad",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1610,
+          "name": "homemade yolk mayo",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1607,
+          "name": "japanese-inspired egg salad sandwich",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1605,
+          "name": "sandwich",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1612,
+          "name": "sandwich assembly",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1608,
+          "name": "shokupan dough",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1609,
+          "name": "tangzhong",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -3529,7 +4543,43 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1616,
+          "name": "cocktail sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1615,
+          "name": "shrimp",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1614,
+          "name": "shrimp cocktail",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1613,
+          "name": "shrimp stock",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1617,
+          "name": "thai coconut curry",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -3574,7 +4624,64 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1624,
+          "name": "fennel salad",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1625,
+          "name": "filet mignon with chimichurri",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1619,
+          "name": "pasta puttanesca",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1623,
+          "name": "pork tenderloin",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1621,
+          "name": "pork tenderloin with romesco saucerom",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1620,
+          "name": "puttanesca",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1622,
+          "name": "romesco sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1618,
+          "name": "tomato confit",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -3628,7 +4735,64 @@
           "image_link": null
         }
       ],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1632,
+          "name": "boiled eggs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1626,
+          "name": "deviled eggs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1627,
+          "name": "hard boiled eggs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1628,
+          "name": "homemade mayo",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1630,
+          "name": "purple deviled eggs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1629,
+          "name": "regular deviled eggs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1633,
+          "name": "scotch eggs",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1631,
+          "name": "waffle soldiers",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -3787,7 +4951,7 @@
       "recipes": [
         {
           "recipe_id": 1250,
-          "name": "cinnamon sugar mixture",
+          "name": "classic cinnamon sugar filling",
           "image_link": null,
           "raw_ingredient_list": "flour\nsugar",
           "raw_procedure": ""
@@ -3893,7 +5057,7 @@
         },
         {
           "recipe_id": 1260,
-          "name": "condiments & toppings",
+          "name": "Burger Sauce",
           "image_link": null,
           "raw_ingredient_list": "milk warm\nbeef\nbutter\nsugar\negg\ntomatoes thinly",
           "raw_procedure": ""
@@ -4337,7 +5501,7 @@
       "recipes": [
         {
           "recipe_id": 1264,
-          "name": "garnish",
+          "name": "Blooming Fish",
           "image_link": null,
           "raw_ingredient_list": "corn starch\npotato starch\nblack sea bass\nneutral oil\nshaoxing cooking wine\nsalt\n40g white vinegar",
           "raw_procedure": ""
@@ -4365,12 +5529,27 @@
           "name": "Anime"
         }
       ],
-      "guests": [],
-      "inspired_by": [],
+      "guests": [
+        {
+          "guest_id": 76,
+          "name": "Alvin Zhou",
+          "image_link": null
+        }
+      ],
+      "inspired_by": [
+        {
+          "reference_id": 596,
+          "type": "tv_show",
+          "name": "Jujutsu Kaisen",
+          "description": "MAPPA anime adapting Gege Akutami's manga about teenage sorcerers fighting curses.",
+          "external_link": null,
+          "image_link": null
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1265,
-          "name": "ramen in hotpot broth",
+          "name": "chicken meatball hotpot",
           "image_link": null,
           "raw_ingredient_list": "rice\nchrysanthemum\neggs\nboneless skinless chicken thighs",
           "raw_procedure": ""
@@ -4409,7 +5588,78 @@
           "image_link": null
         }
       ],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1636,
+          "name": "chocolate flavor",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1641,
+          "name": "choux pastry :",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1634,
+          "name": "cr\u00e8me anglaise",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1640,
+          "name": "hot fudge sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1635,
+          "name": "ice cream flavors:",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1638,
+          "name": "matcha flavor",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1643,
+          "name": "milk mixture",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1642,
+          "name": "pastry cream",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1639,
+          "name": "strawberry flavor",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1637,
+          "name": "vanilla flavor",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -4507,7 +5757,13 @@
           "name": "Anime"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 76,
+          "name": "Alvin Zhou",
+          "image_link": null
+        }
+      ],
       "inspired_by": [
         {
           "reference_id": 65,
@@ -4528,7 +5784,7 @@
         },
         {
           "recipe_id": 1270,
-          "name": "alvin's version",
+          "name": "Garlic Fried Rice",
           "image_link": null,
           "raw_ingredient_list": "garlic thinly\nparsley\nbeef tallow butter\nbutter\nsalt",
           "raw_procedure": ""
@@ -4784,7 +6040,18 @@
           "name": "Anime"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 76,
+          "name": "Alvin Zhou",
+          "image_link": null
+        },
+        {
+          "guest_id": 77,
+          "name": "Kendall Beach",
+          "image_link": null
+        }
+      ],
       "inspired_by": [
         {
           "reference_id": 593,
@@ -4798,7 +6065,7 @@
       "recipes": [
         {
           "recipe_id": 1276,
-          "name": "ham cheese croissants",
+          "name": "324 layer croissant",
           "image_link": null,
           "raw_ingredient_list": "croissant dough scraps\ncroissant dough\nlayer croissant dough",
           "raw_procedure": ""
@@ -5832,7 +7099,7 @@
       "recipes": [
         {
           "recipe_id": 1294,
-          "name": "beef",
+          "name": "Italian beef (Al's-style top sirloin)",
           "image_link": null,
           "raw_ingredient_list": "top sirloin butt",
           "raw_procedure": ""
@@ -5929,7 +7196,16 @@
         }
       ],
       "guests": [],
-      "inspired_by": [],
+      "inspired_by": [
+        {
+          "reference_id": 639,
+          "type": null,
+          "name": "Fallout",
+          "description": null,
+          "external_link": null,
+          "image_link": null
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1296,
@@ -5977,7 +7253,16 @@
         }
       ],
       "guests": [],
-      "inspired_by": [],
+      "inspired_by": [
+        {
+          "reference_id": 640,
+          "type": null,
+          "name": "Shrek 2",
+          "description": null,
+          "external_link": null,
+          "image_link": null
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1297,
@@ -6245,7 +7530,16 @@
         }
       ],
       "guests": [],
-      "inspired_by": [],
+      "inspired_by": [
+        {
+          "reference_id": 535,
+          "type": "tv_show",
+          "name": "Futurama",
+          "description": "Matt Groening's animated sci-fi sitcom about a 20th-century delivery boy cryogenically frozen until the year 3000.",
+          "external_link": null,
+          "image_link": null
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1303,
@@ -6347,11 +7641,6 @@
           "name": "Baking"
         },
         {
-          "tag_id": 15,
-          "axis": "Category",
-          "name": "Quick"
-        },
-        {
           "tag_id": 20,
           "axis": "Category",
           "name": "Sandwiches"
@@ -6393,11 +7682,20 @@
         }
       ],
       "guests": [],
-      "inspired_by": [],
+      "inspired_by": [
+        {
+          "reference_id": 641,
+          "type": null,
+          "name": "Mr. & Mrs. Smith",
+          "description": null,
+          "external_link": null,
+          "image_link": null
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1306,
-          "name": "everything bagel ingredients:",
+          "name": "Everything Bagel",
           "image_link": null,
           "raw_ingredient_list": "milk\nflour\nsalt\nsugar\nwhite vinegar\nwhite sesame seeds",
           "raw_procedure": ""
@@ -6525,11 +7823,20 @@
         }
       ],
       "guests": [],
-      "inspired_by": [],
+      "inspired_by": [
+        {
+          "reference_id": 642,
+          "type": null,
+          "name": "2024 Oscars",
+          "description": null,
+          "external_link": null,
+          "image_link": null
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1309,
-          "name": "short cut past\u00e9is de nata ingredients:",
+          "name": "Past\u00e9is de Nata",
           "image_link": null,
           "raw_ingredient_list": "milk\nsweet cherries\nsugar\nflour\negg yolks\nbrown sugar or sugar\ncognac or grand marnier",
           "raw_procedure": ""
@@ -6633,11 +7940,20 @@
         }
       ],
       "guests": [],
-      "inspired_by": [],
+      "inspired_by": [
+        {
+          "reference_id": 14,
+          "type": "tv_show",
+          "name": "Bob's Burgers",
+          "description": "Bob Belcher, along with his wife and 3 children, try to run their last hope of holding the family together, which is running Bob's dream restaurant. IMDb.",
+          "external_link": "https://www.imdb.com/title/tt1561755/",
+          "image_link": "https://i.ytimg.com/sh/YFIqnn7YyVe01H23BBPlyA/market.jpg"
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1312,
-          "name": "buttermilk bacon fat bechamel ingredients:",
+          "name": "Loaded Baked Potato Lasagna",
           "image_link": null,
           "raw_ingredient_list": "flour rolling\nfrozen hashbrowns according package instructions\nthick cut bacon\nbeef\ncheddar cheese",
           "raw_procedure": ""
@@ -6704,11 +8020,20 @@
         }
       ],
       "guests": [],
-      "inspired_by": [],
+      "inspired_by": [
+        {
+          "reference_id": 643,
+          "type": null,
+          "name": "Bluey",
+          "description": null,
+          "external_link": null,
+          "image_link": null
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1314,
-          "name": "duck cake:",
+          "name": "Duck Cake",
           "image_link": null,
           "raw_ingredient_list": "butter\nsugar\nflour\nmilk\nbuttermilk\neggs",
           "raw_procedure": ""
@@ -6737,7 +8062,16 @@
         }
       ],
       "guests": [],
-      "inspired_by": [],
+      "inspired_by": [
+        {
+          "reference_id": 568,
+          "type": "tv_show",
+          "name": "One Piece",
+          "description": "Long-running Japanese anime adapting Eiichiro Oda's manga about Monkey D. Luffy's pirate crew searching for the One Piece treasure.",
+          "external_link": null,
+          "image_link": null
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1315,
@@ -6807,7 +8141,16 @@
         }
       ],
       "guests": [],
-      "inspired_by": [],
+      "inspired_by": [
+        {
+          "reference_id": 644,
+          "type": null,
+          "name": "Mean Girls",
+          "description": null,
+          "external_link": null,
+          "image_link": null
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1317,
@@ -6906,7 +8249,16 @@
         }
       ],
       "guests": [],
-      "inspired_by": [],
+      "inspired_by": [
+        {
+          "reference_id": 535,
+          "type": "tv_show",
+          "name": "Futurama",
+          "description": "Matt Groening's animated sci-fi sitcom about a 20th-century delivery boy cryogenically frozen until the year 3000.",
+          "external_link": null,
+          "image_link": null
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1321,
@@ -7422,7 +8774,7 @@
       "recipes": [
         {
           "recipe_id": 1337,
-          "name": "baked bacon",
+          "name": "fried chicken cutlets",
           "image_link": null,
           "raw_ingredient_list": "boneless skinless chicken breast butterfied\nbuttermilk\nflour",
           "raw_procedure": ""
@@ -7523,7 +8875,7 @@
       "recipes": [
         {
           "recipe_id": 1339,
-          "name": "basil gel",
+          "name": "Chicago Deep-Dish Pizza",
           "image_link": null,
           "raw_ingredient_list": "gelatin sheets\nflour\ndeli style low moisture mozzarella cheese\ntomatoes on the vine\ntomato paste\nvegetable oil more for greasing\nbasil",
           "raw_procedure": ""
@@ -7918,39 +9270,6 @@
     }
   },
   {
-    "episode_id": "carnitas",
-    "name": "CARNITAS",
-    "published_date": "2023-05-12",
-    "youtube_link": "https://www.youtube.com/watch?v=FEZioC-qMd4",
-    "official_link": "https://www.babi.sh/recipes/carnitas",
-    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690352698/ldnpp7ukrrvaiormf4ux.webp",
-    "related": {
-      "tags": [
-        {
-          "tag_id": 21,
-          "axis": "Category",
-          "name": "Meat"
-        },
-        {
-          "tag_id": 13,
-          "axis": "Series",
-          "name": "Basics"
-        }
-      ],
-      "guests": [],
-      "inspired_by": [],
-      "recipes": [
-        {
-          "recipe_id": 1349,
-          "name": "carnitas cuban sliders",
-          "image_link": null,
-          "raw_ingredient_list": "pork shoulder cut into two three inch pieces\nlard\ncoca cola preferably mexican\ncorn tortillas\nevaporated milk",
-          "raw_procedure": ""
-        }
-      ]
-    }
-  },
-  {
     "episode_id": "glowing-popsicles-the-mandalorian",
     "name": "Glowing Popsicles inspired by The Mandalorian",
     "published_date": "2023-05-12",
@@ -8051,7 +9370,7 @@
   },
   {
     "episode_id": "barbacoa-de-res",
-    "name": "BARBACOA DE RES CON CONSOM\u00c9",
+    "name": "Barbacoa Tacos and Gringas de Barbacoa with Consom\u00e9 | Pru\u00e9balo with Rick Martinez",
     "published_date": "2023-05-05",
     "youtube_link": "https://www.youtube.com/watch?v=Ya5u2uC3d2U",
     "official_link": "https://www.babi.sh/recipes/barbacoa-de-res",
@@ -8079,6 +9398,39 @@
           "name": "serving",
           "image_link": null,
           "raw_ingredient_list": "cloves\ncilantro tender stems\nunflavored pulque\ndried garbanzo beans , dried",
+          "raw_procedure": ""
+        }
+      ]
+    }
+  },
+  {
+    "episode_id": "carnitas",
+    "name": "Easy Carnitas",
+    "published_date": "2023-05-02",
+    "youtube_link": "https://www.youtube.com/watch?v=FEZioC-qMd4",
+    "official_link": "https://www.babi.sh/recipes/carnitas",
+    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690352698/ldnpp7ukrrvaiormf4ux.webp",
+    "related": {
+      "tags": [
+        {
+          "tag_id": 21,
+          "axis": "Category",
+          "name": "Meat"
+        },
+        {
+          "tag_id": 13,
+          "axis": "Series",
+          "name": "Basics"
+        }
+      ],
+      "guests": [],
+      "inspired_by": [],
+      "recipes": [
+        {
+          "recipe_id": 1349,
+          "name": "carnitas",
+          "image_link": null,
+          "raw_ingredient_list": "pork shoulder cut into two three inch pieces\nlard\ncoca cola preferably mexican\ncorn tortillas\nevaporated milk",
           "raw_procedure": ""
         }
       ]
@@ -8553,7 +9905,57 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1649,
+          "name": "applesauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1647,
+          "name": "beef filling",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1650,
+          "name": "homemade sour cream",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1648,
+          "name": "mushroom sauerkraut filling",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1645,
+          "name": "pierogoi dough",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1644,
+          "name": "pierogoi dough & assembly",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1646,
+          "name": "potato filling",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -8938,54 +10340,6 @@
     }
   },
   {
-    "episode_id": "beer-can-chicken",
-    "name": "BEER CAN CHICKEN",
-    "published_date": "2022-12-19",
-    "youtube_link": "https://www.youtube.com/watch?v=Xo0v7ZuA9C0",
-    "official_link": "https://www.babi.sh/recipes/beer-can-chicken",
-    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png",
-    "related": {
-      "tags": [
-        {
-          "tag_id": 21,
-          "axis": "Category",
-          "name": "Meat"
-        },
-        {
-          "tag_id": 15,
-          "axis": "Category",
-          "name": "Quick"
-        },
-        {
-          "tag_id": 31,
-          "axis": "Difficulty",
-          "name": "Beginner"
-        },
-        {
-          "tag_id": 30,
-          "axis": "Meal",
-          "name": "Dinner"
-        },
-        {
-          "tag_id": 13,
-          "axis": "Series",
-          "name": "Basics"
-        }
-      ],
-      "guests": [],
-      "inspired_by": [],
-      "recipes": [
-        {
-          "recipe_id": 1372,
-          "name": "beer chicken",
-          "image_link": null,
-          "raw_ingredient_list": "chicken\nbaby potatoes\nbrussels sprouts\nbeer\nhen of the wood or maitake mushrooms\nchicken stock\ngarlic cloves smashed",
-          "raw_procedure": ""
-        }
-      ]
-    }
-  },
-  {
     "episode_id": "meatballs-30rock",
     "name": "Meatballs inspired by 30 Rock",
     "published_date": "2022-12-19",
@@ -9042,6 +10396,54 @@
           "name": "meatballs",
           "image_link": null,
           "raw_ingredient_list": "beef\npork\nveal\nwhite bread crusts removed, torn into pieces\nbuttermilk\npacked parsley\negg\nuncured pancetta\ngarlic",
+          "raw_procedure": ""
+        }
+      ]
+    }
+  },
+  {
+    "episode_id": "beer-can-chicken",
+    "name": "BEER CAN CHICKEN",
+    "published_date": "2022-12-18",
+    "youtube_link": "https://www.youtube.com/watch?v=Xo0v7ZuA9C0",
+    "official_link": "https://www.babi.sh/recipes/beer-can-chicken",
+    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png",
+    "related": {
+      "tags": [
+        {
+          "tag_id": 21,
+          "axis": "Category",
+          "name": "Meat"
+        },
+        {
+          "tag_id": 15,
+          "axis": "Category",
+          "name": "Quick"
+        },
+        {
+          "tag_id": 31,
+          "axis": "Difficulty",
+          "name": "Beginner"
+        },
+        {
+          "tag_id": 30,
+          "axis": "Meal",
+          "name": "Dinner"
+        },
+        {
+          "tag_id": 13,
+          "axis": "Series",
+          "name": "Basics"
+        }
+      ],
+      "guests": [],
+      "inspired_by": [],
+      "recipes": [
+        {
+          "recipe_id": 1372,
+          "name": "beer can chicken",
+          "image_link": null,
+          "raw_ingredient_list": "chicken\nbaby potatoes\nbrussels sprouts\nbeer\nhen of the wood or maitake mushrooms\nchicken stock\ngarlic cloves smashed",
           "raw_procedure": ""
         }
       ]
@@ -9790,7 +11192,7 @@
       "recipes": [
         {
           "recipe_id": 1391,
-          "name": "maconara",
+          "name": "Carbonara Anything",
           "image_link": null,
           "raw_ingredient_list": "dried spaghetti\npanko breadcrumbs\naged yellow cheddar cheese\nguanciale\nhen of the woods or maitake mushrooms cut/torn into bite size pieces\nthick cut bacon\ndried macaroni or cavatappi",
           "raw_procedure": ""
@@ -9889,68 +11291,6 @@
     }
   },
   {
-    "episode_id": "churrons-broad-city",
-    "name": "Churrons inspired by Broad City",
-    "published_date": "2022-08-17",
-    "youtube_link": "https://www.youtube.com/watch?v=JiUsCTy8nEY",
-    "official_link": "https://www.babi.sh/recipes/churrons-broad-city",
-    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695905/babishImages/undefined-290140.png",
-    "related": {
-      "tags": [
-        {
-          "tag_id": 16,
-          "axis": "Category",
-          "name": "Baking"
-        },
-        {
-          "tag_id": 18,
-          "axis": "Category",
-          "name": "Dessert"
-        },
-        {
-          "tag_id": 15,
-          "axis": "Category",
-          "name": "Quick"
-        },
-        {
-          "tag_id": 33,
-          "axis": "Difficulty",
-          "name": "Difficult"
-        },
-        {
-          "tag_id": 12,
-          "axis": "Series",
-          "name": "Binging"
-        },
-        {
-          "tag_id": 4,
-          "axis": "Source",
-          "name": "TV Show"
-        }
-      ],
-      "guests": [],
-      "inspired_by": [
-        {
-          "reference_id": 546,
-          "type": "tv_show",
-          "name": "Broad City",
-          "description": "Comedy Central series following two best friends navigating life and work in New York City.",
-          "external_link": null,
-          "image_link": null
-        }
-      ],
-      "recipes": [
-        {
-          "recipe_id": 1396,
-          "name": "cinnamon orange churros",
-          "image_link": null,
-          "raw_ingredient_list": "sugar\nbutter\neggs\nmilk\nflour",
-          "raw_procedure": ""
-        }
-      ]
-    }
-  },
-  {
     "episode_id": "empanadas",
     "name": "EMPANADAS",
     "published_date": "2022-08-17",
@@ -10032,12 +11372,12 @@
     }
   },
   {
-    "episode_id": "chocolate-croissants-its-complicated",
-    "name": "Chocolate Croissants inspired by It's Complicated",
-    "published_date": "2022-08-01",
-    "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
-    "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
-    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png",
+    "episode_id": "churrons-broad-city",
+    "name": "Churrons inspired by Broad City",
+    "published_date": "2022-08-03",
+    "youtube_link": "https://www.youtube.com/watch?v=JiUsCTy8nEY",
+    "official_link": "https://www.babi.sh/recipes/churrons-broad-city",
+    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695905/babishImages/undefined-290140.png",
     "related": {
       "tags": [
         {
@@ -10051,14 +11391,9 @@
           "name": "Dessert"
         },
         {
-          "tag_id": 32,
+          "tag_id": 33,
           "axis": "Difficulty",
-          "name": "Experienced"
-        },
-        {
-          "tag_id": 28,
-          "axis": "Meal",
-          "name": "Breakfast"
+          "name": "Difficult"
         },
         {
           "tag_id": 12,
@@ -10074,20 +11409,20 @@
       "guests": [],
       "inspired_by": [
         {
-          "reference_id": 623,
-          "type": "movie",
-          "name": "It's Complicated",
-          "description": "Nancy Meyers's 2009 romantic comedy starring Meryl Streep, Alec Baldwin, and Steve Martin.",
+          "reference_id": 546,
+          "type": "tv_show",
+          "name": "Broad City",
+          "description": "Comedy Central series following two best friends navigating life and work in New York City.",
           "external_link": null,
           "image_link": null
         }
       ],
       "recipes": [
         {
-          "recipe_id": 1398,
-          "name": "egg wash",
+          "recipe_id": 1396,
+          "name": "cinnamon orange churros",
           "image_link": null,
-          "raw_ingredient_list": "flour\nmilk\nunsalted european style butter\nchocolate\nsugar\nbutter",
+          "raw_ingredient_list": "sugar\nbutter\neggs\nmilk\nflour",
           "raw_procedure": ""
         }
       ]
@@ -10145,6 +11480,63 @@
           "name": "herb butter",
           "image_link": null,
           "raw_ingredient_list": "lobster\neggs\nbutter\nblack pepper\nparsley\ndill\ngarlic\nmarjoram",
+          "raw_procedure": ""
+        }
+      ]
+    }
+  },
+  {
+    "episode_id": "chocolate-croissants-its-complicated",
+    "name": "Chocolate Croissants inspired by It's Complicated",
+    "published_date": "2022-07-13",
+    "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
+    "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
+    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png",
+    "related": {
+      "tags": [
+        {
+          "tag_id": 16,
+          "axis": "Category",
+          "name": "Baking"
+        },
+        {
+          "tag_id": 18,
+          "axis": "Category",
+          "name": "Dessert"
+        },
+        {
+          "tag_id": 32,
+          "axis": "Difficulty",
+          "name": "Experienced"
+        },
+        {
+          "tag_id": 28,
+          "axis": "Meal",
+          "name": "Breakfast"
+        },
+        {
+          "tag_id": 12,
+          "axis": "Series",
+          "name": "Binging"
+        }
+      ],
+      "guests": [],
+      "inspired_by": [
+        {
+          "reference_id": 623,
+          "type": "movie",
+          "name": "It's Complicated",
+          "description": "Nancy Meyers's 2009 romantic comedy starring Meryl Streep, Alec Baldwin, and Steve Martin.",
+          "external_link": null,
+          "image_link": null
+        }
+      ],
+      "recipes": [
+        {
+          "recipe_id": 1398,
+          "name": "Chocolate Croissants",
+          "image_link": null,
+          "raw_ingredient_list": "flour\nmilk\nunsalted european style butter\nchocolate\nsugar\nbutter",
           "raw_procedure": ""
         }
       ]
@@ -10408,9 +11800,52 @@
     }
   },
   {
+    "episode_id": "lemon-meringue-pie",
+    "name": "LEMON MERINGUE PIE",
+    "published_date": "2022-05-27",
+    "youtube_link": "https://www.youtube.com/watch?v=f0fmS1WEm3s",
+    "official_link": "https://www.babi.sh/recipes/lemon-meringue-pie",
+    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696099/babishImages/undefined-443317.png",
+    "related": {
+      "tags": [
+        {
+          "tag_id": 16,
+          "axis": "Category",
+          "name": "Baking"
+        },
+        {
+          "tag_id": 18,
+          "axis": "Category",
+          "name": "Dessert"
+        },
+        {
+          "tag_id": 32,
+          "axis": "Difficulty",
+          "name": "Experienced"
+        },
+        {
+          "tag_id": 13,
+          "axis": "Series",
+          "name": "Basics"
+        }
+      ],
+      "guests": [],
+      "inspired_by": [],
+      "recipes": [
+        {
+          "recipe_id": 1404,
+          "name": "meringue topping",
+          "image_link": null,
+          "raw_ingredient_list": "sugar\nbutter\nmeyer lemon juice\negg whites\nflour\negg yolks\ncornstarch",
+          "raw_procedure": ""
+        }
+      ]
+    }
+  },
+  {
     "episode_id": "crab-bisque-seinfeld",
     "name": "Crab Bisque inspired by Seinfeld",
-    "published_date": "2022-05-27",
+    "published_date": "2022-05-24",
     "youtube_link": "https://www.youtube.com/watch?v=5kKMB890ABc",
     "official_link": "https://www.babi.sh/recipes/crab-bisque-seinfeld",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695634/babishImages/undefined-585834.png",
@@ -10459,49 +11894,6 @@
           "name": "crab bisque",
           "image_link": null,
           "raw_ingredient_list": "seafood stock\nchicken wings\ndry white wine\ncarrots cut into 3 segments\nfrozen shrimp\ncrab claws\nlump crab\nsteamed lump crab meat",
-          "raw_procedure": ""
-        }
-      ]
-    }
-  },
-  {
-    "episode_id": "lemon-meringue-pie",
-    "name": "LEMON MERINGUE PIE",
-    "published_date": "2022-05-27",
-    "youtube_link": "https://www.youtube.com/watch?v=f0fmS1WEm3s",
-    "official_link": "https://www.babi.sh/recipes/lemon-meringue-pie",
-    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696099/babishImages/undefined-443317.png",
-    "related": {
-      "tags": [
-        {
-          "tag_id": 16,
-          "axis": "Category",
-          "name": "Baking"
-        },
-        {
-          "tag_id": 18,
-          "axis": "Category",
-          "name": "Dessert"
-        },
-        {
-          "tag_id": 32,
-          "axis": "Difficulty",
-          "name": "Experienced"
-        },
-        {
-          "tag_id": 13,
-          "axis": "Series",
-          "name": "Basics"
-        }
-      ],
-      "guests": [],
-      "inspired_by": [],
-      "recipes": [
-        {
-          "recipe_id": 1404,
-          "name": "meringue topping",
-          "image_link": null,
-          "raw_ingredient_list": "sugar\nbutter\nmeyer lemon juice\negg whites\nflour\negg yolks\ncornstarch",
           "raw_procedure": ""
         }
       ]
@@ -10661,7 +12053,7 @@
   },
   {
     "episode_id": "corned-beef",
-    "name": "CORNED BEEF",
+    "name": "Corned Beef",
     "published_date": "2022-03-17",
     "youtube_link": "https://www.youtube.com/watch?v=IDkuwVvZpWM",
     "official_link": "https://www.babi.sh/recipes/corned-beef",
@@ -10823,7 +12215,7 @@
   },
   {
     "episode_id": "chicken-piccata",
-    "name": "CHICKEN PICCATA",
+    "name": "Chicken Piccata",
     "published_date": "2022-02-18",
     "youtube_link": "https://www.youtube.com/watch?v=ZqEqtmMY1M0",
     "official_link": "https://www.babi.sh/recipes/chicken-piccata",
@@ -10866,7 +12258,7 @@
       "recipes": [
         {
           "recipe_id": 1412,
-          "name": "babish chicken picatta",
+          "name": "Chicken Piccata",
           "image_link": null,
           "raw_ingredient_list": "flour\nchicken stock preferably homemade\ncapellini spaghetti, or angel hair pasta,\nlinguini\nunsalted butter &\ndry white wine\ncapers\ncapers drained",
           "raw_procedure": ""
@@ -11245,7 +12637,78 @@
       ],
       "guests": [],
       "inspired_by": [],
-      "recipes": []
+      "recipes": [
+        {
+          "recipe_id": 1654,
+          "name": "basil oil",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1656,
+          "name": "browned butter sage",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1653,
+          "name": "confit tomatoes",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1658,
+          "name": "cornish hen",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1657,
+          "name": "cornish hen & sauces",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1655,
+          "name": "deconstructed pesto",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1660,
+          "name": "gremolata",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1659,
+          "name": "simple mustard pan sauce",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1652,
+          "name": "whipped ricotta",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1651,
+          "name": "whipped ricotta & toppings",
+          "image_link": null,
+          "raw_ingredient_list": "",
+          "raw_procedure": ""
+        }
+      ]
     }
   },
   {
@@ -11755,7 +13218,7 @@
   },
   {
     "episode_id": "apple-cider-donuts",
-    "name": "APPLE CIDER DONUTS",
+    "name": "Apple Cider Donuts",
     "published_date": "2021-11-09",
     "youtube_link": "https://www.youtube.com/watch?v=baZoJYAQjfI",
     "official_link": "https://www.babi.sh/recipes/apple-cider-donuts",
@@ -11873,105 +13336,6 @@
           "name": "Meat Pie Filling",
           "image_link": null,
           "raw_ingredient_list": "~2 lb chuck roast, trimmed + cut into 1-inch cubes\n\u00bd white onion, diced\n2 tsp fresh thyme leaves\nTo taste kosher salt\nTo taste freshly ground black pepper",
-          "raw_procedure": ""
-        }
-      ]
-    }
-  },
-  {
-    "episode_id": "cake-pops",
-    "name": "CAKE POPS",
-    "published_date": "2021-11-02",
-    "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
-    "official_link": "https://www.babi.sh/recipes/cake-pops",
-    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png",
-    "related": {
-      "tags": [
-        {
-          "tag_id": 16,
-          "axis": "Category",
-          "name": "Baking"
-        },
-        {
-          "tag_id": 18,
-          "axis": "Category",
-          "name": "Dessert"
-        },
-        {
-          "tag_id": 31,
-          "axis": "Difficulty",
-          "name": "Beginner"
-        },
-        {
-          "tag_id": 13,
-          "axis": "Series",
-          "name": "Basics"
-        }
-      ],
-      "guests": [],
-      "inspired_by": [],
-      "recipes": [
-        {
-          "recipe_id": 1183,
-          "name": "Birthday Cake Pops",
-          "image_link": null,
-          "raw_ingredient_list": "Vanilla Cake, crumbled (see recipe above)\nVanilla Frosting (see recipe above)\n200 g white chocolate, melted\nCookie Crumbles (see recipe above)\nFood-safe decorative popsicle sticks",
-          "raw_procedure": ""
-        },
-        {
-          "recipe_id": 1175,
-          "name": "Chocolate Cake",
-          "image_link": null,
-          "raw_ingredient_list": "100 g cocoa powder + more for coating\n180 g water, boiling\n210 g whole milk, cold\n190 g unsalted butter, room temperature\n450 g sugar\n3 large eggs\n1 tsp vanilla extract\n270 g all-purpose flour\n1 \u00bd tsp baking powder\n\u00be tsp baking soda\n1 tsp kosher salt",
-          "raw_procedure": ""
-        },
-        {
-          "recipe_id": 1177,
-          "name": "Chocolate Peppermint Cake Pops",
-          "image_link": null,
-          "raw_ingredient_list": "500 g dark chocolate, chopped\nChocolate Cake, crumbled (see recipe above)\nPeppermint Frosting (see recipe above)\nFood-safe decorative popsicle sticks\nAs needed peppermint candy, crushed",
-          "raw_procedure": ""
-        },
-        {
-          "recipe_id": 1182,
-          "name": "Cookie Crumbles",
-          "image_link": null,
-          "raw_ingredient_list": "100 g sugar\n25 g brown sugar\n90 g cake flour\n\u00bd tsp baking powder\n\u00bd tsp kosher salt\n20 g rainbow sprinkles\n40 g vegetable oil\n1 Tbsp vanilla extract",
-          "raw_procedure": ""
-        },
-        {
-          "recipe_id": 1176,
-          "name": "Peppermint Frosting",
-          "image_link": null,
-          "raw_ingredient_list": "60 g unsalted butter, room temperature\n180 g powdered sugar\n30 g whole milk\n\u215b tsp peppermint extract",
-          "raw_procedure": ""
-        },
-        {
-          "recipe_id": 1180,
-          "name": "Pumpkin Spice Cake Pops",
-          "image_link": null,
-          "raw_ingredient_list": "Vanilla Cake, crumbled (see recipe above)\nPumpkin Spice Cream Cheese Icing (see recipe above)\n500 g white chocolate, melted\nFood-safe decorative popsicle sticks\nAs needed orange food coloring\nAs needed green food coloring",
-          "raw_procedure": ""
-        },
-        {
-          "recipe_id": 1179,
-          "name": "Pumpkin Spice Cream Cheese Icing",
-          "image_link": null,
-          "raw_ingredient_list": "60 g unsalted butter, room temperature\n120 g cream cheese, room temperature\n120 g powdered sugar\n1 tsp ground cinnamon\n\u00bd tsp ground ginger\n\u00bc tsp ground nutmeg\n\u215b tsp ground allspice\n\u215b tsp ground cloves",
-          "raw_procedure": ""
-        },
-        {
-          "recipe_id": 1178,
-          "name": "Vanilla Cake",
-          "image_link": null,
-          "raw_ingredient_list": "215 g unsalted butter, room temperature\n415 g granulated sugar\n4 large eggs, room temperature\n2 \u00bd Tbsp vanilla paste\n350 g all-purpose flour\n2 \u00bd tsp baking powder\n1 tsp kosher salt\n300 ml buttermilk, room temperature",
-          "raw_procedure": ""
-        },
-        {
-          "recipe_id": 1181,
-          "name": "Vanilla Frosting",
-          "image_link": null,
-          "raw_ingredient_list": "60 g unsalted butter, room temperature\n180 g powdered sugar\n30 g whole milk\n1 tsp vanilla paste or \u00bd tsp vanilla extract\n2 Tbsp rainbow sprinkles",
           "raw_procedure": ""
         }
       ]
@@ -12133,6 +13497,105 @@
           "name": "Root Beer-Braised Short Ribs",
           "image_link": null,
           "raw_ingredient_list": "5-6 bone-in short ribs\nAs needed kosher salt\nAs needed freshly ground black pepper\n1 Tbsp vegetable oil\n1 large yellow onion, chopped\n3 medium carrots, peeled + chopped\n2 celery stalks, chopped\n3 Tbsp tomato paste\n4 cloves garlic, crushed\n\u00bc Cup soy sauce\n1 \u00bd Cups root beer\n3-4 Cup chicken stock\n5-6 sprigs fresh thyme\n3 stems parsley (leaves included)",
+          "raw_procedure": ""
+        }
+      ]
+    }
+  },
+  {
+    "episode_id": "cake-pops",
+    "name": "Cake Pops",
+    "published_date": "2021-10-21",
+    "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
+    "official_link": "https://www.babi.sh/recipes/cake-pops",
+    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png",
+    "related": {
+      "tags": [
+        {
+          "tag_id": 16,
+          "axis": "Category",
+          "name": "Baking"
+        },
+        {
+          "tag_id": 18,
+          "axis": "Category",
+          "name": "Dessert"
+        },
+        {
+          "tag_id": 31,
+          "axis": "Difficulty",
+          "name": "Beginner"
+        },
+        {
+          "tag_id": 13,
+          "axis": "Series",
+          "name": "Basics"
+        }
+      ],
+      "guests": [],
+      "inspired_by": [],
+      "recipes": [
+        {
+          "recipe_id": 1183,
+          "name": "Birthday Cake Pops",
+          "image_link": null,
+          "raw_ingredient_list": "Vanilla Cake, crumbled (see recipe above)\nVanilla Frosting (see recipe above)\n200 g white chocolate, melted\nCookie Crumbles (see recipe above)\nFood-safe decorative popsicle sticks",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1175,
+          "name": "Chocolate Cake",
+          "image_link": null,
+          "raw_ingredient_list": "100 g cocoa powder + more for coating\n180 g water, boiling\n210 g whole milk, cold\n190 g unsalted butter, room temperature\n450 g sugar\n3 large eggs\n1 tsp vanilla extract\n270 g all-purpose flour\n1 \u00bd tsp baking powder\n\u00be tsp baking soda\n1 tsp kosher salt",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1177,
+          "name": "Chocolate Peppermint Cake Pops",
+          "image_link": null,
+          "raw_ingredient_list": "500 g dark chocolate, chopped\nChocolate Cake, crumbled (see recipe above)\nPeppermint Frosting (see recipe above)\nFood-safe decorative popsicle sticks\nAs needed peppermint candy, crushed",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1182,
+          "name": "Cookie Crumbles",
+          "image_link": null,
+          "raw_ingredient_list": "100 g sugar\n25 g brown sugar\n90 g cake flour\n\u00bd tsp baking powder\n\u00bd tsp kosher salt\n20 g rainbow sprinkles\n40 g vegetable oil\n1 Tbsp vanilla extract",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1176,
+          "name": "Peppermint Frosting",
+          "image_link": null,
+          "raw_ingredient_list": "60 g unsalted butter, room temperature\n180 g powdered sugar\n30 g whole milk\n\u215b tsp peppermint extract",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1180,
+          "name": "Pumpkin Spice Cake Pops",
+          "image_link": null,
+          "raw_ingredient_list": "Vanilla Cake, crumbled (see recipe above)\nPumpkin Spice Cream Cheese Icing (see recipe above)\n500 g white chocolate, melted\nFood-safe decorative popsicle sticks\nAs needed orange food coloring\nAs needed green food coloring",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1179,
+          "name": "Pumpkin Spice Cream Cheese Icing",
+          "image_link": null,
+          "raw_ingredient_list": "60 g unsalted butter, room temperature\n120 g cream cheese, room temperature\n120 g powdered sugar\n1 tsp ground cinnamon\n\u00bd tsp ground ginger\n\u00bc tsp ground nutmeg\n\u215b tsp ground allspice\n\u215b tsp ground cloves",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1178,
+          "name": "Vanilla Cake",
+          "image_link": null,
+          "raw_ingredient_list": "215 g unsalted butter, room temperature\n415 g granulated sugar\n4 large eggs, room temperature\n2 \u00bd Tbsp vanilla paste\n350 g all-purpose flour\n2 \u00bd tsp baking powder\n1 tsp kosher salt\n300 ml buttermilk, room temperature",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 1181,
+          "name": "Vanilla Frosting",
+          "image_link": null,
+          "raw_ingredient_list": "60 g unsalted butter, room temperature\n180 g powdered sugar\n30 g whole milk\n1 tsp vanilla paste or \u00bd tsp vanilla extract\n2 Tbsp rainbow sprinkles",
           "raw_procedure": ""
         }
       ]
@@ -12541,7 +14004,7 @@
   },
   {
     "episode_id": "biscotti",
-    "name": "BISCOTTI",
+    "name": "Biscotti",
     "published_date": "2021-09-24",
     "youtube_link": "https://www.youtube.com/watch?v=g4EkzEKlGOA",
     "official_link": "https://www.babi.sh/recipes/biscotti",
@@ -12579,7 +14042,7 @@
       "recipes": [
         {
           "recipe_id": 1132,
-          "name": "Orange Chocolate Biscotti",
+          "name": "Double Chocolate Orange Biscotti",
           "image_link": null,
           "raw_ingredient_list": "As needed nonstick spray\n200 g all purpose flour\n50 g cocoa powder\n1 tsp baking powder\n\u00bc tsp baking soda\n\u00bd tsp kosher salt\n120 g dark chocolate\n3 large eggs\n175 g granulated sugar\nZest of 1 large orange\nOptional: \u00bc tsp orange extract\n1 tsp vanilla extract\nOrange glaze (see recipe below)",
           "raw_procedure": ""
@@ -12732,7 +14195,7 @@
   },
   {
     "episode_id": "calistyle-burrito",
-    "name": "CALI-STYLE BURRITO",
+    "name": "California Style Burritos",
     "published_date": "2021-09-13",
     "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
     "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
@@ -12765,7 +14228,13 @@
           "name": "Basics"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 81,
+          "name": "Jess",
+          "image_link": null
+        }
+      ],
       "inspired_by": [],
       "recipes": [
         {
@@ -13018,7 +14487,7 @@
   },
   {
     "episode_id": "chiles-rellenos",
-    "name": "CHILES RELLENOS",
+    "name": "Chiles Rellenos",
     "published_date": "2021-08-26",
     "youtube_link": "https://www.youtube.com/watch?v=gAKW8RB6aeU",
     "official_link": "https://www.babi.sh/recipes/chiles-rellenos",
@@ -14622,7 +16091,7 @@
   },
   {
     "episode_id": "corn-dogs",
-    "name": "CORN DOGS",
+    "name": "Corn Dogs",
     "published_date": "2021-05-27",
     "youtube_link": "https://www.youtube.com/watch?v=zGT45vVJNso",
     "official_link": "https://www.babi.sh/recipes/corn-dogs",
@@ -15020,7 +16489,7 @@
   },
   {
     "episode_id": "bacon",
-    "name": "HOMEMADE BACON",
+    "name": "Homemade Bacon",
     "published_date": "2021-04-30",
     "youtube_link": "https://www.youtube.com/watch?v=TUh4Z2li1UM",
     "official_link": "https://www.babi.sh/recipes/bacon",
@@ -15073,7 +16542,7 @@
         },
         {
           "recipe_id": 996,
-          "name": "Healthy-esque BLT ingredients",
+          "name": "Healthy-esque BLT",
           "image_link": null,
           "raw_ingredient_list": "2 classic bacon slices\n2 slices tomato\nAs needed kosher salt\n2 slices seeded whole wheat bread\n1 Tbsp unsalted butter\n1 Tbsp avocado mayonnaise\n\u00bc cup (loosely packed) alfalfa sprouts\nTo taste kosher salt\nTo taste freshly ground black pepper",
           "raw_procedure": ""
@@ -15405,7 +16874,7 @@
   },
   {
     "episode_id": "creme-caramel",
-    "name": "CR\u00c8ME CARAMEL",
+    "name": "Cr\u00e8me Caramel",
     "published_date": "2021-04-08",
     "youtube_link": "https://www.youtube.com/watch?v=ihS8__strtM",
     "official_link": "https://www.babi.sh/recipes/creme-caramel",
@@ -15423,7 +16892,13 @@
           "name": "Basics"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 84,
+          "name": "Dominique Ansel",
+          "image_link": null
+        }
+      ],
       "inspired_by": [],
       "recipes": [
         {
@@ -15602,7 +17077,7 @@
   {
     "episode_id": "chefs-choice-platter-monster-hunter-world",
     "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-    "published_date": "2021-03-31",
+    "published_date": "2021-03-30",
     "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
     "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png",
@@ -15990,17 +17465,17 @@
           "raw_procedure": ""
         },
         {
-          "recipe_id": 936,
-          "name": "https://www.seriouseats.com/recipes/2016/05/dry-toasted-sugar-granulated-caramel-recipe.html",
-          "image_link": null,
-          "raw_ingredient_list": "4 cups white granulated sugar",
-          "raw_procedure": ""
-        },
-        {
           "recipe_id": 935,
           "name": "Improved Shortbread Biscuit",
           "image_link": null,
           "raw_ingredient_list": "5 oz unsalted butter, very soft + more for greasing\nAs needed demerara sugar\n2 oz browned butter, soft (see recipe below)\n\u00be tsp kosher salt\n5 oz toasted sugar (see recipe below)\n9.5 oz all purpose flour\n2 oz cornstarch",
+          "raw_procedure": ""
+        },
+        {
+          "recipe_id": 936,
+          "name": "Toasted Sugar",
+          "image_link": null,
+          "raw_ingredient_list": "4 cups white granulated sugar",
           "raw_procedure": ""
         }
       ]
@@ -16008,7 +17483,7 @@
   },
   {
     "episode_id": "birria-tacos",
-    "name": "BIRRIA TACOS",
+    "name": "Birria Tacos",
     "published_date": "2021-03-11",
     "youtube_link": "https://www.youtube.com/watch?v=pQmSrlIbULk",
     "official_link": "https://www.babi.sh/recipes/birria-tacos",
@@ -16225,7 +17700,7 @@
   },
   {
     "episode_id": "biscuits-and-gravy",
-    "name": "BISCUITS AND GRAVY",
+    "name": "Biscuits & Gravy",
     "published_date": "2021-02-25",
     "youtube_link": "https://www.youtube.com/watch?v=NMbMT9tY8-Q",
     "official_link": "https://www.babi.sh/recipes/biscuits-and-gravy",
@@ -16376,7 +17851,7 @@
   },
   {
     "episode_id": "advanced-grilled-cheese",
-    "name": "ADVANCED GRILLED CHEESE",
+    "name": "Advanced Grilled Cheese",
     "published_date": "2021-02-19",
     "youtube_link": "https://www.youtube.com/watch?v=Zo7sRijXG00",
     "official_link": "https://www.babi.sh/recipes/advanced-grilled-cheese",
@@ -17760,7 +19235,7 @@
   },
   {
     "episode_id": "chicken-parmesan",
-    "name": "CHICKEN PARMESAN",
+    "name": "Chicken Parmesan",
     "published_date": "2020-12-10",
     "youtube_link": "https://www.youtube.com/watch?v=ZrR0VbqNdW8",
     "official_link": "https://www.babi.sh/recipes/chicken-parmesan",
@@ -18114,7 +19589,7 @@
   },
   {
     "episode_id": "andrewsohlathanksgiving",
-    "name": "ANDREW & SOHLA THANKSGIVING RECIPES",
+    "name": "Thanksgiving Recipe Livestream with Sohla El-Waylly",
     "published_date": "2020-11-20",
     "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
     "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
@@ -18132,12 +19607,25 @@
           "name": "Basics"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 78,
+          "name": "Sohla El-Waylly",
+          "image_link": null
+        }
+      ],
       "inspired_by": [],
       "recipes": [
         {
+          "recipe_id": 809,
+          "name": "Elote Spoon Bread",
+          "image_link": null,
+          "raw_ingredient_list": "1 \u2154 cups fresh or frozen corn kernels",
+          "raw_procedure": ""
+        },
+        {
           "recipe_id": 808,
-          "name": "Casserole Dish Prep",
+          "name": "Elote Spoon Bread Pan Prep",
           "image_link": null,
           "raw_ingredient_list": "2 tbsp mayonnaise\n\u00bc cup finely crumbled cotija cheese",
           "raw_procedure": ""
@@ -18175,13 +19663,6 @@
           "name": "The Caramel Topping",
           "image_link": null,
           "raw_ingredient_list": "5 tbsp (70 grams) unsalted butter, divided\n1 \u00bc cup plus 2 tbsp (250g plus 28g) granulated sugar\n2 medium oranges, scrubbed\n1 cup Blue Moon Belgian White Wheat Ale\n\u00bc tsp Diamond Crystal kosher salt",
-          "raw_procedure": ""
-        },
-        {
-          "recipe_id": 809,
-          "name": "The Casserole",
-          "image_link": null,
-          "raw_ingredient_list": "1 \u2154 cups fresh or frozen corn kernels",
           "raw_procedure": ""
         },
         {
@@ -18759,7 +20240,7 @@
       "recipes": [
         {
           "recipe_id": 1431,
-          "name": "hazelnuts baklava",
+          "name": "chocolate hazelnut baklava",
           "image_link": null,
           "raw_ingredient_list": "phyllo dough\nhazelnuts\npistachio de shelled\nbutter\nsugar\ndark chocolate\nhoney",
           "raw_procedure": ""
@@ -19713,11 +21194,6 @@
           "name": "Difficult"
         },
         {
-          "tag_id": 28,
-          "axis": "Meal",
-          "name": "Breakfast"
-        },
-        {
           "tag_id": 12,
           "axis": "Series",
           "name": "Binging"
@@ -19809,7 +21285,7 @@
   },
   {
     "episode_id": "cheese-fondue",
-    "name": "CHEEESE FONDUE",
+    "name": "Cheese Fondue",
     "published_date": "2020-07-23",
     "youtube_link": "https://www.youtube.com/watch?v=_X-Mm8h1AHM",
     "official_link": "https://www.babi.sh/recipes/cheese-fondue",
@@ -19837,7 +21313,7 @@
       "recipes": [
         {
           "recipe_id": 1440,
-          "name": "fonduta",
+          "name": "Cheese Fondue",
           "image_link": null,
           "raw_ingredient_list": "desired cheese\nyellow & white cheddar\nfontina cheese\ndry white wine\nbeer\nmilk\nbutter",
           "raw_procedure": ""
@@ -20917,7 +22393,13 @@
           "name": "TV Show"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 80,
+          "name": "H. Jon Benjamin",
+          "image_link": null
+        }
+      ],
       "inspired_by": [
         {
           "reference_id": 23,
@@ -20996,7 +22478,7 @@
   },
   {
     "episode_id": "chimichangas",
-    "name": "CHIMICHANGAS",
+    "name": "Deadpool's Chimichangas",
     "published_date": "2020-04-28",
     "youtube_link": "https://www.youtube.com/watch?v=szFLA4_pwew",
     "official_link": "https://www.babi.sh/recipes/chimichangas",
@@ -21010,11 +22492,20 @@
         }
       ],
       "guests": [],
-      "inspired_by": [],
+      "inspired_by": [
+        {
+          "reference_id": 54,
+          "type": "movie",
+          "name": "Deadpool",
+          "description": "A wisecracking mercenary gets experimented on and becomes immortal but ugly, and sets out to track down the man who ruined his looks. IMDb.",
+          "external_link": "https://www.imdb.com/title/tt1431045/",
+          "image_link": "https://img.youtube.com/vi/AEIKS4IbfNk/mqdefault.jpg"
+        }
+      ],
       "recipes": [
         {
           "recipe_id": 1450,
-          "name": "deep frying",
+          "name": "Chimichangas",
           "image_link": null,
           "raw_ingredient_list": "chicken",
           "raw_procedure": ""
@@ -21138,7 +22629,7 @@
   },
   {
     "episode_id": "ben-wyatt-calzones",
-    "name": "Calzones inspired by Parks & Rec",
+    "name": "Ben Wyatt's Calzones",
     "published_date": "2020-04-15",
     "youtube_link": "https://www.youtube.com/watch?v=PvgCEifW7Jo",
     "official_link": "https://www.babi.sh/recipes/ben-wyatt-calzones",
@@ -21174,17 +22665,17 @@
       ],
       "recipes": [
         {
-          "recipe_id": 679,
-          "name": "Crust",
+          "recipe_id": 680,
+          "name": "Apple Pie Filling",
           "image_link": null,
-          "raw_ingredient_list": "300 grams all-purpose flour\n2 Tbsp sugar\n1 tsp kosher salt\n225 grams unsalted butter, cold & cubed\n6-8 Tbsp ice water",
+          "raw_ingredient_list": "2lbs honey crisp apples, peeled and sliced\n1 lemon, juiced\n\u00be cup sugar\n1 \u00bd Tbsp cornstarch\n\u00bc cup brown sugar\n2 tsp cinnamon\n\u00bd tsp ground ginger\n\u00bd tsp allspice\n\u00bc tsp ground clove\nZest of 1 lemon\n1 tsp kosher salt\n1 egg white\nDemerara sugar",
           "raw_procedure": ""
         },
         {
-          "recipe_id": 680,
-          "name": "Filling",
+          "recipe_id": 679,
+          "name": "Pie Dough Crust",
           "image_link": null,
-          "raw_ingredient_list": "2lbs honey crisp apples, peeled and sliced\n1 lemon, juiced\n\u00be cup sugar\n1 \u00bd Tbsp cornstarch\n\u00bc cup brown sugar\n2 tsp cinnamon\n\u00bd tsp ground ginger\n\u00bd tsp allspice\n\u00bc tsp ground clove\nZest of 1 lemon\n1 tsp kosher salt\n1 egg white\nDemerara sugar",
+          "raw_ingredient_list": "300 grams all-purpose flour\n2 Tbsp sugar\n1 tsp kosher salt\n225 grams unsalted butter, cold & cubed\n6-8 Tbsp ice water",
           "raw_procedure": ""
         },
         {
@@ -21497,7 +22988,7 @@
       "recipes": [
         {
           "recipe_id": 1456,
-          "name": "chocolate chip cookies",
+          "name": "chickpea (aquafaba) chocolate chip cookies",
           "image_link": null,
           "raw_ingredient_list": "chickpeas\nflour\ncan crushed tomatoes\ngarbanzo beans\nliquid from chickpeas",
           "raw_procedure": ""
@@ -22635,7 +24126,7 @@
     "episode_id": "beer-steamed-chili-dogs",
     "name": "Chili Dogs inspired by The Irishman",
     "published_date": "2019-12-17",
-    "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/c0A1bkF4mKM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM",
     "official_link": "https://www.babi.sh/recipes/beer-steamed-chili-dogs",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695792/babishImages/undefined-202970.png",
     "related": {
@@ -23495,100 +24986,6 @@
     }
   },
   {
-    "episode_id": "crepessuzette",
-    "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-    "published_date": "2019-10-24",
-    "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
-    "official_link": "https://www.babi.sh/recipes/crepessuzette",
-    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png",
-    "related": {
-      "tags": [
-        {
-          "tag_id": 18,
-          "axis": "Category",
-          "name": "Dessert"
-        },
-        {
-          "tag_id": 33,
-          "axis": "Difficulty",
-          "name": "Difficult"
-        },
-        {
-          "tag_id": 12,
-          "axis": "Series",
-          "name": "Binging"
-        },
-        {
-          "tag_id": 5,
-          "axis": "Source",
-          "name": "Movie"
-        }
-      ],
-      "guests": [],
-      "inspired_by": [
-        {
-          "reference_id": 137,
-          "type": "movie",
-          "name": "Talladega Nights: The Ballad of Ricky Bobby",
-          "description": "Number one NASCAR driver Ricky Bobby stays atop the heap thanks to a pact with his best friend and teammate, Cal Naughton, Jr. But when a French Formula One driver, makes his way up the ladder, Ricky Bobby's talent and devotion are put to the test.",
-          "external_link": "https://www.imdb.com/title/tt0415306/",
-          "image_link": "https://img.youtube.com/vi/8cWRHcl5GFI/mqdefault.jpg"
-        }
-      ],
-      "recipes": [
-        {
-          "recipe_id": 575,
-          "name": "Breakfast Cr\u00eapes",
-          "image_link": "",
-          "raw_ingredient_list": "1 egg\nSwiss cheese, grated\nKosher salt\nFreshly ground pepper\nFreshly minced chives\nHomemade chili oil (ingredients below)",
-          "raw_procedure": "For making the actual cr\u00eapes, follow either the classic cr\u00eape recipe or the buckwheat cr\u00eape recipe, which are both listed above.\nOnce you flip the cr\u00eape, add a generous grating of swiss cheese to the top of the cr\u00eape.\nCoat a pan with butter and fry one egg sunny-side up. Once the egg is fried, add it on top center of the cr\u00eape.\nFold four edges up around the center to make a square. Season with kosher salt, freshly ground pepper, and freshly minced chives.\nIf desired, add some homemade chili oil (recipe listed below) to top everything off."
-        },
-        {
-          "recipe_id": 574,
-          "name": "Buckwheat Cr\u00eapes",
-          "image_link": "",
-          "raw_ingredient_list": "2 large eggs\n\u00bd cup water\n\u00be cup milk\n3 Tbsp melted butter\nSalt\n1 cup buckwheat flour",
-          "raw_procedure": "In a blender, combine 2 large eggs, \u00bd cup of water. \u00be cup of milk, 3 Tbsp of melted butter, a pinch of salt, and 1 cup of buckwheat flour.\nPulse the mixture 10-12 times on low power until combined and then scrape down the sides for any loose bits of flour. Pulse a couple more times until you have a thin pancake batter. Let the mixture sit in the refrigerator for one hour to get rid of any bubbles.\nUsing a non-stick skillet or a cr\u00eape maker that is coated with butter, pour your batter in and slowly rotate the pan until the entire surface is covered with batter and it is nice and thin.\nLet cook for 30-60 seconds over medium high heat until it is dappled brown. Flip the cr\u00eape and let cook for an additional 15-30 seconds until it is cooked through."
-        },
-        {
-          "recipe_id": 576,
-          "name": "Chili Oil",
-          "image_link": "",
-          "raw_ingredient_list": "Szechuan peppercorns\nStar anise pods\nCassia bark\nKnob of peeled ginger\n3 lightly crushed cloves of garlic\nCanola oil (or any neutral flavored oil)\nSichuan chili",
-          "raw_procedure": "In a small saucepan, throw a handful of Szechuan peppercorns, star anise pods, cassia bark, a knob of peeled ginger, and 3 lightly crushed cloves of garlic.\nPour 2-3 cups of canola oil over the top and gently swirl over medium heat until the oil reaches about 325 degrees Fahrenheit. Strain and pour over about a cup of Sichuan chili flakes into a heat-proof bowl. Give a little mix and set aside for about 30 minutes to cool."
-        },
-        {
-          "recipe_id": 573,
-          "name": "Cr\u00eapes",
-          "image_link": "",
-          "raw_ingredient_list": "2 large eggs\n\u00bd cup water\n\u00be cup milk\n3 Tbsp melted butter\nSalt\n1 cup flour",
-          "raw_procedure": "In a blender, combine 2 large eggs, \u00bd cup of water. \u00be cup of milk, 3 Tbsp of melted butter, a pinch of salt, and 1 cup of flour.\nPulse the mixture 10-12 times on low power until combined and then scrape down the sides for any loose bits of flour. Pulse a couple more times until you have a thin pancake batter. Let the mixture sit in the refrigerator for one hour to get rid of any bubbles.\nUsing a non-stick skillet or a cr\u00eape maker that is coated with butter, pour your batter in and slowly rotate the pan until the entire surface is covered with batter and it is nice and thin.\nLet cook for 30-60 seconds over medium high heat until it is dappled brown. Flip the cr\u00eape and let cook for an additional 15-30 seconds until it is cooked through."
-        },
-        {
-          "recipe_id": 579,
-          "name": "Cr\u00eapes Suzette",
-          "image_link": "",
-          "raw_ingredient_list": "3 Tbsp butter\nSugar\n1 orange\nDry sherry or cognac\nVanilla ice cream",
-          "raw_procedure": "For making the actual cr\u00eapes, follow either the classic cr\u00eape recipe or the buckwheat cr\u00eape recipe, which are both listed above.\nMelt 3 tablespoons of butter in a large saut\u00e9 pan and add at least 2 tablespoons of sugar. Then, add the zest and juice from any type of orange of your choice.\nBring the mixture to a simmer and gently swirl to incorporate all of the sugar.\nBegin dunking your pre-prepared cr\u00eapes into the liquid and make sure that it is nicely coated on both sides of the bottom half of the cr\u00eape.\nLay the cr\u00eape down in the liquid and fold it in half double quesadilla style.\nRinse and repeat with two additional cr\u00eapes and arrange them into a quadrant. Cook for about one minute on the first side before flipping to make sure that they are nice and evenly coated.\nLet the cr\u00eapes sit in the pan for 3-5 minutes over medium heat until they are nice and caramelized on one side. Arrange the cr\u00eapes on a plate.\nFlambe over the stovetop with either dry sherry or cognac.\nGently pour over the cr\u00eapes or add one scoop of vanilla ice cream to top everything off."
-        },
-        {
-          "recipe_id": 577,
-          "name": "Mushroom and Gruyere Cr\u00eapes",
-          "image_link": "",
-          "raw_ingredient_list": "5-6 oz mushrooms\n\u00bc small Spanish onion, diced\n1 single garlic clove\n1 Tbsp butter\nDry sherry or cognac\nGruyere cheese\nFreshly picked thyme",
-          "raw_procedure": "Finely chop up \u00bc of a small Spanish onion as well as 1 single clove of garlic.\nOn the stovetop, coat a pan with 1 tablespoon of butter and let melt over medium heat. Then, add the onion and mushrooms and let them saut\u00e9 for 5-7 minutes. Toss occasionally and add salt to draw any excess moisture out of the mushrooms and cook until brown and soft.\nAdd the garlic and saut\u00e9 for an additional 30 seconds. Season with freshly ground pepper and optionally flambe with a bit of dry sherry or cognac.\nFor making the actual cr\u00eapes, follow either the classic cr\u00eape recipe or the buckwheat cr\u00eape recipe, which are both listed above.\nTop off your cr\u00eape with a generous amount of grated Gruyere cheese as well as your mushroom mixture. Fold the cr\u00eape and roll it up like a flat wide open-ended burrito.\nGrate a little bit of extra cheese on top and garnish with freshly picked thyme."
-        },
-        {
-          "recipe_id": 578,
-          "name": "Nutella and Strawberry Cr\u00eapes",
-          "image_link": "",
-          "raw_ingredient_list": "Strawberries\nNutella\nWhipped cream\nChocolate syrup",
-          "raw_procedure": "For making the actual cr\u00eapes, follow either the classic cr\u00eape recipe or the buckwheat cr\u00eape recipe, which are both listed above.\nSlice up some fresh strawberries and set aside for later. To the top of your cr\u00eape, add a generous dollop of Nutella and evenly spread it out to the edges.\nAdd the strawberries to the top of the cr\u00eape. Fold the cr\u00eape in half like a quesadilla and then fold in half one more time. Add some whipped cream and chocolate syrup to top everything off."
-        }
-      ]
-    }
-  },
-  {
     "episode_id": "espressodrinks",
     "name": "ESPRESSO DRINKS",
     "published_date": "2019-10-24",
@@ -23701,6 +25098,100 @@
           "image_link": "",
           "raw_ingredient_list": "Espresso (double shot)\nSteamed milk\nChocolate sauce",
           "raw_procedure": "Start with a double shot of espresso and add to it an equal amount of chocolate sauce. This is a similar deal to the latte with a whole lot of steamed milk and a little bit of foam. Top the drink off with some whipped cream, cocoa powder, chocolate drizzle, a cinnamon stick if desired."
+        }
+      ]
+    }
+  },
+  {
+    "episode_id": "crepessuzette",
+    "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
+    "published_date": "2019-10-22",
+    "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
+    "official_link": "https://www.babi.sh/recipes/crepessuzette",
+    "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png",
+    "related": {
+      "tags": [
+        {
+          "tag_id": 18,
+          "axis": "Category",
+          "name": "Dessert"
+        },
+        {
+          "tag_id": 33,
+          "axis": "Difficulty",
+          "name": "Difficult"
+        },
+        {
+          "tag_id": 12,
+          "axis": "Series",
+          "name": "Binging"
+        },
+        {
+          "tag_id": 5,
+          "axis": "Source",
+          "name": "Movie"
+        }
+      ],
+      "guests": [],
+      "inspired_by": [
+        {
+          "reference_id": 137,
+          "type": "movie",
+          "name": "Talladega Nights: The Ballad of Ricky Bobby",
+          "description": "Number one NASCAR driver Ricky Bobby stays atop the heap thanks to a pact with his best friend and teammate, Cal Naughton, Jr. But when a French Formula One driver, makes his way up the ladder, Ricky Bobby's talent and devotion are put to the test.",
+          "external_link": "https://www.imdb.com/title/tt0415306/",
+          "image_link": "https://img.youtube.com/vi/8cWRHcl5GFI/mqdefault.jpg"
+        }
+      ],
+      "recipes": [
+        {
+          "recipe_id": 575,
+          "name": "Breakfast Cr\u00eapes",
+          "image_link": "",
+          "raw_ingredient_list": "1 egg\nSwiss cheese, grated\nKosher salt\nFreshly ground pepper\nFreshly minced chives\nHomemade chili oil (ingredients below)",
+          "raw_procedure": "For making the actual cr\u00eapes, follow either the classic cr\u00eape recipe or the buckwheat cr\u00eape recipe, which are both listed above.\nOnce you flip the cr\u00eape, add a generous grating of swiss cheese to the top of the cr\u00eape.\nCoat a pan with butter and fry one egg sunny-side up. Once the egg is fried, add it on top center of the cr\u00eape.\nFold four edges up around the center to make a square. Season with kosher salt, freshly ground pepper, and freshly minced chives.\nIf desired, add some homemade chili oil (recipe listed below) to top everything off."
+        },
+        {
+          "recipe_id": 574,
+          "name": "Buckwheat Cr\u00eapes",
+          "image_link": "",
+          "raw_ingredient_list": "2 large eggs\n\u00bd cup water\n\u00be cup milk\n3 Tbsp melted butter\nSalt\n1 cup buckwheat flour",
+          "raw_procedure": "In a blender, combine 2 large eggs, \u00bd cup of water. \u00be cup of milk, 3 Tbsp of melted butter, a pinch of salt, and 1 cup of buckwheat flour.\nPulse the mixture 10-12 times on low power until combined and then scrape down the sides for any loose bits of flour. Pulse a couple more times until you have a thin pancake batter. Let the mixture sit in the refrigerator for one hour to get rid of any bubbles.\nUsing a non-stick skillet or a cr\u00eape maker that is coated with butter, pour your batter in and slowly rotate the pan until the entire surface is covered with batter and it is nice and thin.\nLet cook for 30-60 seconds over medium high heat until it is dappled brown. Flip the cr\u00eape and let cook for an additional 15-30 seconds until it is cooked through."
+        },
+        {
+          "recipe_id": 576,
+          "name": "Chili Oil",
+          "image_link": "",
+          "raw_ingredient_list": "Szechuan peppercorns\nStar anise pods\nCassia bark\nKnob of peeled ginger\n3 lightly crushed cloves of garlic\nCanola oil (or any neutral flavored oil)\nSichuan chili",
+          "raw_procedure": "In a small saucepan, throw a handful of Szechuan peppercorns, star anise pods, cassia bark, a knob of peeled ginger, and 3 lightly crushed cloves of garlic.\nPour 2-3 cups of canola oil over the top and gently swirl over medium heat until the oil reaches about 325 degrees Fahrenheit. Strain and pour over about a cup of Sichuan chili flakes into a heat-proof bowl. Give a little mix and set aside for about 30 minutes to cool."
+        },
+        {
+          "recipe_id": 573,
+          "name": "Cr\u00eapes",
+          "image_link": "",
+          "raw_ingredient_list": "2 large eggs\n\u00bd cup water\n\u00be cup milk\n3 Tbsp melted butter\nSalt\n1 cup flour",
+          "raw_procedure": "In a blender, combine 2 large eggs, \u00bd cup of water. \u00be cup of milk, 3 Tbsp of melted butter, a pinch of salt, and 1 cup of flour.\nPulse the mixture 10-12 times on low power until combined and then scrape down the sides for any loose bits of flour. Pulse a couple more times until you have a thin pancake batter. Let the mixture sit in the refrigerator for one hour to get rid of any bubbles.\nUsing a non-stick skillet or a cr\u00eape maker that is coated with butter, pour your batter in and slowly rotate the pan until the entire surface is covered with batter and it is nice and thin.\nLet cook for 30-60 seconds over medium high heat until it is dappled brown. Flip the cr\u00eape and let cook for an additional 15-30 seconds until it is cooked through."
+        },
+        {
+          "recipe_id": 579,
+          "name": "Cr\u00eapes Suzette",
+          "image_link": "",
+          "raw_ingredient_list": "3 Tbsp butter\nSugar\n1 orange\nDry sherry or cognac\nVanilla ice cream",
+          "raw_procedure": "For making the actual cr\u00eapes, follow either the classic cr\u00eape recipe or the buckwheat cr\u00eape recipe, which are both listed above.\nMelt 3 tablespoons of butter in a large saut\u00e9 pan and add at least 2 tablespoons of sugar. Then, add the zest and juice from any type of orange of your choice.\nBring the mixture to a simmer and gently swirl to incorporate all of the sugar.\nBegin dunking your pre-prepared cr\u00eapes into the liquid and make sure that it is nicely coated on both sides of the bottom half of the cr\u00eape.\nLay the cr\u00eape down in the liquid and fold it in half double quesadilla style.\nRinse and repeat with two additional cr\u00eapes and arrange them into a quadrant. Cook for about one minute on the first side before flipping to make sure that they are nice and evenly coated.\nLet the cr\u00eapes sit in the pan for 3-5 minutes over medium heat until they are nice and caramelized on one side. Arrange the cr\u00eapes on a plate.\nFlambe over the stovetop with either dry sherry or cognac.\nGently pour over the cr\u00eapes or add one scoop of vanilla ice cream to top everything off."
+        },
+        {
+          "recipe_id": 577,
+          "name": "Mushroom and Gruyere Cr\u00eapes",
+          "image_link": "",
+          "raw_ingredient_list": "5-6 oz mushrooms\n\u00bc small Spanish onion, diced\n1 single garlic clove\n1 Tbsp butter\nDry sherry or cognac\nGruyere cheese\nFreshly picked thyme",
+          "raw_procedure": "Finely chop up \u00bc of a small Spanish onion as well as 1 single clove of garlic.\nOn the stovetop, coat a pan with 1 tablespoon of butter and let melt over medium heat. Then, add the onion and mushrooms and let them saut\u00e9 for 5-7 minutes. Toss occasionally and add salt to draw any excess moisture out of the mushrooms and cook until brown and soft.\nAdd the garlic and saut\u00e9 for an additional 30 seconds. Season with freshly ground pepper and optionally flambe with a bit of dry sherry or cognac.\nFor making the actual cr\u00eapes, follow either the classic cr\u00eape recipe or the buckwheat cr\u00eape recipe, which are both listed above.\nTop off your cr\u00eape with a generous amount of grated Gruyere cheese as well as your mushroom mixture. Fold the cr\u00eape and roll it up like a flat wide open-ended burrito.\nGrate a little bit of extra cheese on top and garnish with freshly picked thyme."
+        },
+        {
+          "recipe_id": 578,
+          "name": "Nutella and Strawberry Cr\u00eapes",
+          "image_link": "",
+          "raw_ingredient_list": "Strawberries\nNutella\nWhipped cream\nChocolate syrup",
+          "raw_procedure": "For making the actual cr\u00eapes, follow either the classic cr\u00eape recipe or the buckwheat cr\u00eape recipe, which are both listed above.\nSlice up some fresh strawberries and set aside for later. To the top of your cr\u00eape, add a generous dollop of Nutella and evenly spread it out to the edges.\nAdd the strawberries to the top of the cr\u00eape. Fold the cr\u00eape in half like a quesadilla and then fold in half one more time. Add some whipped cream and chocolate syrup to top everything off."
         }
       ]
     }
@@ -24022,7 +25513,7 @@
     "episode_id": "coffeejelly",
     "name": "Coffee Jelly inspired by The Disastrous Life of Saiki K.",
     "published_date": "2019-09-24",
-    "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YxEcd_wTf5c/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c",
     "official_link": "https://www.babi.sh/recipes/coffeejelly",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png",
     "related": {
@@ -24173,7 +25664,7 @@
   },
   {
     "episode_id": "cajunfood",
-    "name": "CAJUN FOOD",
+    "name": "Cajun Food",
     "published_date": "2019-09-13",
     "youtube_link": "https://www.youtube.com/watch?v=nORg_aXMsmA",
     "official_link": "https://www.babi.sh/recipes/cajunfood",
@@ -24396,7 +25887,7 @@
     "episode_id": "applefritters",
     "name": "Double-Glazed Apple Fritters inspired by Regular Show",
     "published_date": "2019-08-27",
-    "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YYSP1D6GJ30/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30",
     "official_link": "https://www.babi.sh/recipes/applefritters",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695467/babishImages/undefined-689012.png",
     "related": {
@@ -24806,7 +26297,7 @@
     "episode_id": "bagelsandwiches",
     "name": "Bagel Sandwiches inspired by Steven Universe",
     "published_date": "2019-07-23",
-    "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
     "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png",
     "related": {
@@ -25423,7 +26914,7 @@
     "episode_id": "alwayssunny",
     "name": "It's Always Sunny in Philadelphia Special (Part II)",
     "published_date": "2019-06-12",
-    "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/_fnhy5xO9vQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ",
     "official_link": "https://www.babi.sh/recipes/alwayssunny",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696347/babishImages/undefined-129032.png",
     "related": {
@@ -25489,7 +26980,7 @@
   },
   {
     "episode_id": "being-with-babish-4",
-    "name": "Training like Kratos for 30 Days | Body by Babish",
+    "name": "Training like Kratos for 30 Days | Being with Babish",
     "published_date": "2019-06-07",
     "youtube_link": "https://www.youtube.com/watch?v=n_aq5TVb0HA",
     "official_link": "https://www.youtube.com/watch?v=n_aq5TVb0HA",
@@ -25498,13 +26989,13 @@
       "tags": [],
       "guests": [
         {
-          "guest_id": 73,
-          "name": "Sarah and Stefan",
+          "guest_id": 79,
+          "name": "Chris Parnell",
           "image_link": null
         },
         {
-          "guest_id": 68,
-          "name": "Sawyer Jacobs",
+          "guest_id": 73,
+          "name": "Sarah and Stefan",
           "image_link": null
         }
       ],
@@ -25970,7 +27461,7 @@
   },
   {
     "episode_id": "cheesdips",
-    "name": "CHEESE DIPS",
+    "name": "Cheese Dips",
     "published_date": "2019-05-02",
     "youtube_link": "https://www.youtube.com/watch?v=9toK5UUGeok",
     "official_link": "https://www.babi.sh/recipes/cheesdips",
@@ -26031,7 +27522,7 @@
     "episode_id": "avengersicecream",
     "name": "Ice Cream Flavors inspired by Avengers: Infinity War",
     "published_date": "2019-04-30",
-    "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Ukjat70Iyt4/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4",
     "official_link": "https://www.babi.sh/recipes/avengersicecream",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695805/babishImages/undefined-987247.png",
     "related": {
@@ -26139,7 +27630,7 @@
     "episode_id": "bubbashrimp2",
     "name": "Shrimp inspired by Forrest Gump Part II",
     "published_date": "2019-04-23",
-    "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/mF6JUfczaO8/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8",
     "official_link": "https://www.babi.sh/recipes/bubbashrimp2",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696055/babishImages/undefined-252668.png",
     "related": {
@@ -26459,7 +27950,7 @@
     "episode_id": "brocksdonuts",
     "name": "Brock's Donuts inspired by Pok\u00e9mon",
     "published_date": "2019-04-02",
-    "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/RentKWlhUXc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc",
     "official_link": "https://www.babi.sh/recipes/brocksdonuts",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695178/babishImages/undefined-56205.png",
     "related": {
@@ -26570,7 +28061,7 @@
   },
   {
     "episode_id": "chickentikkamasala",
-    "name": "CHICKEN TIKKA MASALA",
+    "name": "Chicken Tikka Masala",
     "published_date": "2019-03-28",
     "youtube_link": "https://www.youtube.com/watch?v=Bkd0LxBd2L8",
     "official_link": "https://www.babi.sh/recipes/chickentikkamasala",
@@ -26839,7 +28330,7 @@
   },
   {
     "episode_id": "blendersoups",
-    "name": "BLENDER SOUPS",
+    "name": "Blender Soups",
     "published_date": "2019-03-05",
     "youtube_link": "https://www.youtube.com/watch?v=S-gUFvpRQoU",
     "official_link": "https://www.babi.sh/recipes/blendersoups",
@@ -26965,16 +28456,11 @@
     "episode_id": "baobuns",
     "name": "Bao inspired by Pixar's Bao",
     "published_date": "2019-02-19",
-    "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M&amp;t=46s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/OFt3SThGi7M/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M",
     "official_link": "https://www.babi.sh/recipes/baobuns",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695380/babishImages/undefined-293013.png",
     "related": {
       "tags": [
-        {
-          "tag_id": 18,
-          "axis": "Category",
-          "name": "Dessert"
-        },
         {
           "tag_id": 32,
           "axis": "Difficulty",
@@ -27176,7 +28662,7 @@
   },
   {
     "episode_id": "biggamesnacks",
-    "name": "BIG GAME SNACKS",
+    "name": "Big Game Snacks",
     "published_date": "2019-01-31",
     "youtube_link": "https://www.youtube.com/watch?v=8ckxhlDFNkg",
     "official_link": "https://www.babi.sh/recipes/biggamesnacks",
@@ -27298,7 +28784,7 @@
   },
   {
     "episode_id": "bagels",
-    "name": "BAGELS",
+    "name": "Bagels",
     "published_date": "2019-01-24",
     "youtube_link": "https://www.youtube.com/watch?v=ZrJtpCTZk38",
     "official_link": "https://www.babi.sh/recipes/bagels",
@@ -27339,7 +28825,7 @@
     "episode_id": "aristocats",
     "name": "Cr\u00e8me de la Cr\u00e8me \u00e0 la Edgar inspired by The Aristocats",
     "published_date": "2019-01-23",
-    "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/zNY-qzp7pD0/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0",
     "official_link": "https://www.babi.sh/recipes/aristocats",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696317/babishImages/undefined-541474.png",
     "related": {
@@ -27378,18 +28864,18 @@
       ],
       "recipes": [
         {
-          "recipe_id": 127,
-          "name": "Big Cracker",
-          "image_link": null,
-          "raw_ingredient_list": "10 ounces all purpose flour\n3 tsp baking powder\n\u00bd tsp kosher salt\n1 Tbsp granulated sugar\n6 Tbsp cold butter\n2 Tbsp vegetable oil\n\u2154 cup ice water",
-          "raw_procedure": "In a food processor add 10 ounces of all purpose flour along with 3 tsp of baking powder, \u00bd tsp of kosher salt, and 1 Tbsp of granulated sugar. Pulse to combine.\nNext add 6 Tbsp of sliced cold butter along with 2 Tbsp of vegetable oil and mix to combine before drizzling \u2154 cup of ice cold water into the food processor while it\u2019s processing. When a ball of dough forms, remove and immediately wrap in plastic wrap and place in the fridge for 10-15 minutes.\nRemove dough from the fridge and liberally flour your work surface. Roll out your dough as thin as possible. Using a fluted biscuit cutter, cut out cracker shapes and place them on a parchment lined baking sheet. Using a toothpick add the signature Ritz Cracker 7 holes and then brush all of them down with some melted butter. Place in a 400\u00b0F oven for 10-15 minutes.\nOnce they are golden brown in the oven, remove and brush with butter and immediately sprinkle with some salt."
-        },
-        {
           "recipe_id": 128,
           "name": "Cr\u00e8me de la Cr\u00e8me \u00e0 la Edgar",
           "image_link": null,
           "raw_ingredient_list": "1 pint heavy cream\n1 pint whole milk\n1 vanilla bean\n\u2153 cup sugar\n\u00bc tsp ground cinnamon\n\u00bc tsp ground nutmeg\nPinch of salt",
           "raw_procedure": "In a pot add 1 pint of heavy cream and 1 pint of whole milk. Stir to combine.\nScrape one vanilla bean and then add the beans and the pod to the milk mixture along with \u2153 cup of sugar, \u00bc tsp ground cinnamon, \u00bc tsp ground nutmeg and a pinch of salt.\nJust bring to a boil and stir to combine.\nServe with crackers and enjoy!"
+        },
+        {
+          "recipe_id": 127,
+          "name": "Homemade Ritz Crackers",
+          "image_link": null,
+          "raw_ingredient_list": "10 ounces all purpose flour\n3 tsp baking powder\n\u00bd tsp kosher salt\n1 Tbsp granulated sugar\n6 Tbsp cold butter\n2 Tbsp vegetable oil\n\u2154 cup ice water",
+          "raw_procedure": "In a food processor add 10 ounces of all purpose flour along with 3 tsp of baking powder, \u00bd tsp of kosher salt, and 1 Tbsp of granulated sugar. Pulse to combine.\nNext add 6 Tbsp of sliced cold butter along with 2 Tbsp of vegetable oil and mix to combine before drizzling \u2154 cup of ice cold water into the food processor while it\u2019s processing. When a ball of dough forms, remove and immediately wrap in plastic wrap and place in the fridge for 10-15 minutes.\nRemove dough from the fridge and liberally flour your work surface. Roll out your dough as thin as possible. Using a fluted biscuit cutter, cut out cracker shapes and place them on a parchment lined baking sheet. Using a toothpick add the signature Ritz Cracker 7 holes and then brush all of them down with some melted butter. Place in a 400\u00b0F oven for 10-15 minutes.\nOnce they are golden brown in the oven, remove and brush with butter and immediately sprinkle with some salt."
         }
       ]
     }
@@ -27398,7 +28884,7 @@
     "episode_id": "coqauvin",
     "name": "Coq au Vin inspired by Donnie Brasco",
     "published_date": "2019-01-15",
-    "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/VP1uTgikarU/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU",
     "official_link": "https://www.babi.sh/recipes/coqauvin",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695986/babishImages/undefined-867897.png",
     "related": {
@@ -28075,7 +29561,7 @@
     "episode_id": "chileanseabass",
     "name": "Chilean Sea Bass inspired by Jurassic Park",
     "published_date": "2018-11-27",
-    "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/p73kqpqGqqQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ",
     "official_link": "https://www.babi.sh/recipes/chileanseabass",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695721/babishImages/undefined-408439.png",
     "related": {
@@ -28132,7 +29618,7 @@
     "episode_id": "charliebrownthanksgiving",
     "name": "Charlie Brown Thanksgiving",
     "published_date": "2018-11-20",
-    "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5FyKxVJmsdE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE",
     "official_link": "https://www.babi.sh/recipes/charliebrownthanksgiving",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg",
     "related": {
@@ -28354,7 +29840,7 @@
     "episode_id": "bearstew",
     "name": "Bear Stew inspired by Red Dead Redemption 2",
     "published_date": "2018-11-06",
-    "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wMxKbkWrvDc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc",
     "official_link": "https://www.babi.sh/recipes/bearstew",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679263840/iyxpvkao4lwi6xqkcwd1.webp",
     "related": {
@@ -28544,7 +30030,7 @@
     "episode_id": "cinnamonrolls",
     "name": "Cinnamon Rolls inspired by Jim Gaffigan's Stand Up (sort of)",
     "published_date": "2018-10-23",
-    "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/jFYi2QRVFOc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc",
     "official_link": "https://www.babi.sh/recipes/cinnamonrolls",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679245506/gyb4qsztcyrv4kjnvwug.webp",
     "related": {
@@ -29592,7 +31078,7 @@
       "recipes": [
         {
           "recipe_id": 226,
-          "name": "Car Panini",
+          "name": "Winning #BabishPanini Car Panini",
           "image_link": null,
           "raw_ingredient_list": "Mole Sauce\nPasilla dried chilis\nGuajillo dried chilis\nAncho dried chilis\n1 tsp whole cloves\n1 tsp peppercorn\n3 bay leaves, crumbled\n1 cinnamon stick\n1 corn tortilla\n1 slice of white bread\n\u2153 cup peanuts\n\u2153 cup pumpkin seeds\n\u2153 cup almonds\n\u2153 cup raisins\n\u00bc cup sesame seeds\n1 large tomato, quartered\n1 large onion\n4 cloves of garlic\n\u00bc tsp dried thyme\n\u00bc tsp marjoram\n\u00bc tsp aniseed\n4 cups chicken stock, hot\n4 ounces bittersweet chocolate, chopped\nSugar (if necessary)\nTomatillos (optional)\nCheddar Crisps\nShredded mild cheddar cheese\nGoat Cheese Cream\n5 ounces goat cheese\n1 Tbsp honey\n2 Tbsp heavy cream\nSandwich Stuff\n2 slices of white bread\nChorizo",
           "raw_procedure": "Start by stemming and seeding some dried pasilla, guajillo, and ancho chilis. Save a few tablespoons of the seeds.\nHeat a cast iron skillet to a medium heat and add chilis. Dry roast them for about 2 minutes. Place about 12 chilis into a blender and set aside. Remove any extra chilis from skillet.\nIn the same skillet add 1 tsp whole cloves, 1 tsp peppercorns, 3 crumbled bay leaves, 1 cinnamon stick broken into a few pieces, and some of our reserved chili seeds. Dry roast for about 2 minutes or until the seeds darken. Remove from skillet and add to the blender.\nAdd one corn tortilla that has been torn into smaller pieces to the skillet cook with a little bit of oil until they turn brown. Add them to the blender.\nToast 1 piece of white bread and add that to the blender.\nAdd some vegetable oil to the pan along with \u2153 cup each of peanuts, pumpkin seeds, almonds and raisins. Roast for about one minute before adding \u00bc cup of sesame seeds. Let it go for one more minute before placing all of it into the blender.\nAdd some oil to the skillet and turn to a medium high heat. Add 1 large quartered tomato, 1 large chopped onion, and 4 cloves of garlic (If you have tomatillos this is the time to add them). Let them sit undisturbed for about a minute, letting them get nice and brown. Add \u00bc tsp each of dried thyme, marjoram, and aniseed. Cook for about a minute and then add to the blender.\nHeat up 4 cups of chicken stock and add that to the blender. Let everything sit in the blender for 10 minutes. Blend on medium for about 2 minutes or until smooth.\nAdd blended sauce to a large saucepan and cook on medium-low heat for about an hour.\nRun the sauce through a mesh sieve until you have a thick paste in the sieve and a smooth puree below.\nAdd the puree back to saucepan on a medium heat and add 4 ounces of chopped bittersweet chocolate. Taste and add sugar if necessary.\nPreheat oven to 425\u00b0F. Place a small handful of cheddar cheese in six piles on a cookie sheet lined with a silicon mat or parchment paper. Bake the cheese for about 10 minutes, checking constantly just until all cheese is melted and edges begin to brown. Remove from oven and let cool slightly. Transfer crisps to a wire rack to cool.\nIn a blender combine 5 ounces of goat cheese with 1 Tbsp of honey and 2 Tbsp of heavy cream. Blend on high speed until you have a thick spreadable cream.\nIn a skillet cook up one piece of chorizo until your preferred doneness. Cut into 4 pieces.\nButter both slices of bread on the outside. On one piece of bread, slather some mole, top with cooked chorizo sausages, cheese crisps, and goat cheese cream. Top with other piece of bread. Place into your panini press/George Foreman grill. Serve and enjoy!"
@@ -29850,11 +31336,6 @@
           "tag_id": 16,
           "axis": "Category",
           "name": "Baking"
-        },
-        {
-          "tag_id": 18,
-          "axis": "Category",
-          "name": "Dessert"
         },
         {
           "tag_id": 13,
@@ -30188,7 +31669,7 @@
   },
   {
     "episode_id": "barbecueporkchops",
-    "name": "BARBECUE PORK CHOPS",
+    "name": "Barbecue Pork Chops",
     "published_date": "2018-06-28",
     "youtube_link": "https://www.youtube.com/watch?v=YV9XuvfIudY",
     "official_link": "https://www.babi.sh/recipes/barbecueporkchops",
@@ -30369,18 +31850,13 @@
   },
   {
     "episode_id": "burgers",
-    "name": "BURGERS",
+    "name": "Burgers",
     "published_date": "2018-06-14",
     "youtube_link": "https://www.youtube.com/watch?v=nbCgfiqq-5c",
     "official_link": "https://www.babi.sh/recipes/burgers",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1686072856/hopwyczgnd5layejyvpe.webp",
     "related": {
       "tags": [
-        {
-          "tag_id": 18,
-          "axis": "Category",
-          "name": "Dessert"
-        },
         {
           "tag_id": 15,
           "axis": "Category",
@@ -31379,7 +32855,7 @@
     "episode_id": "baressentials-7xwwz",
     "name": "CHOCOLATE CHIP COOKIES",
     "published_date": "2018-03-29",
-    "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/ylxzfecackM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM",
     "official_link": "https://www.babi.sh/recipes/baressentials-7xwwz",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690485488/p72d0navvupz8bsaur3g.webp",
     "related": {
@@ -31403,11 +32879,6 @@
           "tag_id": 13,
           "axis": "Series",
           "name": "Basics"
-        },
-        {
-          "tag_id": 12,
-          "axis": "Series",
-          "name": "Binging"
         }
       ],
       "guests": [],
@@ -31545,6 +33016,14 @@
           "image_link": "https://i.ytimg.com/sh/SnTDhFDmcbB3lkFWrIi8MA/market.jpg"
         },
         {
+          "reference_id": 648,
+          "type": null,
+          "name": "Lots of Things",
+          "description": null,
+          "external_link": null,
+          "image_link": null
+        },
+        {
           "reference_id": 21,
           "type": "tv_show",
           "name": "Spongebob Squarepants",
@@ -31574,9 +33053,9 @@
   },
   {
     "episode_id": "baressentials",
-    "name": "BAR ESSENTIALS",
+    "name": "Bar Essentials",
     "published_date": "2018-03-15",
-    "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/iZUfPIKbgUM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+    "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM",
     "official_link": "https://www.babi.sh/recipes/baressentials",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690416607/jlnnbuig1g2nrqafs58x.webp",
     "related": {
@@ -31613,7 +33092,7 @@
         },
         {
           "recipe_id": 304,
-          "name": "Margaretta",
+          "name": "Margarita",
           "image_link": null,
           "raw_ingredient_list": "4 oz Tequila\n1 oz Triple Sec\nLime juice\nSalt",
           "raw_procedure": "Salt the rim of a glass using lime juice.\nMix and serve."
@@ -33376,7 +34855,13 @@
           "name": "TV Show"
         }
       ],
-      "guests": [],
+      "guests": [
+        {
+          "guest_id": 83,
+          "name": "You Suck at Cooking",
+          "image_link": null
+        }
+      ],
       "inspired_by": [
         {
           "reference_id": 79,
@@ -33385,14 +34870,6 @@
           "description": "Explores the early relationship between the renowned psychiatrist and his patient, a young FBI criminal profiler, who is haunted by his ability to empathize with serial killers. IMDb.",
           "external_link": "https://www.imdb.com/title/tt2243973/",
           "image_link": "https://img.youtube.com/vi/uBl48Y-3tI8/mqdefault.jpg"
-        },
-        {
-          "reference_id": 113,
-          "type": "youtube_channel",
-          "name": "You Suck at Cooking",
-          "description": "Being taught to cook by a professional chef is everybody's dream. And if not everybody's dream, mostlybody's dream. But chasing your dreams is overrated and often leads to heartbreak. That's why you should throw your dreams in the garbage and learn to cook here, instead. In these cooking tutorial videos youre learn next to nothing, and you'll like it.",
-          "external_link": "https://www.youtube.com/channel/UCekQr9znsk2vWxBo3YiLq2w",
-          "image_link": "https://yt3.ggpht.com/a/AGF-l7_wVfJ2wHSX9nB-fMjIS7X4nX76KP0oSn3YrQ=s288-c-k-c0xffffffff-no-rj-mo"
         }
       ],
       "recipes": [
@@ -34658,7 +36135,7 @@
   {
     "episode_id": "cocktail-special",
     "name": "Cocktail Special",
-    "published_date": "2017-06-28",
+    "published_date": "2017-06-27",
     "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
     "official_link": "https://www.babi.sh/recipes/cocktail-special",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp",
@@ -34996,14 +36473,6 @@
           "description": "Story of a wonderful little girl, who happens to be a genius, and her wonderful teacher vs. the worst parents ever and the worst school principal imaginable. IMDb.",
           "external_link": "https://www.imdb.com/title/tt0117008/",
           "image_link": "https://img.youtube.com/vi/dFBYH6GHNzE/mqdefault.jpg"
-        },
-        {
-          "reference_id": 114,
-          "type": "tv_show",
-          "name": "You're Eating It Wrong",
-          "description": "This is a web series from Cooking Channel. They also combined episodes and broadcast on TV. IMDb.",
-          "external_link": "https://www.imdb.com/title/tt5195594/",
-          "image_link": "https://img.youtube.com/vi/--B_ENKrG-8/mqdefault.jpg"
         }
       ],
       "recipes": [
@@ -35335,7 +36804,7 @@
   {
     "episode_id": "babka-inspired-by-seinfeld",
     "name": "Babka inspired by Seinfeld",
-    "published_date": "2017-05-10",
+    "published_date": "2017-05-09",
     "youtube_link": "https://www.youtube.com/watch?v=pw2A03Z91FI",
     "official_link": "https://www.babi.sh/recipes/babka-inspired-by-seinfeld",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp",
@@ -35887,7 +37356,7 @@
   {
     "episode_id": "cubanos-inspired-by-chef",
     "name": "Cubanos inspired by Chef",
-    "published_date": "2017-03-29",
+    "published_date": "2017-03-28",
     "youtube_link": "https://www.youtube.com/watch?v=hXYoduN0kWs",
     "official_link": "https://www.babi.sh/recipes/cubanos-inspired-by-chef",
     "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992067/etfzgspqjiwp3janr32z.webp",
@@ -37556,16 +39025,7 @@
         }
       ],
       "guests": [],
-      "inspired_by": [
-        {
-          "reference_id": 115,
-          "type": "movie",
-          "name": "American Pie",
-          "description": "Four teenage boys enter a pact to lose their virginity by prom night. IMDb.",
-          "external_link": "https://www.imdb.com/title/tt0163651/",
-          "image_link": "https://img.youtube.com/vi/0WRQFUwEpDY/mqdefault.jpg"
-        }
-      ],
+      "inspired_by": [],
       "recipes": [
         {
           "recipe_id": 512,
@@ -37595,11 +39055,6 @@
           "tag_id": 31,
           "axis": "Difficulty",
           "name": "Beginner"
-        },
-        {
-          "tag_id": 32,
-          "axis": "Difficulty",
-          "name": "Experienced"
         },
         {
           "tag_id": 28,

--- a/datasets/ibdb.guests.json
+++ b/datasets/ibdb.guests.json
@@ -1,5 +1,92 @@
 [
   {
+    "guest_id": 76,
+    "name": "Alvin Zhou",
+    "image_link": null,
+    "appearances": [
+      {
+        "episode_id": "4-cheese-lasagna-inspired-by-one-piece",
+        "name": "4-Cheese Lasagna inspired by One Piece",
+        "published_date": "2025-08-12",
+        "youtube_link": "https://www.youtube.com/watch?v=5LNNcu-t5kE",
+        "official_link": "https://www.babi.sh/recipes/4-cheese-lasagna-inspired-by-one-piece",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1755010442/kum7nnwdyimfrjrzeslp.webp"
+      },
+      {
+        "episode_id": "18-pound-giant-fried-chicken-bowl",
+        "name": "18 Pound Giant Fried Chicken Bowl",
+        "published_date": "2025-08-11",
+        "youtube_link": "https://www.youtube.com/watch?v=WM2d4JGynXc",
+        "official_link": "https://www.babi.sh/recipes/18-pound-giant-fried-chicken-bowl",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1754941912/nm2jss7wgfnfnv7bs3oo.webp"
+      },
+      {
+        "episode_id": "28-layer-chocolate-cake",
+        "name": "28 Layer Chocolate Cake",
+        "published_date": "2025-06-06",
+        "youtube_link": "https://www.youtube.com/watch?v=ouK26QCvC9U&ab_channel=BabishCulinaryUniverse",
+        "official_link": "https://www.babi.sh/recipes/28-layer-chocolate-cake",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749225920/k1yvoateks4tp7wbhjhm.webp"
+      },
+      {
+        "episode_id": "classic-fettucine-alfredo",
+        "name": "Classic Fettuccine Alfredo",
+        "published_date": "2025-06-06",
+        "youtube_link": "https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo",
+        "official_link": "https://www.babi.sh/recipes/classic-fettucine-alfredo",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749216590/llpz2sobgkra4ttgl9kx.webp"
+      },
+      {
+        "episode_id": "copy-cat-spicy-vodka-rigatoni",
+        "name": "Copy Cat Spicy Vodka Rigatoni",
+        "published_date": "2025-06-06",
+        "youtube_link": "https://www.youtube.com/watch?v=KMUvINcrpzM",
+        "official_link": "https://www.babi.sh/recipes/copy-cat-spicy-vodka-rigatoni",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749222937/h0akjerb4dvfjjofwtkj.webp"
+      },
+      {
+        "episode_id": "chocolate-cake-milkshake-inspired-by-portillo's",
+        "name": "Chocolate Cake Milkshake inspired by Portillo's",
+        "published_date": "2025-06-04",
+        "youtube_link": "https://www.youtube.com/watch?v=NqEqOQZSXOE&pp=ygUoY2hvY29sYXRlIGNha2Ugc2hha2UgYmluZ2luZyB3aXRoIGJhYmlzaA%3D%3D",
+        "official_link": "https://www.babi.sh/recipes/chocolate-cake-milkshake-inspired-by-portillo's",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749064072/hstkkvyg9ja8s6vazkgi.webp"
+      },
+      {
+        "episode_id": "cheesecake-inspired-by-junior's-cheesecakes",
+        "name": "Cheesecake inspired by Junior's Cheesecakes",
+        "published_date": "2025-03-11",
+        "youtube_link": "https://www.youtube.com/watch?v=gQeY_wx9bsI&t=26s&ab_channel=BabishCulinaryUniverse",
+        "official_link": "https://www.babi.sh/recipes/cheesecake-inspired-by-junior's-cheesecakes",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741657095/qjrimy3opynb08w9zudl.webp"
+      },
+      {
+        "episode_id": "chicken-meatball-hotpot-inspired-by-jujutsu-kaisen",
+        "name": "Chicken Meatball Hotpot inspired By Jujutsu Kaisen",
+        "published_date": "2024-10-02",
+        "youtube_link": "https://www.youtube.com/watch?v=GymqadVYSXk&t=34s",
+        "official_link": "https://www.babi.sh/recipes/chicken-meatball-hotpot-inspired-by-jujutsu-kaisen",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727887830/cnkxewktxghxefrnq6xa.webp"
+      },
+      {
+        "episode_id": "a5-wagyu-roti-don-inspired-by-food-wars!",
+        "name": "A5 Wagyu Roti Don inspired by Food Wars!",
+        "published_date": "2024-09-12",
+        "youtube_link": "https://www.youtube.com/watch?v=VzPJE4LUxC4",
+        "official_link": "https://www.babi.sh/recipes/a5-wagyu-roti-don-inspired-by-food-wars!",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1726150996/cqreovarq8cekj22lfnt.webp"
+      },
+      {
+        "episode_id": "324-layer-croissant-inspired-by-yakitate!!-japan",
+        "name": "324 Layer Croissant inspired by Yakitate!! Japan",
+        "published_date": "2024-09-04",
+        "youtube_link": "https://www.youtube.com/watch?v=Ni8BsXyln_Q",
+        "official_link": "https://www.babi.sh/recipes/324-layer-croissant-inspired-by-yakitate!!-japan",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1725483449/qdfiijvciz0hlmgz6qrs.webp"
+      }
+    ]
+  },
+  {
     "guest_id": 55,
     "name": "Ashwin Ramdas",
     "image_link": null,
@@ -26,6 +113,36 @@
         "youtube_link": "https://www.youtube.com/watch?v=TkWmK-cplV4",
         "official_link": "https://www.babi.sh/recipes/lasagna",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715729/babishImages/undefined-269836.png"
+      }
+    ]
+  },
+  {
+    "guest_id": 75,
+    "name": "Brian Sa",
+    "image_link": null,
+    "appearances": [
+      {
+        "episode_id": "10-levels-of-cheesesteak",
+        "name": "10 Levels of Philly Cheesesteak",
+        "published_date": "2026-04-30",
+        "youtube_link": "https://www.youtube.com/watch?v=jNan4FWeQEE",
+        "official_link": "https://www.babi.sh/recipes/10-levels-of-cheesesteak",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1777507861/icg9k8c02j1h9nfo5qb7.webp"
+      }
+    ]
+  },
+  {
+    "guest_id": 79,
+    "name": "Chris Parnell",
+    "image_link": null,
+    "appearances": [
+      {
+        "episode_id": "being-with-babish-4",
+        "name": "Training like Kratos for 30 Days | Being with Babish",
+        "published_date": "2019-06-07",
+        "youtube_link": "https://www.youtube.com/watch?v=n_aq5TVb0HA",
+        "official_link": "https://www.youtube.com/watch?v=n_aq5TVb0HA",
+        "image_link": "https://img.youtube.com/vi/n_aq5TVb0HA/mqdefault.jpg"
       }
     ]
   },
@@ -59,7 +176,7 @@
       },
       {
         "episode_id": "bagels",
-        "name": "BAGELS",
+        "name": "Bagels",
         "published_date": "2019-01-24",
         "youtube_link": "https://www.youtube.com/watch?v=ZrJtpCTZk38",
         "official_link": "https://www.babi.sh/recipes/bagels",
@@ -94,6 +211,21 @@
         "youtube_link": "https://www.youtube.com/watch?v=YUDogDKMJbE",
         "official_link": "https://www.youtube.com/watch?v=YUDogDKMJbE",
         "image_link": "https://img.youtube.com/vi/YUDogDKMJbE/mqdefault.jpg"
+      }
+    ]
+  },
+  {
+    "guest_id": 84,
+    "name": "Dominique Ansel",
+    "image_link": null,
+    "appearances": [
+      {
+        "episode_id": "creme-caramel",
+        "name": "Cr\u00e8me Caramel",
+        "published_date": "2021-04-08",
+        "youtube_link": "https://www.youtube.com/watch?v=ihS8__strtM",
+        "official_link": "https://www.babi.sh/recipes/creme-caramel",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695974/babishImages/undefined-25052.png"
       }
     ]
   },
@@ -158,17 +290,47 @@
     ]
   },
   {
+    "guest_id": 80,
+    "name": "H. Jon Benjamin",
+    "image_link": null,
+    "appearances": [
+      {
+        "episode_id": "archer-margarita",
+        "name": "Margaritas inspired by Archer",
+        "published_date": "2020-05-05",
+        "youtube_link": "https://www.youtube.com/watch?v=hsPXh3yna1U",
+        "official_link": "https://www.babi.sh/recipes/archer-margarita",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695554/babishImages/undefined-521982.png"
+      }
+    ]
+  },
+  {
     "guest_id": 64,
     "name": "Isaac Toups",
     "image_link": null,
     "appearances": [
       {
         "episode_id": "cajunfood",
-        "name": "CAJUN FOOD",
+        "name": "Cajun Food",
         "published_date": "2019-09-13",
         "youtube_link": "https://www.youtube.com/watch?v=nORg_aXMsmA",
         "official_link": "https://www.babi.sh/recipes/cajunfood",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1685738278/bdfgvfer8ydjozwjsvmf.webp"
+      }
+    ]
+  },
+  {
+    "guest_id": 81,
+    "name": "Jess",
+    "image_link": null,
+    "appearances": [
+      {
+        "episode_id": "calistyle-burrito",
+        "name": "California Style Burritos",
+        "published_date": "2021-09-13",
+        "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
+        "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695451/babishImages/undefined-566187.png"
       }
     ]
   },
@@ -184,6 +346,21 @@
         "youtube_link": "https://www.youtube.com/watch?v=qbMTukAJskQ",
         "official_link": "https://www.babi.sh/recipes/chocolatelavacakes",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715705/babishImages/undefined-478519.png"
+      }
+    ]
+  },
+  {
+    "guest_id": 77,
+    "name": "Kendall Beach",
+    "image_link": null,
+    "appearances": [
+      {
+        "episode_id": "324-layer-croissant-inspired-by-yakitate!!-japan",
+        "name": "324 Layer Croissant inspired by Yakitate!! Japan",
+        "published_date": "2024-09-04",
+        "youtube_link": "https://www.youtube.com/watch?v=Ni8BsXyln_Q",
+        "official_link": "https://www.babi.sh/recipes/324-layer-croissant-inspired-by-yakitate!!-japan",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1725483449/qdfiijvciz0hlmgz6qrs.webp"
       }
     ]
   },
@@ -229,6 +406,21 @@
         "youtube_link": "https://www.youtube.com/watch?v=nEoSBL25RO4",
         "official_link": "https://www.babi.sh/recipes/buttermilk-pancakes-inspired-by-twin-peaks",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992075/k6lh85gi9qv44sgwuezx.webp"
+      }
+    ]
+  },
+  {
+    "guest_id": 82,
+    "name": "Olivia Tiedemann",
+    "image_link": null,
+    "appearances": [
+      {
+        "episode_id": "christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
+        "name": "Christmas Turkey inspired by National Lampoon's Christmas Vacation",
+        "published_date": "2025-11-29",
+        "youtube_link": "https://youtube.com/watch?v=w0pZ7MWajW8&si=r2TmnS9oJhDHIbp5",
+        "official_link": "https://www.babi.sh/recipes/christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1764189007/giyklwlgdj7x3nwbi38c.webp"
       }
     ]
   },
@@ -285,7 +477,7 @@
     "appearances": [
       {
         "episode_id": "being-with-babish-4",
-        "name": "Training like Kratos for 30 Days | Body by Babish",
+        "name": "Training like Kratos for 30 Days | Being with Babish",
         "published_date": "2019-06-07",
         "youtube_link": "https://www.youtube.com/watch?v=n_aq5TVb0HA",
         "official_link": "https://www.youtube.com/watch?v=n_aq5TVb0HA",
@@ -313,14 +505,6 @@
         "youtube_link": "https://www.youtube.com/watch?v=oM8c31ru92A",
         "official_link": "https://www.youtube.com/watch?v=oM8c31ru92A",
         "image_link": "https://img.youtube.com/vi/oM8c31ru92A/mqdefault.jpg"
-      },
-      {
-        "episode_id": "being-with-babish-4",
-        "name": "Training like Kratos for 30 Days | Body by Babish",
-        "published_date": "2019-06-07",
-        "youtube_link": "https://www.youtube.com/watch?v=n_aq5TVb0HA",
-        "official_link": "https://www.youtube.com/watch?v=n_aq5TVb0HA",
-        "image_link": "https://img.youtube.com/vi/n_aq5TVb0HA/mqdefault.jpg"
       },
       {
         "episode_id": "being-with-babish-3",
@@ -395,6 +579,21 @@
     ]
   },
   {
+    "guest_id": 78,
+    "name": "Sohla El-Waylly",
+    "image_link": null,
+    "appearances": [
+      {
+        "episode_id": "andrewsohlathanksgiving",
+        "name": "Thanksgiving Recipe Livestream with Sohla El-Waylly",
+        "published_date": "2020-11-20",
+        "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
+        "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715526/babishImages/undefined-665559.jpg"
+      }
+    ]
+  },
+  {
     "guest_id": 70,
     "name": "Sukki Hufford",
     "image_link": null,
@@ -459,6 +658,21 @@
         "youtube_link": "https://www.youtube.com/watch?v=TkWmK-cplV4",
         "official_link": "https://www.babi.sh/recipes/lasagna",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715729/babishImages/undefined-269836.png"
+      }
+    ]
+  },
+  {
+    "guest_id": 83,
+    "name": "You Suck at Cooking",
+    "image_link": null,
+    "appearances": [
+      {
+        "episode_id": "clayroastedthigh",
+        "name": "Clay-Roasted Thigh inspired by Hannibal",
+        "published_date": "2017-10-31",
+        "youtube_link": "https://www.youtube.com/watch?v=lnB7svFAZBs&amp;t=2s",
+        "official_link": "https://www.babi.sh/recipes/clayroastedthigh",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715438/babishImages/undefined-943571.png"
       }
     ]
   }

--- a/datasets/ibdb.recipes.json
+++ b/datasets/ibdb.recipes.json
@@ -1,5 +1,110 @@
 [
   {
+    "recipe_id": 1507,
+    "name": "$10 meatballs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-levels-of-spaghetti-or-with-babish",
+      "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
+      "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769797846/qlt7lmqzvuonokq8elpd.webp"
+    }
+  },
+  {
+    "recipe_id": 1506,
+    "name": "$10 spaghetti and meatballs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-levels-of-spaghetti-or-with-babish",
+      "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
+      "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769797846/qlt7lmqzvuonokq8elpd.webp"
+    }
+  },
+  {
+    "recipe_id": 1502,
+    "name": "$1 spaghetti and meatballs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-levels-of-spaghetti-or-with-babish",
+      "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
+      "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769797846/qlt7lmqzvuonokq8elpd.webp"
+    }
+  },
+  {
+    "recipe_id": 1522,
+    "name": "$200 beef wellington",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "beef-wellington-or-with-babish",
+      "name": "$20 vs $200 Beef Wellington | With Babish",
+      "published_date": "2025-12-23",
+      "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
+      "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
+    }
+  },
+  {
+    "recipe_id": 1524,
+    "name": "$20 beef wellington",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "beef-wellington-or-with-babish",
+      "name": "$20 vs $200 Beef Wellington | With Babish",
+      "published_date": "2025-12-23",
+      "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
+      "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
+    }
+  },
+  {
+    "recipe_id": 1508,
+    "name": "$25 spaghetti and meatballs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-levels-of-spaghetti-or-with-babish",
+      "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
+      "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769797846/qlt7lmqzvuonokq8elpd.webp"
+    }
+  },
+  {
+    "recipe_id": 1509,
+    "name": "$50 spaghetti and meatballs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-levels-of-spaghetti-or-with-babish",
+      "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
+      "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769797846/qlt7lmqzvuonokq8elpd.webp"
+    }
+  },
+  {
     "recipe_id": 1205,
     "name": "10 Levels of Chocolate Chip Cookies | With Babish",
     "image_link": null,
@@ -27,6 +132,36 @@
       "youtube_link": "https://www.youtube.com/watch?v=xGHTj4y_bd8",
       "official_link": "https://www.babi.sh/recipes/butterednoodles-community",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695894/babishImages/undefined-831336.png"
+    }
+  },
+  {
+    "recipe_id": 1276,
+    "name": "324 layer croissant",
+    "image_link": null,
+    "raw_ingredient_list": "croissant dough scraps\ncroissant dough\nlayer croissant dough",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "324-layer-croissant-inspired-by-yakitate!!-japan",
+      "name": "324 Layer Croissant inspired by Yakitate!! Japan",
+      "published_date": "2024-09-04",
+      "youtube_link": "https://www.youtube.com/watch?v=Ni8BsXyln_Q",
+      "official_link": "https://www.babi.sh/recipes/324-layer-croissant-inspired-by-yakitate!!-japan",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1725483449/qdfiijvciz0hlmgz6qrs.webp"
+    }
+  },
+  {
+    "recipe_id": 1216,
+    "name": "4-Cheese Lasagna",
+    "image_link": null,
+    "raw_ingredient_list": "hot italian sausage casings removed\nsweet italian sausage casings removed\nmilk ricotta cheese\nno boil lasagna noodles for flat layers\nlow moisture mozzarella thinly\npecorino cheese\nparmesan",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "4-cheese-lasagna-inspired-by-one-piece",
+      "name": "4-Cheese Lasagna inspired by One Piece",
+      "published_date": "2025-08-12",
+      "youtube_link": "https://www.youtube.com/watch?v=5LNNcu-t5kE",
+      "official_link": "https://www.babi.sh/recipes/4-cheese-lasagna-inspired-by-one-piece",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1755010442/kum7nnwdyimfrjrzeslp.webp"
     }
   },
   {
@@ -82,7 +217,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "advanced-grilled-cheese",
-      "name": "ADVANCED GRILLED CHEESE",
+      "name": "Advanced Grilled Cheese",
       "published_date": "2021-02-19",
       "youtube_link": "https://www.youtube.com/watch?v=Zo7sRijXG00",
       "official_link": "https://www.babi.sh/recipes/advanced-grilled-cheese",
@@ -150,6 +285,21 @@
     }
   },
   {
+    "recipe_id": 1242,
+    "name": "Agua de Jamaica Granita",
+    "image_link": null,
+    "raw_ingredient_list": "dried sorrel\ncinnamon orange peel, or a few cloves,\nheavy cream\nsweetened condensed milk",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "agua-de-jamaica-granita",
+      "name": "Agua de Jamaica Granita",
+      "published_date": "2025-04-29",
+      "youtube_link": "https://www.youtube.com/shorts/NYPxT4K-jEw",
+      "official_link": "https://www.babi.sh/recipes/agua-de-jamaica-granita",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1745960432/nlcsou9whnpdevviupw4.webp"
+    }
+  },
+  {
     "recipe_id": 1031,
     "name": "Alabama Style White Sauce",
     "image_link": null,
@@ -207,21 +357,6 @@
       "youtube_link": "https://www.youtube.com/watch?v=Mf4wwXM2o_M",
       "official_link": "https://www.babi.sh/recipes/everymeatburrito",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715513/babishImages/undefined-6335.png"
-    }
-  },
-  {
-    "recipe_id": 1270,
-    "name": "alvin's version",
-    "image_link": null,
-    "raw_ingredient_list": "garlic thinly\nparsley\nbeef tallow butter\nbutter\nsalt",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "a5-wagyu-roti-don-inspired-by-food-wars!",
-      "name": "A5 Wagyu Roti Don inspired by Food Wars!",
-      "published_date": "2024-09-12",
-      "youtube_link": "https://www.youtube.com/watch?v=VzPJE4LUxC4",
-      "official_link": "https://www.babi.sh/recipes/a5-wagyu-roti-don-inspired-by-food-wars!",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1726150996/cqreovarq8cekj22lfnt.webp"
     }
   },
   {
@@ -352,7 +487,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "apple-cider-donuts",
-      "name": "APPLE CIDER DONUTS",
+      "name": "Apple Cider Donuts",
       "published_date": "2021-11-09",
       "youtube_link": "https://www.youtube.com/watch?v=baZoJYAQjfI",
       "official_link": "https://www.babi.sh/recipes/apple-cider-donuts",
@@ -420,6 +555,21 @@
     }
   },
   {
+    "recipe_id": 680,
+    "name": "Apple Pie Filling",
+    "image_link": null,
+    "raw_ingredient_list": "2lbs honey crisp apples, peeled and sliced\n1 lemon, juiced\n\u00be cup sugar\n1 \u00bd Tbsp cornstarch\n\u00bc cup brown sugar\n2 tsp cinnamon\n\u00bd tsp ground ginger\n\u00bd tsp allspice\n\u00bc tsp ground clove\nZest of 1 lemon\n1 tsp kosher salt\n1 egg white\nDemerara sugar",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ben-wyatt-calzones",
+      "name": "Ben Wyatt's Calzones",
+      "published_date": "2020-04-15",
+      "youtube_link": "https://www.youtube.com/watch?v=PvgCEifW7Jo",
+      "official_link": "https://www.babi.sh/recipes/ben-wyatt-calzones",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695309/babishImages/undefined-56906.png"
+    }
+  },
+  {
     "recipe_id": 512,
     "name": "Apple Pie Smoothie",
     "image_link": null,
@@ -432,6 +582,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=mv1z2p3to0U",
       "official_link": "https://www.babi.sh/recipes/applepiesmoothie",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991771/oz6gen69krvy3tfzijvm.webp"
+    }
+  },
+  {
+    "recipe_id": 1649,
+    "name": "applesauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "pierogis",
+      "name": "PIEROGIS",
+      "published_date": "2023-02-24",
+      "youtube_link": "https://www.youtube.com/watch?v=58hC3MCVwkw",
+      "official_link": "https://www.babi.sh/recipes/pierogis",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690353185/d6hdqdddrsens6ovoe07.webp"
     }
   },
   {
@@ -582,21 +747,6 @@
       "youtube_link": "https://www.youtube.com/watch?v=fypEVSous_g",
       "official_link": "https://www.babi.sh/recipes/meatball-smashwich-with-babish",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1762019441/c8sbuzgg2n73jmsphlhg.webp"
-    }
-  },
-  {
-    "recipe_id": 1216,
-    "name": "assembly",
-    "image_link": null,
-    "raw_ingredient_list": "hot italian sausage casings removed\nsweet italian sausage casings removed\nmilk ricotta cheese\nno boil lasagna noodles for flat layers\nlow moisture mozzarella thinly\npecorino cheese\nparmesan",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "4-cheese-lasagna-inspired-by-one-piece",
-      "name": "4-Cheese Lasagna inspired by One Piece",
-      "published_date": "2025-08-12",
-      "youtube_link": "https://www.youtube.com/watch?v=5LNNcu-t5kE",
-      "official_link": "https://www.babi.sh/recipes/4-cheese-lasagna-inspired-by-one-piece",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1755010442/kum7nnwdyimfrjrzeslp.webp"
     }
   },
   {
@@ -982,7 +1132,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "bacon",
-      "name": "HOMEMADE BACON",
+      "name": "Homemade Bacon",
       "published_date": "2021-04-30",
       "youtube_link": "https://www.youtube.com/watch?v=TUh4Z2li1UM",
       "official_link": "https://www.babi.sh/recipes/bacon",
@@ -1017,21 +1167,6 @@
       "youtube_link": "https://www.youtube.com/watch?v=nowFI0WRpO0",
       "official_link": "https://www.babi.sh/recipes/bachelor-chow-futurama",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696129/babishImages/undefined-898773.png"
-    }
-  },
-  {
-    "recipe_id": 1412,
-    "name": "babish chicken picatta",
-    "image_link": null,
-    "raw_ingredient_list": "flour\nchicken stock preferably homemade\ncapellini spaghetti, or angel hair pasta,\nlinguini\nunsalted butter &\ndry white wine\ncapers\ncapers drained",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "chicken-piccata",
-      "name": "CHICKEN PICCATA",
-      "published_date": "2022-02-18",
-      "youtube_link": "https://www.youtube.com/watch?v=ZqEqtmMY1M0",
-      "official_link": "https://www.babi.sh/recipes/chicken-piccata",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695515/babishImages/undefined-561520.png"
     }
   },
   {
@@ -1170,6 +1305,21 @@
     }
   },
   {
+    "recipe_id": 1206,
+    "name": "Babish's Ultimate Fried Chicken",
+    "image_link": null,
+    "raw_ingredient_list": "flour\nchicken broken down into ten pieces\nbuttermilk\nsalt\npotato starch\nwhite rice flour\nliquid egg whites",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "babish's-ultimate-fried-chicken",
+      "name": "Babish\u2019s Ultimate Fried Chicken",
+      "published_date": "2025-10-23",
+      "youtube_link": "https://www.youtube.com/watch?v=yvKf6aDxBLk",
+      "official_link": "https://www.babi.sh/recipes/babish's-ultimate-fried-chicken",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1761246372/oljov21inpdw2zrpqypy.webp"
+    }
+  },
+  {
     "recipe_id": 1189,
     "name": "Babish Sweet Potato Casserole",
     "image_link": null,
@@ -1185,6 +1335,21 @@
     }
   },
   {
+    "recipe_id": 1550,
+    "name": "babish version",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "name": "Fallout Fancy Lad Snack Cakes inspired by Fallout 76",
+      "published_date": "2025-10-01",
+      "youtube_link": "https://www.youtube.com/watch?v=v1f835eNhUc",
+      "official_link": "https://www.babi.sh/recipes/fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759334763/qv57em4y8nloxgzztjrs.webp"
+    }
+  },
+  {
     "recipe_id": 441,
     "name": "Babka",
     "image_link": null,
@@ -1193,7 +1358,7 @@
     "source": {
       "episode_id": "babka-inspired-by-seinfeld",
       "name": "Babka inspired by Seinfeld",
-      "published_date": "2017-05-10",
+      "published_date": "2017-05-09",
       "youtube_link": "https://www.youtube.com/watch?v=pw2A03Z91FI",
       "official_link": "https://www.babi.sh/recipes/babka-inspired-by-seinfeld",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp"
@@ -1212,6 +1377,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=basFyoMSjds",
       "official_link": "https://www.babi.sh/recipes/bobsburgers",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992045/htwpdlxcj4iomemedrez.webp"
+    }
+  },
+  {
+    "recipe_id": 1529,
+    "name": "bacon",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "coq-au-vin",
+      "name": "Coq au Vin",
+      "published_date": "2025-10-11",
+      "youtube_link": "https://www.youtube.com/watch?v=cf1H6ylUFH4",
+      "official_link": "https://www.babi.sh/recipes/coq-au-vin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1760217634/qggynlnkmhze8roieemn.webp"
     }
   },
   {
@@ -1284,7 +1464,7 @@
       "episode_id": "bagelsandwiches",
       "name": "Bagel Sandwiches inspired by Steven Universe",
       "published_date": "2019-07-23",
-      "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
       "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png"
     }
@@ -1297,7 +1477,7 @@
     "raw_procedure": "In a food processor add: 14.66 ounces of bread flour, 4 tsp of vital wheat gluten, and 2 tsp of instant yeast. Pulse to combine.\nNext combine 9 ounces of cold water and 2 Tbsp of malt syrup in a bowl. Whisk to mix. Turn food processor on low and add the cold water and malt syrup mixture. Mix for about 20 seconds, stop, and let it sit for 10 minutes. Once it has rested for 10 minutes, add 2 tsp of salt. Turn the food processor on medium to high for about 90 seconds.\nRemove dough from food processor and knead for about a minute. Next, divide dough into 3.5 ounce pieces. Roll the pieces into tight balls and cover with plastic wrap and let rest for 15 minutes. Once they have rested, decide which method you will use to turn your balls of dough into bagels. For the best tutorial, watch the episode to see the difference in the methods.\nOption 1 - Twist Method: Roll out a piece of dough with a rolling pin until it\u2019s roughly 5 inches across. Next, start from one end of the circle and start rolling the dough onto itself. Once it is rolled into a tight roll that is 9-10 inches long, it\u2019s time to twist the dough. Place one hand on each side of the dough roll and then roll the ends in opposite directions to create the \u201ctwist\u201d. Wrap the dough around your hand and then pinch the ends together. With the ring of dough still wrapped around your hand, roll the dough on your work surface to seal together.\nOption 2 - Punch Method: Take a ball of dough and place it on your work surface. Stick one finger into the center and shake the dough around your finger until a round hole forms. Pick up the dough and shape it with two fingers, coaxing it into a bagel shape. This method is easier, but doesn\u2019t yield as great of a bagel texture as the twist method.\nPlace the bagels on a baking sheet covered in cornmeal. Cover that with plastic wrap and let sit for an hour. Once they\u2019ve sat for an hour, place them in the fridge overnight or for 24 hours.\nBring water in a pot to a boil and add \u00bc cup of sugar and 1 Tbsp of baking soda. Add the bagels to the water and boil for about 20 seconds on each side.\nRemove and place them on a wire rimmed baking sheet, making sure the cornmeal side is down. If you\u2019d like to add toppings, now is the time to do it.\nAdd \u00bd cup of boiling water to the bottom of the pan and then place in the oven at 450\u00b0F for 20 to 25 minutes flipping them halfway through.\nLet cool, serve, and enjoy!",
     "source": {
       "episode_id": "bagels",
-      "name": "BAGELS",
+      "name": "Bagels",
       "published_date": "2019-01-24",
       "youtube_link": "https://www.youtube.com/watch?v=ZrJtpCTZk38",
       "official_link": "https://www.babi.sh/recipes/bagels",
@@ -1329,7 +1509,7 @@
       "episode_id": "bagelsandwiches",
       "name": "Bagel Sandwiches inspired by Steven Universe",
       "published_date": "2019-07-23",
-      "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
       "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png"
     }
@@ -1344,7 +1524,7 @@
       "episode_id": "bagelsandwiches",
       "name": "Bagel Sandwiches inspired by Steven Universe",
       "published_date": "2019-07-23",
-      "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
       "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png"
     }
@@ -1359,7 +1539,7 @@
       "episode_id": "bagelsandwiches",
       "name": "Bagel Sandwiches inspired by Steven Universe",
       "published_date": "2019-07-23",
-      "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
       "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png"
     }
@@ -1374,7 +1554,7 @@
       "episode_id": "bagelsandwiches",
       "name": "Bagel Sandwiches inspired by Steven Universe",
       "published_date": "2019-07-23",
-      "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
       "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png"
     }
@@ -1422,21 +1602,6 @@
       "youtube_link": "https://www.youtube.com/watch?v=z4Bwb8_k7yM",
       "official_link": "https://www.babi.sh/recipes/the-sims-special",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1680347083/v6pyttpnbczp1opgeaug.webp"
-    }
-  },
-  {
-    "recipe_id": 1337,
-    "name": "baked bacon",
-    "image_link": null,
-    "raw_ingredient_list": "boneless skinless chicken breast butterfied\nbuttermilk\nflour",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "crispiest-sandwich-kidnapped-on-christmas",
-      "name": "The Crispiest Sandwich inspired by They Kidnapped my Son on Christmas",
-      "published_date": "2023-08-09",
-      "youtube_link": "https://www.youtube.com/watch?v=mhLM0FUlhJg",
-      "official_link": "https://www.babi.sh/recipes/crispiest-sandwich-kidnapped-on-christmas",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1695094920/vr0vqmqsilm4by7affx7.webp"
     }
   },
   {
@@ -1507,7 +1672,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "barbacoa-de-res",
-      "name": "BARBACOA DE RES CON CONSOM\u00c9",
+      "name": "Barbacoa Tacos and Gringas de Barbacoa with Consom\u00e9 | Pru\u00e9balo with Rick Martinez",
       "published_date": "2023-05-05",
       "youtube_link": "https://www.youtube.com/watch?v=Ya5u2uC3d2U",
       "official_link": "https://www.babi.sh/recipes/barbacoa-de-res",
@@ -1538,7 +1703,7 @@
     "source": {
       "episode_id": "cocktail-special",
       "name": "Cocktail Special",
-      "published_date": "2017-06-28",
+      "published_date": "2017-06-27",
       "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
       "official_link": "https://www.babi.sh/recipes/cocktail-special",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -1582,7 +1747,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "advanced-grilled-cheese",
-      "name": "ADVANCED GRILLED CHEESE",
+      "name": "Advanced Grilled Cheese",
       "published_date": "2021-02-19",
       "youtube_link": "https://www.youtube.com/watch?v=Zo7sRijXG00",
       "official_link": "https://www.babi.sh/recipes/advanced-grilled-cheese",
@@ -1602,6 +1767,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=SfNgpLkV6KE&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/SfNgpLkV6KE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
       "official_link": "https://www.babi.sh/recipes/mostexpensiveshake",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695865/babishImages/undefined-614460.png"
+    }
+  },
+  {
+    "recipe_id": 1604,
+    "name": "basic egg salad sandwich",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "egg-salad-inspired-by-futurama",
+      "name": "Egg Salad inspired by Futurama",
+      "published_date": "2025-03-07",
+      "youtube_link": "https://www.youtube.com/watch?v=cgLi9t6w9Qc&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/egg-salad-inspired-by-futurama",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741383035/fhpr01pnfwh4o1lpeje9.webp"
     }
   },
   {
@@ -1695,18 +1875,18 @@
     }
   },
   {
-    "recipe_id": 1339,
-    "name": "basil gel",
+    "recipe_id": 1654,
+    "name": "basil oil",
     "image_link": null,
-    "raw_ingredient_list": "gelatin sheets\nflour\ndeli style low moisture mozzarella cheese\ntomatoes on the vine\ntomato paste\nvegetable oil more for greasing\nbasil",
+    "raw_ingredient_list": "",
     "raw_procedure": "",
     "source": {
-      "episode_id": "chicago-deep-dish-the-bear",
-      "name": "Chicago Deep Dish Pizza inspired by The Bear",
-      "published_date": "2023-07-21",
-      "youtube_link": "https://www.youtube.com/watch?v=Ris0udk2C84",
-      "official_link": "https://www.babi.sh/recipes/chicago-deep-dish-the-bear",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690249416/oxrjvgjzaljdvfvtinpj.webp"
+      "episode_id": "date-night-2",
+      "name": "DATE NIGHT II",
+      "published_date": "2022-01-11",
+      "youtube_link": "https://www.youtube.com/watch?v=dlATzLk8Nh8",
+      "official_link": "https://www.babi.sh/recipes/date-night-2",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1680979695/cbadjt8l6pkrdiadhks1.webp"
     }
   },
   {
@@ -1737,21 +1917,6 @@
       "youtube_link": "https://www.youtube.com/watch?v=lhc_bXGvmp0",
       "official_link": "https://www.babi.sh/recipes/szechuansaucerevisited",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715749/babishImages/undefined-396765.png"
-    }
-  },
-  {
-    "recipe_id": 1206,
-    "name": "batter dredge",
-    "image_link": null,
-    "raw_ingredient_list": "flour\nchicken broken down into ten pieces\nbuttermilk\nsalt\npotato starch\nwhite rice flour\nliquid egg whites",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "babish's-ultimate-fried-chicken",
-      "name": "Babish\u2019s Ultimate Fried Chicken",
-      "published_date": "2025-10-23",
-      "youtube_link": "https://www.youtube.com/watch?v=yvKf6aDxBLk",
-      "official_link": "https://www.babi.sh/recipes/babish's-ultimate-fried-chicken",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1761246372/oljov21inpdw2zrpqypy.webp"
     }
   },
   {
@@ -1794,7 +1959,7 @@
       "episode_id": "bubbashrimp2",
       "name": "Shrimp inspired by Forrest Gump Part II",
       "published_date": "2019-04-23",
-      "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/mF6JUfczaO8/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8",
       "official_link": "https://www.babi.sh/recipes/bubbashrimp2",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696055/babishImages/undefined-252668.png"
     }
@@ -1839,7 +2004,7 @@
       "episode_id": "bearstew",
       "name": "Bear Stew inspired by Red Dead Redemption 2",
       "published_date": "2018-11-06",
-      "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wMxKbkWrvDc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc",
       "official_link": "https://www.babi.sh/recipes/bearstew",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679263840/iyxpvkao4lwi6xqkcwd1.webp"
     }
@@ -1897,7 +2062,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "advanced-grilled-cheese",
-      "name": "ADVANCED GRILLED CHEESE",
+      "name": "Advanced Grilled Cheese",
       "published_date": "2021-02-19",
       "youtube_link": "https://www.youtube.com/watch?v=Zo7sRijXG00",
       "official_link": "https://www.babi.sh/recipes/advanced-grilled-cheese",
@@ -1920,21 +2085,6 @@
     }
   },
   {
-    "recipe_id": 1294,
-    "name": "beef",
-    "image_link": null,
-    "raw_ingredient_list": "top sirloin butt",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "chicago-style-italian-beef-inspired-by-the-bear",
-      "name": "Chicago-Style Italian Beef inspired by The Bear",
-      "published_date": "2024-07-08",
-      "youtube_link": "https://www.youtube.com/watch?v=xrXDdlrcuKs",
-      "official_link": "https://www.babi.sh/recipes/chicago-style-italian-beef-inspired-by-the-bear",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1720451211/caje3wf74d8gwuq8hbjn.webp"
-    }
-  },
-  {
     "recipe_id": 272,
     "name": "Beef and Vegetable Kebabs",
     "image_link": null,
@@ -1950,6 +2100,36 @@
     }
   },
   {
+    "recipe_id": 1647,
+    "name": "beef filling",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "pierogis",
+      "name": "PIEROGIS",
+      "published_date": "2023-02-24",
+      "youtube_link": "https://www.youtube.com/watch?v=58hC3MCVwkw",
+      "official_link": "https://www.babi.sh/recipes/pierogis",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690353185/d6hdqdddrsens6ovoe07.webp"
+    }
+  },
+  {
+    "recipe_id": 1591,
+    "name": "beef patties",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "japanese-style-big-mac-inspired-by-weathering-with-you",
+      "name": "Japanese-Style Big Mac inspired by Weathering with You",
+      "published_date": "2025-03-19",
+      "youtube_link": "https://www.youtube.com/watch?v=BzKBag59duU&pp=ygUTYWx2aW4gamFwYW4gYmlnIG1hYw%3D%3D",
+      "official_link": "https://www.babi.sh/recipes/japanese-style-big-mac-inspired-by-weathering-with-you",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1742407838/ofwjdoqrkbbijmlqiu7e.webp"
+    }
+  },
+  {
     "recipe_id": 1326,
     "name": "beef patty filling",
     "image_link": null,
@@ -1962,6 +2142,36 @@
       "youtube_link": "https://www.youtube.com/watch?v=Yg6uZIpzHBI&pp=ygUGYmFiaXNo",
       "official_link": "https://www.babi.sh/recipes/spiderverse-beef-patty",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1702402526/rtanhmhfoh4kpnfdqyp8.webp"
+    }
+  },
+  {
+    "recipe_id": 1517,
+    "name": "beef prep",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ultimate-pot-roast-or-with-babish",
+      "name": "Ultimate Pot Roast | With Babish",
+      "published_date": "2026-01-15",
+      "youtube_link": "https://www.youtube.com/watch?v=5_7pC4K-Y1g",
+      "official_link": "https://www.babi.sh/recipes/ultimate-pot-roast-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768506428/gryanukvd2zeutfh9ibh.webp"
+    }
+  },
+  {
+    "recipe_id": 1525,
+    "name": "beef prep ($20 wellington)",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "beef-wellington-or-with-babish",
+      "name": "$20 vs $200 Beef Wellington | With Babish",
+      "published_date": "2025-12-23",
+      "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
+      "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
     }
   },
   {
@@ -2077,11 +2287,26 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "corned-beef",
-      "name": "CORNED BEEF",
+      "name": "Corned Beef",
       "published_date": "2022-03-17",
       "youtube_link": "https://www.youtube.com/watch?v=IDkuwVvZpWM",
       "official_link": "https://www.babi.sh/recipes/corned-beef",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695564/babishImages/undefined-160589.png"
+    }
+  },
+  {
+    "recipe_id": 1372,
+    "name": "beer can chicken",
+    "image_link": null,
+    "raw_ingredient_list": "chicken\nbaby potatoes\nbrussels sprouts\nbeer\nhen of the wood or maitake mushrooms\nchicken stock\ngarlic cloves smashed",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "beer-can-chicken",
+      "name": "BEER CAN CHICKEN",
+      "published_date": "2022-12-18",
+      "youtube_link": "https://www.youtube.com/watch?v=Xo0v7ZuA9C0",
+      "official_link": "https://www.babi.sh/recipes/beer-can-chicken",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png"
     }
   },
   {
@@ -2092,26 +2317,11 @@
     "raw_procedure": "Start by chopping 2 pounds of sharp cheddar cheese into \u00bd inch cubes. Place the cheese cubes into a bowl and add 1 Tbsp of cornstarch. Toss to combine.\nBring 1 Mexican beer to a boil in cast iron pan and then slowly add your cheese cubes. Do it in about 4 batches, adding some cheese and then mixing until it\u2019s smooth and combined before adding more cheese.\nOnce you\u2019ve added all the cheese, add \u00bc cup chopped red pepper, a pinch of salt and some cayenne pepper. Mix to combine.\nPlace under the broiler for 3-5 minutes or until golden brown on top before topping with \u00bc cup chopped red onion and 1 sliced jalapeno.\nServe with tortilla chips and enjoy!",
     "source": {
       "episode_id": "cheesdips",
-      "name": "CHEESE DIPS",
+      "name": "Cheese Dips",
       "published_date": "2019-05-02",
       "youtube_link": "https://www.youtube.com/watch?v=9toK5UUGeok",
       "official_link": "https://www.babi.sh/recipes/cheesdips",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1686005952/sgzpqqlxhdnjser57r5j.webp"
-    }
-  },
-  {
-    "recipe_id": 1372,
-    "name": "beer chicken",
-    "image_link": null,
-    "raw_ingredient_list": "chicken\nbaby potatoes\nbrussels sprouts\nbeer\nhen of the wood or maitake mushrooms\nchicken stock\ngarlic cloves smashed",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "beer-can-chicken",
-      "name": "BEER CAN CHICKEN",
-      "published_date": "2022-12-19",
-      "youtube_link": "https://www.youtube.com/watch?v=Xo0v7ZuA9C0",
-      "official_link": "https://www.babi.sh/recipes/beer-can-chicken",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png"
     }
   },
   {
@@ -2124,7 +2334,7 @@
       "episode_id": "beer-steamed-chili-dogs",
       "name": "Chili Dogs inspired by The Irishman",
       "published_date": "2019-12-17",
-      "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/c0A1bkF4mKM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM",
       "official_link": "https://www.babi.sh/recipes/beer-steamed-chili-dogs",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695792/babishImages/undefined-202970.png"
     }
@@ -2190,6 +2400,21 @@
     }
   },
   {
+    "recipe_id": 1536,
+    "name": "beurre mont\u00e9 sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "coq-au-vin",
+      "name": "Coq au Vin",
+      "published_date": "2025-10-11",
+      "youtube_link": "https://www.youtube.com/watch?v=cf1H6ylUFH4",
+      "official_link": "https://www.babi.sh/recipes/coq-au-vin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1760217634/qggynlnkmhze8roieemn.webp"
+    }
+  },
+  {
     "recipe_id": 406,
     "name": "Biga",
     "image_link": null,
@@ -2220,21 +2445,6 @@
     }
   },
   {
-    "recipe_id": 127,
-    "name": "Big Cracker",
-    "image_link": null,
-    "raw_ingredient_list": "10 ounces all purpose flour\n3 tsp baking powder\n\u00bd tsp kosher salt\n1 Tbsp granulated sugar\n6 Tbsp cold butter\n2 Tbsp vegetable oil\n\u2154 cup ice water",
-    "raw_procedure": "In a food processor add 10 ounces of all purpose flour along with 3 tsp of baking powder, \u00bd tsp of kosher salt, and 1 Tbsp of granulated sugar. Pulse to combine.\nNext add 6 Tbsp of sliced cold butter along with 2 Tbsp of vegetable oil and mix to combine before drizzling \u2154 cup of ice cold water into the food processor while it\u2019s processing. When a ball of dough forms, remove and immediately wrap in plastic wrap and place in the fridge for 10-15 minutes.\nRemove dough from the fridge and liberally flour your work surface. Roll out your dough as thin as possible. Using a fluted biscuit cutter, cut out cracker shapes and place them on a parchment lined baking sheet. Using a toothpick add the signature Ritz Cracker 7 holes and then brush all of them down with some melted butter. Place in a 400\u00b0F oven for 10-15 minutes.\nOnce they are golden brown in the oven, remove and brush with butter and immediately sprinkle with some salt.",
-    "source": {
-      "episode_id": "aristocats",
-      "name": "Cr\u00e8me de la Cr\u00e8me \u00e0 la Edgar inspired by The Aristocats",
-      "published_date": "2019-01-23",
-      "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/zNY-qzp7pD0/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
-      "official_link": "https://www.babi.sh/recipes/aristocats",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696317/babishImages/undefined-541474.png"
-    }
-  },
-  {
     "recipe_id": 488,
     "name": "Big Kahuna Burger",
     "image_link": null,
@@ -2257,7 +2467,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "birria-tacos",
-      "name": "BIRRIA TACOS",
+      "name": "Birria Tacos",
       "published_date": "2021-03-11",
       "youtube_link": "https://www.youtube.com/watch?v=pQmSrlIbULk",
       "official_link": "https://www.babi.sh/recipes/birria-tacos",
@@ -2272,8 +2482,8 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "cake-pops",
-      "name": "CAKE POPS",
-      "published_date": "2021-11-02",
+      "name": "Cake Pops",
+      "published_date": "2021-10-21",
       "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
       "official_link": "https://www.babi.sh/recipes/cake-pops",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
@@ -2302,7 +2512,7 @@
     "raw_procedure": "In a saucepan combine 1 cup of water with 3 Tbsp of dark brown sugar and 4 Tbsp of butter. Stir to combine. Once fully incorporated, remove from heat and add 1 cup of all purpose flour. Mix vigorously until a stiff ball of dough forms.\nNext, add 2 beaten eggs and mix slowly at first and then vigorously again until fully combined and pastelike. Add dough to a pastry bag with a large star shaped tip.\nIn a pot bring oil to 375\u00b0F. Squeeze dough out of bag into about 1 inch pieces, using scissors to trim. Let fry for 2 minutes and flip constantly to make sure all sides are evenly browned.\nDrain on some paper towels.\nIn a bowl combine 1 cup white sugar with 1 Tbsp cinnamon. Add your churros to that bowl and make sure they\u2019re fully covered in the cinnamon sugar mixture.\nServe with your favorite dipping sauce and enjoy!",
     "source": {
       "episode_id": "biggamesnacks",
-      "name": "BIG GAME SNACKS",
+      "name": "Big Game Snacks",
       "published_date": "2019-01-31",
       "youtube_link": "https://www.youtube.com/watch?v=8ckxhlDFNkg",
       "official_link": "https://www.babi.sh/recipes/biggamesnacks",
@@ -2445,6 +2655,21 @@
     }
   },
   {
+    "recipe_id": 1264,
+    "name": "Blooming Fish",
+    "image_link": null,
+    "raw_ingredient_list": "corn starch\npotato starch\nblack sea bass\nneutral oil\nshaoxing cooking wine\nsalt\n40g white vinegar",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "blooming-fish-inspired-by-cinderella-chef",
+      "name": "Blooming Fish inspired by Cinderella Chef",
+      "published_date": "2024-10-02",
+      "youtube_link": "https://www.youtube.com/watch?v=DAwamRa8m9Y",
+      "official_link": "https://www.babi.sh/recipes/blooming-fish-inspired-by-cinderella-chef",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727902497/v0e6pzds2idrfzg2dqbj.webp"
+    }
+  },
+  {
     "recipe_id": 415,
     "name": "Blueberry Pancake",
     "image_link": null,
@@ -2565,6 +2790,21 @@
     }
   },
   {
+    "recipe_id": 1632,
+    "name": "boiled eggs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "the-egg-bar-inspired-by-severance",
+      "name": "The Egg Bar inspired by Severance",
+      "published_date": "2025-02-05",
+      "youtube_link": "https://www.youtube.com/watch?v=pTt4BjY34gk&t=151s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/the-egg-bar-inspired-by-severance",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1738792005/emlcx8fw10frbl32t7lq.webp"
+    }
+  },
+  {
     "recipe_id": 249,
     "name": "Boiled Shrimp",
     "image_link": null,
@@ -2610,6 +2850,21 @@
     }
   },
   {
+    "recipe_id": 1539,
+    "name": "boneless short ribs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "steak",
+      "name": "Steak",
+      "published_date": "2025-10-03",
+      "youtube_link": "https://www.youtube.com/watch?v=peAbYlvP6rU",
+      "official_link": "https://www.babi.sh/recipes/steak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759667611/ivsyx6hgxw8cwudn9brl.webp"
+    }
+  },
+  {
     "recipe_id": 1356,
     "name": "bordelaise sauce",
     "image_link": null,
@@ -2640,6 +2895,36 @@
     }
   },
   {
+    "recipe_id": 1519,
+    "name": "bouquet garni",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ultimate-pot-roast-or-with-babish",
+      "name": "Ultimate Pot Roast | With Babish",
+      "published_date": "2026-01-15",
+      "youtube_link": "https://www.youtube.com/watch?v=5_7pC4K-Y1g",
+      "official_link": "https://www.babi.sh/recipes/ultimate-pot-roast-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768506428/gryanukvd2zeutfh9ibh.webp"
+    }
+  },
+  {
+    "recipe_id": 1531,
+    "name": "bouquet garni",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "coq-au-vin",
+      "name": "Coq au Vin",
+      "published_date": "2025-10-11",
+      "youtube_link": "https://www.youtube.com/watch?v=cf1H6ylUFH4",
+      "official_link": "https://www.babi.sh/recipes/coq-au-vin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1760217634/qggynlnkmhze8roieemn.webp"
+    }
+  },
+  {
     "recipe_id": 891,
     "name": "Bourbon Caramel",
     "image_link": null,
@@ -2652,6 +2937,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=dFh7tZoGYA4",
       "official_link": "https://www.babi.sh/recipes/date-night",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715470/babishImages/undefined-416418.png"
+    }
+  },
+  {
+    "recipe_id": 1584,
+    "name": "bourbon pan sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-weeknight-recipes-for-pork-tenderloin",
+      "name": "5 Weeknight Recipes for Pork Tenderloin",
+      "published_date": "2025-04-08",
+      "youtube_link": "https://www.youtube.com/watch?v=VEAmtpkxXXQ&t=21s",
+      "official_link": "https://www.babi.sh/recipes/5-weeknight-recipes-for-pork-tenderloin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1744118544/yh4iqwlo6kyfxad3flzw.webp"
     }
   },
   {
@@ -2697,6 +2997,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=DUTyGfwdBaY",
       "official_link": "https://www.babi.sh/recipes/short-ribs",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715478/babishImages/undefined-373512.png"
+    }
+  },
+  {
+    "recipe_id": 1518,
+    "name": "braised vegetable prep",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ultimate-pot-roast-or-with-babish",
+      "name": "Ultimate Pot Roast | With Babish",
+      "published_date": "2026-01-15",
+      "youtube_link": "https://www.youtube.com/watch?v=5_7pC4K-Y1g",
+      "official_link": "https://www.babi.sh/recipes/ultimate-pot-roast-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768506428/gryanukvd2zeutfh9ibh.webp"
     }
   },
   {
@@ -2797,7 +3112,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "corn-dogs",
-      "name": "CORN DOGS",
+      "name": "Corn Dogs",
       "published_date": "2021-05-27",
       "youtube_link": "https://www.youtube.com/watch?v=zGT45vVJNso",
       "official_link": "https://www.babi.sh/recipes/corn-dogs",
@@ -2813,8 +3128,8 @@
     "source": {
       "episode_id": "crepessuzette",
       "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-      "published_date": "2019-10-24",
-      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "published_date": "2019-10-22",
+      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
       "official_link": "https://www.babi.sh/recipes/crepessuzette",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png"
     }
@@ -2964,7 +3279,7 @@
       "episode_id": "brocksdonuts",
       "name": "Brock's Donuts inspired by Pok\u00e9mon",
       "published_date": "2019-04-02",
-      "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/RentKWlhUXc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc",
       "official_link": "https://www.babi.sh/recipes/brocksdonuts",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695178/babishImages/undefined-56205.png"
     }
@@ -3012,6 +3327,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=r_yBqWHtWMo",
       "official_link": "https://www.babi.sh/recipes/biscuits-ted-lasso",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695315/babishImages/undefined-343517.png"
+    }
+  },
+  {
+    "recipe_id": 1656,
+    "name": "browned butter sage",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "date-night-2",
+      "name": "DATE NIGHT II",
+      "published_date": "2022-01-11",
+      "youtube_link": "https://www.youtube.com/watch?v=dlATzLk8Nh8",
+      "official_link": "https://www.babi.sh/recipes/date-night-2",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1680979695/cbadjt8l6pkrdiadhks1.webp"
     }
   },
   {
@@ -3158,8 +3488,8 @@
     "source": {
       "episode_id": "crepessuzette",
       "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-      "published_date": "2019-10-24",
-      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "published_date": "2019-10-22",
+      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
       "official_link": "https://www.babi.sh/recipes/crepessuzette",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png"
     }
@@ -3180,6 +3510,21 @@
     }
   },
   {
+    "recipe_id": 1589,
+    "name": "bun",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "japanese-style-big-mac-inspired-by-weathering-with-you",
+      "name": "Japanese-Style Big Mac inspired by Weathering with You",
+      "published_date": "2025-03-19",
+      "youtube_link": "https://www.youtube.com/watch?v=BzKBag59duU&pp=ygUTYWx2aW4gamFwYW4gYmlnIG1hYw%3D%3D",
+      "official_link": "https://www.babi.sh/recipes/japanese-style-big-mac-inspired-by-weathering-with-you",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1742407838/ofwjdoqrkbbijmlqiu7e.webp"
+    }
+  },
+  {
     "recipe_id": 1212,
     "name": "bun dough",
     "image_link": null,
@@ -3195,6 +3540,21 @@
     }
   },
   {
+    "recipe_id": 1593,
+    "name": "buns",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "japanese-style-big-mac-inspired-by-weathering-with-you",
+      "name": "Japanese-Style Big Mac inspired by Weathering with You",
+      "published_date": "2025-03-19",
+      "youtube_link": "https://www.youtube.com/watch?v=BzKBag59duU&pp=ygUTYWx2aW4gamFwYW4gYmlnIG1hYw%3D%3D",
+      "official_link": "https://www.babi.sh/recipes/japanese-style-big-mac-inspired-by-weathering-with-you",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1742407838/ofwjdoqrkbbijmlqiu7e.webp"
+    }
+  },
+  {
     "recipe_id": 257,
     "name": "Burger",
     "image_link": null,
@@ -3202,7 +3562,7 @@
     "raw_procedure": "Place your meat grinder parts in the freezer to begin freezing up. You want them to freeze for about an hour.\nStart by removing bones and silver skin from your brisket, sirloin, and short rib. Slice meat into one inch strips and then cut crosswise into 1-2 inch chunks.\nPlace all the meat on a parchment lined baking sheet and put in the freezer and freeze for 15-20 minutes.\nWhile meat is freezing, prepare all of your toppings. Slice your tomatoes and onions, and chop up your lettuce. You can put any toppings you want, because it\u2019s your burger!\nFor the special sauce, combine equal parts ketchup and mayonnaise with a good sprinkling of garlic powder, onion powder, and paprika, followed by a hearty helping of sweet relish. Mix to combine.\nRemove meat and meat grinder parts from freezer. Assemble your meat grinder and start feeding your meat into the grinder. When you\u2019ve fed all of your meat through, you should have some pebbly ground beef.\nForm into 4-5 inch pucks (or whatever size you\u2019d like). Season with salt and pepper, and let rest in the fridge.\nButter your buns and place them on a hot skillet to toast your buns. Remove them from skillet when golden brown and set aside.\nHeat up your skillet or pan to medium high heat and add some vegetable oil. Place your burger on the skillet and cook for 3-4 minutes and then flip. Once you flip, add your american cheese to the burger. Add about 1 Tbsp water to the skillet and then cover. This allows the cheese to melt and the burger to cook more evenly. When internal temperature of burger reaches your desired level of doneness, remove from skillet.\nAssemble burger to your linking. I recommend bun, lettuce, patty, onion, tomato, then bun with special sauce. Serve and enjoy!",
     "source": {
       "episode_id": "burgers",
-      "name": "BURGERS",
+      "name": "Burgers",
       "published_date": "2018-06-14",
       "youtube_link": "https://www.youtube.com/watch?v=nbCgfiqq-5c",
       "official_link": "https://www.babi.sh/recipes/burgers",
@@ -3240,6 +3600,21 @@
     }
   },
   {
+    "recipe_id": 1571,
+    "name": "burger patties",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "deep-fried-burger-bomb",
+      "name": "Deep Fried Burger Bomb",
+      "published_date": "2025-06-06",
+      "youtube_link": "https://www.youtube.com/watch?v=dhRkD9u0C48&pp=ygUYZnJpZWQgYnVyZ2VyIGJvbWIgYmFiaXNo",
+      "official_link": "https://www.babi.sh/recipes/deep-fried-burger-bomb",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749219273/tfuzfxhkivkjrmtvcjam.webp"
+    }
+  },
+  {
     "recipe_id": 464,
     "name": "Burger Patties",
     "image_link": null,
@@ -3270,6 +3645,36 @@
     }
   },
   {
+    "recipe_id": 1573,
+    "name": "burgers",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "deep-fried-burger-bomb",
+      "name": "Deep Fried Burger Bomb",
+      "published_date": "2025-06-06",
+      "youtube_link": "https://www.youtube.com/watch?v=dhRkD9u0C48&pp=ygUYZnJpZWQgYnVyZ2VyIGJvbWIgYmFiaXNo",
+      "official_link": "https://www.babi.sh/recipes/deep-fried-burger-bomb",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749219273/tfuzfxhkivkjrmtvcjam.webp"
+    }
+  },
+  {
+    "recipe_id": 1260,
+    "name": "Burger Sauce",
+    "image_link": null,
+    "raw_ingredient_list": "milk warm\nbeef\nbutter\nsugar\negg\ntomatoes thinly",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "big-bang-burger-inspired-by-persona-5",
+      "name": "Big Bang Burger inspired by Persona 5",
+      "published_date": "2024-10-07",
+      "youtube_link": "https://www.youtube.com/watch?v=dUxzbnKKzf8&pp=ygUVYmlnIGJhbmcgYnVyZ2VyIGFsdmlu",
+      "official_link": "https://www.babi.sh/recipes/big-bang-burger-inspired-by-persona-5",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1728311555/laq2mbbfwx2xlzw3ucrw.webp"
+    }
+  },
+  {
     "recipe_id": 370,
     "name": "Butterbeer",
     "image_link": null,
@@ -3282,6 +3687,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=LXDAu8DnALw",
       "official_link": "https://www.babi.sh/recipes/harrypotterspecial",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715458/babishImages/undefined-107622.png"
+    }
+  },
+  {
+    "recipe_id": 1527,
+    "name": "butter block",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "beef-wellington-or-with-babish",
+      "name": "$20 vs $200 Beef Wellington | With Babish",
+      "published_date": "2025-12-23",
+      "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
+      "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
     }
   },
   {
@@ -3345,6 +3765,21 @@
     }
   },
   {
+    "recipe_id": 1535,
+    "name": "buttered noodles",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "coq-au-vin",
+      "name": "Coq au Vin",
+      "published_date": "2025-10-11",
+      "youtube_link": "https://www.youtube.com/watch?v=cf1H6ylUFH4",
+      "official_link": "https://www.babi.sh/recipes/coq-au-vin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1760217634/qggynlnkmhze8roieemn.webp"
+    }
+  },
+  {
     "recipe_id": 700,
     "name": "Butter from Scratch",
     "image_link": null,
@@ -3357,21 +3792,6 @@
       "youtube_link": "https://www.youtube.com/watch?v=xGHTj4y_bd8",
       "official_link": "https://www.babi.sh/recipes/butterednoodles-community",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695894/babishImages/undefined-831336.png"
-    }
-  },
-  {
-    "recipe_id": 1312,
-    "name": "buttermilk bacon fat bechamel ingredients:",
-    "image_link": null,
-    "raw_ingredient_list": "flour rolling\nfrozen hashbrowns according package instructions\nthick cut bacon\nbeef\ncheddar cheese",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "bobsburgers-potato-lasagna",
-      "name": "Loaded Baked Potato Lasagna Inspired by Bob's Burgers",
-      "published_date": "2024-03-01",
-      "youtube_link": "youtube.com/watch?v=jts_NfZu2vY",
-      "official_link": "https://www.babi.sh/recipes/bobsburgers-potato-lasagna",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1709308712/bfjgjzbwq9dstzpukvxo.webp"
     }
   },
   {
@@ -3417,6 +3837,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=nEoSBL25RO4",
       "official_link": "https://www.babi.sh/recipes/buttermilk-pancakes-inspired-by-twin-peaks",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992075/k6lh85gi9qv44sgwuezx.webp"
+    }
+  },
+  {
+    "recipe_id": 1533,
+    "name": "butter mushrooms",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "coq-au-vin",
+      "name": "Coq au Vin",
+      "published_date": "2025-10-11",
+      "youtube_link": "https://www.youtube.com/watch?v=cf1H6ylUFH4",
+      "official_link": "https://www.babi.sh/recipes/coq-au-vin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1760217634/qggynlnkmhze8roieemn.webp"
     }
   },
   {
@@ -3525,6 +3960,21 @@
     }
   },
   {
+    "recipe_id": 1547,
+    "name": "cake",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "name": "Fallout Fancy Lad Snack Cakes inspired by Fallout 76",
+      "published_date": "2025-10-01",
+      "youtube_link": "https://www.youtube.com/watch?v=v1f835eNhUc",
+      "official_link": "https://www.babi.sh/recipes/fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759334763/qv57em4y8nloxgzztjrs.webp"
+    }
+  },
+  {
     "recipe_id": 1308,
     "name": "calabrian chili pasta",
     "image_link": null,
@@ -3547,7 +3997,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "calistyle-burrito",
-      "name": "CALI-STYLE BURRITO",
+      "name": "California Style Burritos",
       "published_date": "2021-09-13",
       "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
       "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
@@ -3637,7 +4087,7 @@
     "raw_procedure": "Line a baking sheet with aluminum foil and top with a wire rack. Spray the rack with a nonstick cooking spray.\nLine your thick-cut bacon on the wire rack (making sure not to overlap), brush with maple syrup and then top with a dusting of light brown sugar.\nPlace in a 350\u00b0F oven for about 10 minutes.\nRemove bacon from the oven and then flip each slice. Coat the other side with maple syrup and brown sugar.\nReturn to the oven and flip every 5 minutes until you have nice reddish mahogany color and they are flexible (about 10 more minutes). Let cool completely for 30 minutes.\nServe and enjoy!",
     "source": {
       "episode_id": "biggamesnacks",
-      "name": "BIG GAME SNACKS",
+      "name": "Big Game Snacks",
       "published_date": "2019-01-31",
       "youtube_link": "https://www.youtube.com/watch?v=8ckxhlDFNkg",
       "official_link": "https://www.babi.sh/recipes/biggamesnacks",
@@ -3817,7 +4267,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "creme-caramel",
-      "name": "CR\u00c8ME CARAMEL",
+      "name": "Cr\u00e8me Caramel",
       "published_date": "2021-04-08",
       "youtube_link": "https://www.youtube.com/watch?v=ihS8__strtM",
       "official_link": "https://www.babi.sh/recipes/creme-caramel",
@@ -3847,7 +4297,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "advanced-grilled-cheese",
-      "name": "ADVANCED GRILLED CHEESE",
+      "name": "Advanced Grilled Cheese",
       "published_date": "2021-02-19",
       "youtube_link": "https://www.youtube.com/watch?v=Zo7sRijXG00",
       "official_link": "https://www.babi.sh/recipes/advanced-grilled-cheese",
@@ -3930,6 +4380,21 @@
     }
   },
   {
+    "recipe_id": 1391,
+    "name": "Carbonara Anything",
+    "image_link": null,
+    "raw_ingredient_list": "dried spaghetti\npanko breadcrumbs\naged yellow cheddar cheese\nguanciale\nhen of the woods or maitake mushrooms cut/torn into bite size pieces\nthick cut bacon\ndried macaroni or cavatappi",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "carbonara-anything",
+      "name": "CARBONARA ANYTHING",
+      "published_date": "2022-09-19",
+      "youtube_link": "https://www.youtube.com/watch?v=wrweyL0YS8Y",
+      "official_link": "https://www.babi.sh/recipes/carbonara-anything",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695332/babishImages/undefined-714411.png"
+    }
+  },
+  {
     "recipe_id": 9,
     "name": "Carbonara - Modern",
     "image_link": null,
@@ -3969,7 +4434,7 @@
       "episode_id": "alwayssunny",
       "name": "It's Always Sunny in Philadelphia Special (Part II)",
       "published_date": "2019-06-12",
-      "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/_fnhy5xO9vQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ",
       "official_link": "https://www.babi.sh/recipes/alwayssunny",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696347/babishImages/undefined-129032.png"
     }
@@ -4027,11 +4492,26 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "calistyle-burrito",
-      "name": "CALI-STYLE BURRITO",
+      "name": "California Style Burritos",
       "published_date": "2021-09-13",
       "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
       "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695451/babishImages/undefined-566187.png"
+    }
+  },
+  {
+    "recipe_id": 1349,
+    "name": "carnitas",
+    "image_link": null,
+    "raw_ingredient_list": "pork shoulder cut into two three inch pieces\nlard\ncoca cola preferably mexican\ncorn tortillas\nevaporated milk",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "carnitas",
+      "name": "Easy Carnitas",
+      "published_date": "2023-05-02",
+      "youtube_link": "https://www.youtube.com/watch?v=FEZioC-qMd4",
+      "official_link": "https://www.babi.sh/recipes/carnitas",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690352698/ldnpp7ukrrvaiormf4ux.webp"
     }
   },
   {
@@ -4065,21 +4545,6 @@
     }
   },
   {
-    "recipe_id": 1349,
-    "name": "carnitas cuban sliders",
-    "image_link": null,
-    "raw_ingredient_list": "pork shoulder cut into two three inch pieces\nlard\ncoca cola preferably mexican\ncorn tortillas\nevaporated milk",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "carnitas",
-      "name": "CARNITAS",
-      "published_date": "2023-05-12",
-      "youtube_link": "https://www.youtube.com/watch?v=FEZioC-qMd4",
-      "official_link": "https://www.babi.sh/recipes/carnitas",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690352698/ldnpp7ukrrvaiormf4ux.webp"
-    }
-  },
-  {
     "recipe_id": 437,
     "name": "Carol's Beet and Acorn Cookies",
     "image_link": null,
@@ -4107,21 +4572,6 @@
       "youtube_link": "https://www.youtube.com/watch?v=AwS_DIMeVoM&amp;t=7s",
       "official_link": "https://www.babi.sh/recipes/fraiserspecial",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715531/babishImages/undefined-291594.png"
-    }
-  },
-  {
-    "recipe_id": 226,
-    "name": "Car Panini",
-    "image_link": null,
-    "raw_ingredient_list": "Mole Sauce\nPasilla dried chilis\nGuajillo dried chilis\nAncho dried chilis\n1 tsp whole cloves\n1 tsp peppercorn\n3 bay leaves, crumbled\n1 cinnamon stick\n1 corn tortilla\n1 slice of white bread\n\u2153 cup peanuts\n\u2153 cup pumpkin seeds\n\u2153 cup almonds\n\u2153 cup raisins\n\u00bc cup sesame seeds\n1 large tomato, quartered\n1 large onion\n4 cloves of garlic\n\u00bc tsp dried thyme\n\u00bc tsp marjoram\n\u00bc tsp aniseed\n4 cups chicken stock, hot\n4 ounces bittersweet chocolate, chopped\nSugar (if necessary)\nTomatillos (optional)\nCheddar Crisps\nShredded mild cheddar cheese\nGoat Cheese Cream\n5 ounces goat cheese\n1 Tbsp honey\n2 Tbsp heavy cream\nSandwich Stuff\n2 slices of white bread\nChorizo",
-    "raw_procedure": "Start by stemming and seeding some dried pasilla, guajillo, and ancho chilis. Save a few tablespoons of the seeds.\nHeat a cast iron skillet to a medium heat and add chilis. Dry roast them for about 2 minutes. Place about 12 chilis into a blender and set aside. Remove any extra chilis from skillet.\nIn the same skillet add 1 tsp whole cloves, 1 tsp peppercorns, 3 crumbled bay leaves, 1 cinnamon stick broken into a few pieces, and some of our reserved chili seeds. Dry roast for about 2 minutes or until the seeds darken. Remove from skillet and add to the blender.\nAdd one corn tortilla that has been torn into smaller pieces to the skillet cook with a little bit of oil until they turn brown. Add them to the blender.\nToast 1 piece of white bread and add that to the blender.\nAdd some vegetable oil to the pan along with \u2153 cup each of peanuts, pumpkin seeds, almonds and raisins. Roast for about one minute before adding \u00bc cup of sesame seeds. Let it go for one more minute before placing all of it into the blender.\nAdd some oil to the skillet and turn to a medium high heat. Add 1 large quartered tomato, 1 large chopped onion, and 4 cloves of garlic (If you have tomatillos this is the time to add them). Let them sit undisturbed for about a minute, letting them get nice and brown. Add \u00bc tsp each of dried thyme, marjoram, and aniseed. Cook for about a minute and then add to the blender.\nHeat up 4 cups of chicken stock and add that to the blender. Let everything sit in the blender for 10 minutes. Blend on medium for about 2 minutes or until smooth.\nAdd blended sauce to a large saucepan and cook on medium-low heat for about an hour.\nRun the sauce through a mesh sieve until you have a thick paste in the sieve and a smooth puree below.\nAdd the puree back to saucepan on a medium heat and add 4 ounces of chopped bittersweet chocolate. Taste and add sugar if necessary.\nPreheat oven to 425\u00b0F. Place a small handful of cheddar cheese in six piles on a cookie sheet lined with a silicon mat or parchment paper. Bake the cheese for about 10 minutes, checking constantly just until all cheese is melted and edges begin to brown. Remove from oven and let cool slightly. Transfer crisps to a wire rack to cool.\nIn a blender combine 5 ounces of goat cheese with 1 Tbsp of honey and 2 Tbsp of heavy cream. Blend on high speed until you have a thick spreadable cream.\nIn a skillet cook up one piece of chorizo until your preferred doneness. Cut into 4 pieces.\nButter both slices of bread on the outside. On one piece of bread, slather some mole, top with cooked chorizo sausages, cheese crisps, and goat cheese cream. Top with other piece of bread. Place into your panini press/George Foreman grill. Serve and enjoy!",
-    "source": {
-      "episode_id": "babishpaniniwinner",
-      "name": "#BabishPanini Winning Recipe - Car Panini inspired by Family Guy",
-      "published_date": "2018-08-21",
-      "youtube_link": "https://www.youtube.com/watch?v=4Rz8BPRFeiA",
-      "official_link": "https://www.babi.sh/recipes/babishpaniniwinner",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715515/babishImages/undefined-702398.png"
     }
   },
   {
@@ -4197,21 +4647,6 @@
       "youtube_link": "https://www.youtube.com/watch?v=APwwGy4GzK8",
       "official_link": "https://www.babi.sh/recipes/healthymeals",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1685912869/icxavj8aogbk6ggjueq8.webp"
-    }
-  },
-  {
-    "recipe_id": 808,
-    "name": "Casserole Dish Prep",
-    "image_link": null,
-    "raw_ingredient_list": "2 tbsp mayonnaise\n\u00bc cup finely crumbled cotija cheese",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "andrewsohlathanksgiving",
-      "name": "ANDREW & SOHLA THANKSGIVING RECIPES",
-      "published_date": "2020-11-20",
-      "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
-      "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715526/babishImages/undefined-665559.jpg"
     }
   },
   {
@@ -4344,7 +4779,7 @@
       "episode_id": "baobuns",
       "name": "Bao inspired by Pixar's Bao",
       "published_date": "2019-02-19",
-      "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M&amp;t=46s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/OFt3SThGi7M/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M",
       "official_link": "https://www.babi.sh/recipes/baobuns",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695380/babishImages/undefined-293013.png"
     }
@@ -4410,6 +4845,36 @@
     }
   },
   {
+    "recipe_id": 1599,
+    "name": "cheesecake",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "cheesecake-inspired-by-junior's-cheesecakes",
+      "name": "Cheesecake inspired by Junior's Cheesecakes",
+      "published_date": "2025-03-11",
+      "youtube_link": "https://www.youtube.com/watch?v=gQeY_wx9bsI&t=26s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/cheesecake-inspired-by-junior's-cheesecakes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741657095/qjrimy3opynb08w9zudl.webp"
+    }
+  },
+  {
+    "recipe_id": 1595,
+    "name": "cheesecake batter",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "cheesecake-inspired-by-junior's-cheesecakes",
+      "name": "Cheesecake inspired by Junior's Cheesecakes",
+      "published_date": "2025-03-11",
+      "youtube_link": "https://www.youtube.com/watch?v=gQeY_wx9bsI&t=26s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/cheesecake-inspired-by-junior's-cheesecakes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741657095/qjrimy3opynb08w9zudl.webp"
+    }
+  },
+  {
     "recipe_id": 694,
     "name": "Cheese Crisp",
     "image_link": null,
@@ -4425,6 +4890,21 @@
     }
   },
   {
+    "recipe_id": 1575,
+    "name": "cheese dough balls",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "deep-fried-burger-bomb",
+      "name": "Deep Fried Burger Bomb",
+      "published_date": "2025-06-06",
+      "youtube_link": "https://www.youtube.com/watch?v=dhRkD9u0C48&pp=ygUYZnJpZWQgYnVyZ2VyIGJvbWIgYmFiaXNo",
+      "official_link": "https://www.babi.sh/recipes/deep-fried-burger-bomb",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749219273/tfuzfxhkivkjrmtvcjam.webp"
+    }
+  },
+  {
     "recipe_id": 757,
     "name": "Cheese Filling",
     "image_link": null,
@@ -4437,6 +4917,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=Zhq20aCSh-s",
       "official_link": "https://www.babi.sh/recipes/raspberry-danish-ant-man-and-the-wasp",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696165/babishImages/undefined-142356.png"
+    }
+  },
+  {
+    "recipe_id": 1440,
+    "name": "Cheese Fondue",
+    "image_link": null,
+    "raw_ingredient_list": "desired cheese\nyellow & white cheddar\nfontina cheese\ndry white wine\nbeer\nmilk\nbutter",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "cheese-fondue",
+      "name": "Cheese Fondue",
+      "published_date": "2020-07-23",
+      "youtube_link": "https://www.youtube.com/watch?v=_X-Mm8h1AHM",
+      "official_link": "https://www.babi.sh/recipes/cheese-fondue",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715730/babishImages/undefined-469596.png"
     }
   },
   {
@@ -4467,6 +4962,36 @@
       "youtube_link": "https://www.youtube.com/watch?v=FvUpmMIhpAo",
       "official_link": "https://www.babi.sh/recipes/empanadas",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695742/babishImages/undefined-529600.png"
+    }
+  },
+  {
+    "recipe_id": 1557,
+    "name": "cheese sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-mac-and-cheese",
+      "name": "10 Levels of Mac and Cheese",
+      "published_date": "2025-09-20",
+      "youtube_link": "https://youtube.com/watch?v=XpL2ZyyF55U&si=Ji3keCq-hmDoiCDS",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-mac-and-cheese",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1758370413/qtua6ccyjtklttjssedd.webp"
+    }
+  },
+  {
+    "recipe_id": 1572,
+    "name": "cheese sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "deep-fried-burger-bomb",
+      "name": "Deep Fried Burger Bomb",
+      "published_date": "2025-06-06",
+      "youtube_link": "https://www.youtube.com/watch?v=dhRkD9u0C48&pp=ygUYZnJpZWQgYnVyZ2VyIGJvbWIgYmFiaXNo",
+      "official_link": "https://www.babi.sh/recipes/deep-fried-burger-bomb",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749219273/tfuzfxhkivkjrmtvcjam.webp"
     }
   },
   {
@@ -4587,6 +5112,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=chil75Ip-3w&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/chil75Ip-3w/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
       "official_link": "https://www.babi.sh/recipes/dessertdogs",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696386/babishImages/undefined-530680.png"
+    }
+  },
+  {
+    "recipe_id": 1339,
+    "name": "Chicago Deep-Dish Pizza",
+    "image_link": null,
+    "raw_ingredient_list": "gelatin sheets\nflour\ndeli style low moisture mozzarella cheese\ntomatoes on the vine\ntomato paste\nvegetable oil more for greasing\nbasil",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "chicago-deep-dish-the-bear",
+      "name": "Chicago Deep Dish Pizza inspired by The Bear",
+      "published_date": "2023-07-21",
+      "youtube_link": "https://www.youtube.com/watch?v=Ris0udk2C84",
+      "official_link": "https://www.babi.sh/recipes/chicago-deep-dish-the-bear",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690249416/oxrjvgjzaljdvfvtinpj.webp"
     }
   },
   {
@@ -4725,6 +5265,21 @@
     }
   },
   {
+    "recipe_id": 1265,
+    "name": "chicken meatball hotpot",
+    "image_link": null,
+    "raw_ingredient_list": "rice\nchrysanthemum\neggs\nboneless skinless chicken thighs",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "chicken-meatball-hotpot-inspired-by-jujutsu-kaisen",
+      "name": "Chicken Meatball Hotpot inspired By Jujutsu Kaisen",
+      "published_date": "2024-10-02",
+      "youtube_link": "https://www.youtube.com/watch?v=GymqadVYSXk&t=34s",
+      "official_link": "https://www.babi.sh/recipes/chicken-meatball-hotpot-inspired-by-jujutsu-kaisen",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727887830/cnkxewktxghxefrnq6xa.webp"
+    }
+  },
+  {
     "recipe_id": 339,
     "name": "Chicken Noodle Soup",
     "image_link": null,
@@ -4800,6 +5355,21 @@
     }
   },
   {
+    "recipe_id": 1412,
+    "name": "Chicken Piccata",
+    "image_link": null,
+    "raw_ingredient_list": "flour\nchicken stock preferably homemade\ncapellini spaghetti, or angel hair pasta,\nlinguini\nunsalted butter &\ndry white wine\ncapers\ncapers drained",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "chicken-piccata",
+      "name": "Chicken Piccata",
+      "published_date": "2022-02-18",
+      "youtube_link": "https://www.youtube.com/watch?v=ZqEqtmMY1M0",
+      "official_link": "https://www.babi.sh/recipes/chicken-piccata",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695515/babishImages/undefined-561520.png"
+    }
+  },
+  {
     "recipe_id": 87,
     "name": "Chicken Quesadilla",
     "image_link": null,
@@ -4822,7 +5392,7 @@
     "raw_procedure": "Take 1 small green bell pepper, 2 ribs of celery, and 1 small white onion (also known as the \u201choly trinity\u201d) and dice them into medium-sized pieces. Set aside for later.\nMince 6 garlic cloves and set aside for later.\nFor the roux, add \u00bd cup of vegetable oil to a pot and allow it to get smoking hot before adding \u00bd cup of all purpose flour. Using a wooden spoon or preferably a whisk, mix together until the consistency is similar to wet sand.\nWithin 30 seconds, the roux should be the color of milk chocolate. The darker the roux gets, the more you need to stir it, but let it sit for a few seconds before continuing to stir. After about 5-6 minutes, the color of the roux should be nice and dark or similar to the color of a Hershey\u2019s chocolate bar. Set aside some of the roux to use later.\nAdd 2 bay leaves as well as your \u201choly trinity\u201d to the pot. Make sure to set aside some of the holy trinity mix for later.\nOnce the mixture calms down a bit, add the minced garlic to the pot. Let the roux sit for 30 seconds.\nAdd 8 ounces of beer and stir it in and whisk to prevent the mixture from becoming clumpy. Then, add 4 cups of chicken stock and whisk using the same procedure as the beer.\nTake 1 lb of andouille sausage or smoked kielbasa and cut into coins.\nAdd kosher salt and freshly ground black pepper to both sides of 1 lb of boneless, skinless chicken thighs. Sear the chicken thighs in a smoking hot pan with oil.\nAdd 1 tbsp of cayenne pepper and a pinch of salt to the roux.\nTurn the stovetop temperature to the lowest simmer possible and add a generous amount of black pepper to the roux. Then, add 1 tbsp of smoked paprika and stir.\nAfter browning the chicken, add it straight to the pot and set aside the remaining oil from the chicken. Next, add the chopped up sausage or smoked kielbasa to the pot.\nBring the roux to a bare simmer, cover it, and let sit for a couple of hours.\nServe with cooked white rice, garnish with scallions, and enjoy!",
     "source": {
       "episode_id": "cajunfood",
-      "name": "CAJUN FOOD",
+      "name": "Cajun Food",
       "published_date": "2019-09-13",
       "youtube_link": "https://www.youtube.com/watch?v=nORg_aXMsmA",
       "official_link": "https://www.babi.sh/recipes/cajunfood",
@@ -4897,7 +5467,7 @@
     "raw_procedure": "For the tikka masala sauce, heat 2 Tbsp of vegetable oil over medium high heat before adding \u00bd a small yellow onion finely minced. Cook for about 1 minute before adding 2 cloves of minced garlic, 2 inches of grated ginger, 1 small bird\u2019s eye chili finely minced, 1 Tbsp of tomato paste, and 1 heaping Tbsp of homemade curry powder. Mix them together for about 30 seconds before adding one 28-ounce can of crushed tomatoes along with a little bit of sugar to help with the acidity. Cook for 5 minutes.\nStart cooking your rice at this point, if you\u2019d like to have rice.\nAdd \u00be of a cup of heavy cream to your sauce. Stir to combine.\nNext add your chicken to the sauce and cook for about 5-10 minutes. Taste for seasoning and add salt and pepper if needed.\nPlate up by putting a bed of rice down first, followed by your chicken tikka on top, and then garnish with some cilantro.\nServe and enjoy!",
     "source": {
       "episode_id": "chickentikkamasala",
-      "name": "CHICKEN TIKKA MASALA",
+      "name": "Chicken Tikka Masala",
       "published_date": "2019-03-28",
       "youtube_link": "https://www.youtube.com/watch?v=Bkd0LxBd2L8",
       "official_link": "https://www.babi.sh/recipes/chickentikkamasala",
@@ -4912,11 +5482,26 @@
     "raw_procedure": "In a bowl add 1 cup of full fat yogurt, 2 inches of grated ginger, 2 grated garlic cloves, 1 Tbsp of the homemade curry powder, salt, pepper, and a drizzle of olive oil. Whisk to combine. Cut 3 boneless, skinless, chicken breasts into one inch cubes. Add the cubes to the yogurt mixture. Mix to combine. Cover bowl and place in fridge for at least 4 hours and up to 24 hours.\nSpread chicken out evenly on a broiler pan in a rimmed baking sheet and place under the broiler on high for 10-15 minutes or until they register 160\u00b0F internally.",
     "source": {
       "episode_id": "chickentikkamasala",
-      "name": "CHICKEN TIKKA MASALA",
+      "name": "Chicken Tikka Masala",
       "published_date": "2019-03-28",
       "youtube_link": "https://www.youtube.com/watch?v=Bkd0LxBd2L8",
       "official_link": "https://www.babi.sh/recipes/chickentikkamasala",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1686006735/dk1zntqnkdzyf26vol0o.webp"
+    }
+  },
+  {
+    "recipe_id": 1456,
+    "name": "chickpea (aquafaba) chocolate chip cookies",
+    "image_link": null,
+    "raw_ingredient_list": "chickpeas\nflour\ncan crushed tomatoes\ngarbanzo beans\nliquid from chickpeas",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "chickpeas",
+      "name": "CHICKPEAS (HUMMUS, CHANA MASALA, MERINGUES, COOKIES)",
+      "published_date": "2020-03-19",
+      "youtube_link": "https://www.youtube.com/watch?v=LfzKfD_WuDM",
+      "official_link": "https://www.babi.sh/recipes/chickpeas",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715488/babishImages/undefined-317396.png"
     }
   },
   {
@@ -4944,7 +5529,7 @@
       "episode_id": "chileanseabass",
       "name": "Chilean Sea Bass inspired by Jurassic Park",
       "published_date": "2018-11-27",
-      "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/p73kqpqGqqQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ",
       "official_link": "https://www.babi.sh/recipes/chileanseabass",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695721/babishImages/undefined-408439.png"
     }
@@ -4957,7 +5542,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "chiles-rellenos",
-      "name": "CHILES RELLENOS",
+      "name": "Chiles Rellenos",
       "published_date": "2021-08-26",
       "youtube_link": "https://www.youtube.com/watch?v=gAKW8RB6aeU",
       "official_link": "https://www.babi.sh/recipes/chiles-rellenos",
@@ -5033,10 +5618,25 @@
     "source": {
       "episode_id": "crepessuzette",
       "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-      "published_date": "2019-10-24",
-      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "published_date": "2019-10-22",
+      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
       "official_link": "https://www.babi.sh/recipes/crepessuzette",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png"
+    }
+  },
+  {
+    "recipe_id": 1450,
+    "name": "Chimichangas",
+    "image_link": null,
+    "raw_ingredient_list": "chicken",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "chimichangas",
+      "name": "Deadpool's Chimichangas",
+      "published_date": "2020-04-28",
+      "youtube_link": "https://www.youtube.com/watch?v=szFLA4_pwew",
+      "official_link": "https://www.babi.sh/recipes/chimichangas",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715751/babishImages/undefined-916823.png"
     }
   },
   {
@@ -5078,7 +5678,7 @@
     "source": {
       "episode_id": "babka-inspired-by-seinfeld",
       "name": "Babka inspired by Seinfeld",
-      "published_date": "2017-05-10",
+      "published_date": "2017-05-09",
       "youtube_link": "https://www.youtube.com/watch?v=pw2A03Z91FI",
       "official_link": "https://www.babi.sh/recipes/babka-inspired-by-seinfeld",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp"
@@ -5107,8 +5707,8 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "cake-pops",
-      "name": "CAKE POPS",
-      "published_date": "2021-11-02",
+      "name": "Cake Pops",
+      "published_date": "2021-10-21",
       "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
       "official_link": "https://www.babi.sh/recipes/cake-pops",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
@@ -5160,21 +5760,6 @@
     }
   },
   {
-    "recipe_id": 1456,
-    "name": "chocolate chip cookies",
-    "image_link": null,
-    "raw_ingredient_list": "chickpeas\nflour\ncan crushed tomatoes\ngarbanzo beans\nliquid from chickpeas",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "chickpeas",
-      "name": "CHICKPEAS (HUMMUS, CHANA MASALA, MERINGUES, COOKIES)",
-      "published_date": "2020-03-19",
-      "youtube_link": "https://www.youtube.com/watch?v=LfzKfD_WuDM",
-      "official_link": "https://www.babi.sh/recipes/chickpeas",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715488/babishImages/undefined-317396.png"
-    }
-  },
-  {
     "recipe_id": 295,
     "name": "Chocolate Chip Cookies",
     "image_link": null,
@@ -5184,7 +5769,7 @@
       "episode_id": "baressentials-7xwwz",
       "name": "CHOCOLATE CHIP COOKIES",
       "published_date": "2018-03-29",
-      "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/ylxzfecackM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM",
       "official_link": "https://www.babi.sh/recipes/baressentials-7xwwz",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690485488/p72d0navvupz8bsaur3g.webp"
     }
@@ -5217,6 +5802,36 @@
       "youtube_link": "https://www.youtube.com/watch?v=tfn-LC254Hk",
       "official_link": "https://www.babi.sh/recipes/space-cake-high-maintenance",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696212/babishImages/undefined-120477.png"
+    }
+  },
+  {
+    "recipe_id": 1398,
+    "name": "Chocolate Croissants",
+    "image_link": null,
+    "raw_ingredient_list": "flour\nmilk\nunsalted european style butter\nchocolate\nsugar\nbutter",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "chocolate-croissants-its-complicated",
+      "name": "Chocolate Croissants inspired by It's Complicated",
+      "published_date": "2022-07-13",
+      "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
+      "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png"
+    }
+  },
+  {
+    "recipe_id": 1636,
+    "name": "chocolate flavor",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "whimsical-parfait-inspired-by-darker-than-black",
+      "name": "Whimsical Parfait inspired by Darker than Black",
+      "published_date": "2024-10-02",
+      "youtube_link": "https://www.youtube.com/watch?v=GHwZqJYYB80",
+      "official_link": "https://www.babi.sh/recipes/whimsical-parfait-inspired-by-darker-than-black",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727903480/ek6bh07lnnblfomgfhdy.webp"
     }
   },
   {
@@ -5310,6 +5925,21 @@
     }
   },
   {
+    "recipe_id": 1431,
+    "name": "chocolate hazelnut baklava",
+    "image_link": null,
+    "raw_ingredient_list": "phyllo dough\nhazelnuts\npistachio de shelled\nbutter\nsugar\ndark chocolate\nhoney",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "baklava",
+      "name": "BAKLAVA",
+      "published_date": "2020-10-15",
+      "youtube_link": "https://www.youtube.com/watch?v=OkzpwHodaAs",
+      "official_link": "https://www.babi.sh/recipes/baklava",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715500/babishImages/undefined-703057.png"
+    }
+  },
+  {
     "recipe_id": 1071,
     "name": "Chocolate Ice Cream Base (Cr\u00e8me Anglaise)",
     "image_link": null,
@@ -5362,8 +5992,8 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "cake-pops",
-      "name": "CAKE POPS",
-      "published_date": "2021-11-02",
+      "name": "Cake Pops",
+      "published_date": "2021-10-21",
       "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
       "official_link": "https://www.babi.sh/recipes/cake-pops",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
@@ -5442,6 +6072,21 @@
       "youtube_link": "",
       "official_link": "https://www.babi.sh/recipes/chorizo-clam-pasta",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1723131815/pp5vavgjuw3vbgrspxwe.webp"
+    }
+  },
+  {
+    "recipe_id": 1641,
+    "name": "choux pastry :",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "whimsical-parfait-inspired-by-darker-than-black",
+      "name": "Whimsical Parfait inspired by Darker than Black",
+      "published_date": "2024-10-02",
+      "youtube_link": "https://www.youtube.com/watch?v=GHwZqJYYB80",
+      "official_link": "https://www.babi.sh/recipes/whimsical-parfait-inspired-by-darker-than-black",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727903480/ek6bh07lnnblfomgfhdy.webp"
     }
   },
   {
@@ -5543,7 +6188,7 @@
     "source": {
       "episode_id": "babka-inspired-by-seinfeld",
       "name": "Babka inspired by Seinfeld",
-      "published_date": "2017-05-10",
+      "published_date": "2017-05-09",
       "youtube_link": "https://www.youtube.com/watch?v=pw2A03Z91FI",
       "official_link": "https://www.babi.sh/recipes/babka-inspired-by-seinfeld",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp"
@@ -5558,7 +6203,7 @@
     "source": {
       "episode_id": "churrons-broad-city",
       "name": "Churrons inspired by Broad City",
-      "published_date": "2022-08-17",
+      "published_date": "2022-08-03",
       "youtube_link": "https://www.youtube.com/watch?v=JiUsCTy8nEY",
       "official_link": "https://www.babi.sh/recipes/churrons-broad-city",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695905/babishImages/undefined-290140.png"
@@ -5574,7 +6219,7 @@
       "episode_id": "cinnamonrolls",
       "name": "Cinnamon Rolls inspired by Jim Gaffigan's Stand Up (sort of)",
       "published_date": "2018-10-23",
-      "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/jFYi2QRVFOc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc",
       "official_link": "https://www.babi.sh/recipes/cinnamonrolls",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679245506/gyb4qsztcyrv4kjnvwug.webp"
     }
@@ -5589,24 +6234,9 @@
       "episode_id": "cinnamonrolls",
       "name": "Cinnamon Rolls inspired by Jim Gaffigan's Stand Up (sort of)",
       "published_date": "2018-10-23",
-      "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/jFYi2QRVFOc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc",
       "official_link": "https://www.babi.sh/recipes/cinnamonrolls",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679245506/gyb4qsztcyrv4kjnvwug.webp"
-    }
-  },
-  {
-    "recipe_id": 1250,
-    "name": "cinnamon sugar mixture",
-    "image_link": null,
-    "raw_ingredient_list": "flour\nsugar",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "cinnamon-rolls-3-ways-(pumpkin-spice-strawberry-nutella-classic)",
-      "name": "Cinnamon Rolls 3-Ways (Pumpkin Spice, Strawberry Nutella, Classic)",
-      "published_date": "2024-10-11",
-      "youtube_link": "https://www.youtube.com/watch?v=QsMNoGvPAJ4",
-      "official_link": "https://www.babi.sh/recipes/cinnamon-rolls-3-ways-(pumpkin-spice-strawberry-nutella-classic)",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1728682940/vwybjlgymmmndc3ghs9r.webp"
     }
   },
   {
@@ -5632,7 +6262,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "apple-cider-donuts",
-      "name": "APPLE CIDER DONUTS",
+      "name": "Apple Cider Donuts",
       "published_date": "2021-11-09",
       "youtube_link": "https://www.youtube.com/watch?v=baZoJYAQjfI",
       "official_link": "https://www.babi.sh/recipes/apple-cider-donuts",
@@ -5692,7 +6322,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "bacon",
-      "name": "HOMEMADE BACON",
+      "name": "Homemade Bacon",
       "published_date": "2021-04-30",
       "youtube_link": "https://www.youtube.com/watch?v=TUh4Z2li1UM",
       "official_link": "https://www.babi.sh/recipes/bacon",
@@ -5707,7 +6337,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "bacon",
-      "name": "HOMEMADE BACON",
+      "name": "Homemade Bacon",
       "published_date": "2021-04-30",
       "youtube_link": "https://www.youtube.com/watch?v=TUh4Z2li1UM",
       "official_link": "https://www.babi.sh/recipes/bacon",
@@ -5727,6 +6357,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=MJoSs4BGaHI",
       "official_link": "https://www.babi.sh/recipes/chicken-fingers-community",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695499/babishImages/undefined-134001.png"
+    }
+  },
+  {
+    "recipe_id": 1250,
+    "name": "classic cinnamon sugar filling",
+    "image_link": null,
+    "raw_ingredient_list": "flour\nsugar",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "cinnamon-rolls-3-ways-(pumpkin-spice-strawberry-nutella-classic)",
+      "name": "Cinnamon Rolls 3-Ways (Pumpkin Spice, Strawberry Nutella, Classic)",
+      "published_date": "2024-10-11",
+      "youtube_link": "https://www.youtube.com/watch?v=QsMNoGvPAJ4",
+      "official_link": "https://www.babi.sh/recipes/cinnamon-rolls-3-ways-(pumpkin-spice-strawberry-nutella-classic)",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1728682940/vwybjlgymmmndc3ghs9r.webp"
     }
   },
   {
@@ -5752,7 +6397,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "corn-dogs",
-      "name": "CORN DOGS",
+      "name": "Corn Dogs",
       "published_date": "2021-05-27",
       "youtube_link": "https://www.youtube.com/watch?v=zGT45vVJNso",
       "official_link": "https://www.babi.sh/recipes/corn-dogs",
@@ -5940,6 +6585,21 @@
     }
   },
   {
+    "recipe_id": 1616,
+    "name": "cocktail sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "shrimp-7-ways",
+      "name": "Shrimp 7 Ways",
+      "published_date": "2025-03-05",
+      "youtube_link": "https://www.youtube.com/watch?v=Uct0-gkfEsk&t=324s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/shrimp-7-ways",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741134166/kwu0dmfwjm9sr0h9zabd.webp"
+    }
+  },
+  {
     "recipe_id": 1284,
     "name": "coconut cream cheese frosting",
     "image_link": null,
@@ -5979,7 +6639,7 @@
       "episode_id": "coffeejelly",
       "name": "Coffee Jelly inspired by The Disastrous Life of Saiki K.",
       "published_date": "2019-09-24",
-      "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YxEcd_wTf5c/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c",
       "official_link": "https://www.babi.sh/recipes/coffeejelly",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png"
     }
@@ -5994,7 +6654,7 @@
       "episode_id": "coffeejelly",
       "name": "Coffee Jelly inspired by The Disastrous Life of Saiki K.",
       "published_date": "2019-09-24",
-      "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YxEcd_wTf5c/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c",
       "official_link": "https://www.babi.sh/recipes/coffeejelly",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png"
     }
@@ -6009,7 +6669,7 @@
       "episode_id": "coffeejelly",
       "name": "Coffee Jelly inspired by The Disastrous Life of Saiki K.",
       "published_date": "2019-09-24",
-      "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YxEcd_wTf5c/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c",
       "official_link": "https://www.babi.sh/recipes/coffeejelly",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png"
     }
@@ -6135,21 +6795,6 @@
     }
   },
   {
-    "recipe_id": 1260,
-    "name": "condiments & toppings",
-    "image_link": null,
-    "raw_ingredient_list": "milk warm\nbeef\nbutter\nsugar\negg\ntomatoes thinly",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "big-bang-burger-inspired-by-persona-5",
-      "name": "Big Bang Burger inspired by Persona 5",
-      "published_date": "2024-10-07",
-      "youtube_link": "https://www.youtube.com/watch?v=dUxzbnKKzf8&pp=ygUVYmlnIGJhbmcgYnVyZ2VyIGFsdmlu",
-      "official_link": "https://www.babi.sh/recipes/big-bang-burger-inspired-by-persona-5",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1728311555/laq2mbbfwx2xlzw3ucrw.webp"
-    }
-  },
-  {
     "recipe_id": 472,
     "name": "Confit Byaldi",
     "image_link": null,
@@ -6162,6 +6807,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=roCX0AfBseQ",
       "official_link": "https://www.babi.sh/recipes/ratatouille",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992046/slqlttodtrdyc72qugsf.webp"
+    }
+  },
+  {
+    "recipe_id": 1653,
+    "name": "confit tomatoes",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "date-night-2",
+      "name": "DATE NIGHT II",
+      "published_date": "2022-01-11",
+      "youtube_link": "https://www.youtube.com/watch?v=dlATzLk8Nh8",
+      "official_link": "https://www.babi.sh/recipes/date-night-2",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1680979695/cbadjt8l6pkrdiadhks1.webp"
     }
   },
   {
@@ -6232,8 +6892,8 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "cake-pops",
-      "name": "CAKE POPS",
-      "published_date": "2021-11-02",
+      "name": "Cake Pops",
+      "published_date": "2021-10-21",
       "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
       "official_link": "https://www.babi.sh/recipes/cake-pops",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
@@ -6294,9 +6954,24 @@
       "episode_id": "coqauvin",
       "name": "Coq au Vin inspired by Donnie Brasco",
       "published_date": "2019-01-15",
-      "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/VP1uTgikarU/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU",
       "official_link": "https://www.babi.sh/recipes/coqauvin",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695986/babishImages/undefined-867897.png"
+    }
+  },
+  {
+    "recipe_id": 1532,
+    "name": "coq au vin sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "coq-au-vin",
+      "name": "Coq au Vin",
+      "published_date": "2025-10-11",
+      "youtube_link": "https://www.youtube.com/watch?v=cf1H6ylUFH4",
+      "official_link": "https://www.babi.sh/recipes/coq-au-vin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1760217634/qggynlnkmhze8roieemn.webp"
     }
   },
   {
@@ -6387,6 +7062,36 @@
       "youtube_link": "https://www.youtube.com/watch?v=AwS_DIMeVoM&amp;t=7s",
       "official_link": "https://www.babi.sh/recipes/fraiserspecial",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715531/babishImages/undefined-291594.png"
+    }
+  },
+  {
+    "recipe_id": 1658,
+    "name": "cornish hen",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "date-night-2",
+      "name": "DATE NIGHT II",
+      "published_date": "2022-01-11",
+      "youtube_link": "https://www.youtube.com/watch?v=dlATzLk8Nh8",
+      "official_link": "https://www.babi.sh/recipes/date-night-2",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1680979695/cbadjt8l6pkrdiadhks1.webp"
+    }
+  },
+  {
+    "recipe_id": 1657,
+    "name": "cornish hen & sauces",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "date-night-2",
+      "name": "DATE NIGHT II",
+      "published_date": "2022-01-11",
+      "youtube_link": "https://www.youtube.com/watch?v=dlATzLk8Nh8",
+      "official_link": "https://www.babi.sh/recipes/date-night-2",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1680979695/cbadjt8l6pkrdiadhks1.webp"
     }
   },
   {
@@ -6488,7 +7193,7 @@
     "source": {
       "episode_id": "crab-bisque-seinfeld",
       "name": "Crab Bisque inspired by Seinfeld",
-      "published_date": "2022-05-27",
+      "published_date": "2022-05-24",
       "youtube_link": "https://www.youtube.com/watch?v=5kKMB890ABc",
       "official_link": "https://www.babi.sh/recipes/crab-bisque-seinfeld",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695634/babishImages/undefined-585834.png"
@@ -6675,6 +7380,21 @@
     }
   },
   {
+    "recipe_id": 1634,
+    "name": "cr\u00e8me anglaise",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "whimsical-parfait-inspired-by-darker-than-black",
+      "name": "Whimsical Parfait inspired by Darker than Black",
+      "published_date": "2024-10-02",
+      "youtube_link": "https://www.youtube.com/watch?v=GHwZqJYYB80",
+      "official_link": "https://www.babi.sh/recipes/whimsical-parfait-inspired-by-darker-than-black",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727903480/ek6bh07lnnblfomgfhdy.webp"
+    }
+  },
+  {
     "recipe_id": 892,
     "name": "Cr\u00e8me Anglaise",
     "image_link": null,
@@ -6714,7 +7434,7 @@
       "episode_id": "aristocats",
       "name": "Cr\u00e8me de la Cr\u00e8me \u00e0 la Edgar inspired by The Aristocats",
       "published_date": "2019-01-23",
-      "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/zNY-qzp7pD0/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0",
       "official_link": "https://www.babi.sh/recipes/aristocats",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696317/babishImages/undefined-541474.png"
     }
@@ -6735,6 +7455,21 @@
     }
   },
   {
+    "recipe_id": 1515,
+    "name": "cr\u00e8me fra\u00eeche chantilly",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ultimate-french-toast-or-with-babish",
+      "name": "Ultimate French Toast | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=t0nTt7Dm5Og&pp=ygUhYmluZ2luZyB3aXRoIGJhYmlzaCBmcmVuY2ggdG9hc2R0",
+      "official_link": "https://www.babi.sh/recipes/ultimate-french-toast-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769735233/hleoccmfkh4lbwvu6gzz.webp"
+    }
+  },
+  {
     "recipe_id": 84,
     "name": "Creole Seasoning",
     "image_link": null,
@@ -6744,7 +7479,7 @@
       "episode_id": "bubbashrimp2",
       "name": "Shrimp inspired by Forrest Gump Part II",
       "published_date": "2019-04-23",
-      "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/mF6JUfczaO8/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8",
       "official_link": "https://www.babi.sh/recipes/bubbashrimp2",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696055/babishImages/undefined-252668.png"
     }
@@ -6773,8 +7508,8 @@
     "source": {
       "episode_id": "crepessuzette",
       "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-      "published_date": "2019-10-24",
-      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "published_date": "2019-10-22",
+      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
       "official_link": "https://www.babi.sh/recipes/crepessuzette",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png"
     }
@@ -6788,8 +7523,8 @@
     "source": {
       "episode_id": "crepessuzette",
       "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-      "published_date": "2019-10-24",
-      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "published_date": "2019-10-22",
+      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
       "official_link": "https://www.babi.sh/recipes/crepessuzette",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png"
     }
@@ -6870,21 +7605,6 @@
     }
   },
   {
-    "recipe_id": 679,
-    "name": "Crust",
-    "image_link": null,
-    "raw_ingredient_list": "300 grams all-purpose flour\n2 Tbsp sugar\n1 tsp kosher salt\n225 grams unsalted butter, cold & cubed\n6-8 Tbsp ice water",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "ben-wyatt-calzones",
-      "name": "Calzones inspired by Parks & Rec",
-      "published_date": "2020-04-15",
-      "youtube_link": "https://www.youtube.com/watch?v=PvgCEifW7Jo",
-      "official_link": "https://www.babi.sh/recipes/ben-wyatt-calzones",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695309/babishImages/undefined-56906.png"
-    }
-  },
-  {
     "recipe_id": 462,
     "name": "Cubanos",
     "image_link": null,
@@ -6893,7 +7613,7 @@
     "source": {
       "episode_id": "cubanos-inspired-by-chef",
       "name": "Cubanos inspired by Chef",
-      "published_date": "2017-03-29",
+      "published_date": "2017-03-28",
       "youtube_link": "https://www.youtube.com/watch?v=hXYoduN0kWs",
       "official_link": "https://www.babi.sh/recipes/cubanos-inspired-by-chef",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992067/etfzgspqjiwp3janr32z.webp"
@@ -6937,7 +7657,7 @@
     "raw_procedure": "Start by toasting your cinnamon, bay leaves, cloves, cumin seeds, coriander, cardamom, and red pepper flakes over medium heat in a dry stainless steel saute pan. Make sure you keep the pan moving as not to burn your spices. Once they are fragrant and not quite smoking, add them to a spice grinder and blend them until they form a fine powder. Place in a bowl and grate 1 nutmeg into it.",
     "source": {
       "episode_id": "chickentikkamasala",
-      "name": "CHICKEN TIKKA MASALA",
+      "name": "Chicken Tikka Masala",
       "published_date": "2019-03-28",
       "youtube_link": "https://www.youtube.com/watch?v=Bkd0LxBd2L8",
       "official_link": "https://www.babi.sh/recipes/chickentikkamasala",
@@ -6997,7 +7717,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "creme-caramel",
-      "name": "CR\u00c8ME CARAMEL",
+      "name": "Cr\u00e8me Caramel",
       "published_date": "2021-04-08",
       "youtube_link": "https://www.youtube.com/watch?v=ihS8__strtM",
       "official_link": "https://www.babi.sh/recipes/creme-caramel",
@@ -7140,6 +7860,21 @@
     }
   },
   {
+    "recipe_id": 1655,
+    "name": "deconstructed pesto",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "date-night-2",
+      "name": "DATE NIGHT II",
+      "published_date": "2022-01-11",
+      "youtube_link": "https://www.youtube.com/watch?v=dlATzLk8Nh8",
+      "official_link": "https://www.babi.sh/recipes/date-night-2",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1680979695/cbadjt8l6pkrdiadhks1.webp"
+    }
+  },
+  {
     "recipe_id": 395,
     "name": "Decorative Icing",
     "image_link": null,
@@ -7185,6 +7920,21 @@
     }
   },
   {
+    "recipe_id": 1570,
+    "name": "deep fried burger bomb",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "deep-fried-burger-bomb",
+      "name": "Deep Fried Burger Bomb",
+      "published_date": "2025-06-06",
+      "youtube_link": "https://www.youtube.com/watch?v=dhRkD9u0C48&pp=ygUYZnJpZWQgYnVyZ2VyIGJvbWIgYmFiaXNo",
+      "official_link": "https://www.babi.sh/recipes/deep-fried-burger-bomb",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749219273/tfuzfxhkivkjrmtvcjam.webp"
+    }
+  },
+  {
     "recipe_id": 411,
     "name": "Deep Fried Chicken Wings",
     "image_link": null,
@@ -7215,21 +7965,6 @@
     }
   },
   {
-    "recipe_id": 1450,
-    "name": "deep frying",
-    "image_link": null,
-    "raw_ingredient_list": "chicken",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "chimichangas",
-      "name": "CHIMICHANGAS",
-      "published_date": "2020-04-28",
-      "youtube_link": "https://www.youtube.com/watch?v=szFLA4_pwew",
-      "official_link": "https://www.babi.sh/recipes/chimichangas",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715751/babishImages/undefined-916823.png"
-    }
-  },
-  {
     "recipe_id": 617,
     "name": "Demi-Glace",
     "image_link": "",
@@ -7257,6 +7992,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=A7afwIxo5lE",
       "official_link": "https://www.babi.sh/recipes/back-to-school-sandwich",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715748/babishImages/undefined-681777.png"
+    }
+  },
+  {
+    "recipe_id": 1626,
+    "name": "deviled eggs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "the-egg-bar-inspired-by-severance",
+      "name": "The Egg Bar inspired by Severance",
+      "published_date": "2025-02-05",
+      "youtube_link": "https://www.youtube.com/watch?v=pTt4BjY34gk&t=151s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/the-egg-bar-inspired-by-severance",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1738792005/emlcx8fw10frbl32t7lq.webp"
     }
   },
   {
@@ -7335,6 +8085,21 @@
     }
   },
   {
+    "recipe_id": 1484,
+    "name": "dipping sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "kpop-demon-hunters-airplane-feast",
+      "name": "KPop Demon Hunters Airplane Feast",
+      "published_date": "2026-04-11",
+      "youtube_link": "https://youtube.com/watch?v=W8kIAgoqDAI&si=65fH6Fh3e8T6yGu_",
+      "official_link": "https://www.babi.sh/recipes/kpop-demon-hunters-airplane-feast",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1775873571/sifq1hxehqudhjdfchik.webp"
+    }
+  },
+  {
     "recipe_id": 838,
     "name": "Dipping Sauce",
     "image_link": null,
@@ -7387,9 +8152,9 @@
     "raw_procedure": "Mix and pour into a chilled martini glass. Add an olive on a toothpick. Serve.",
     "source": {
       "episode_id": "baressentials",
-      "name": "BAR ESSENTIALS",
+      "name": "Bar Essentials",
       "published_date": "2018-03-15",
-      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/iZUfPIKbgUM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM",
       "official_link": "https://www.babi.sh/recipes/baressentials",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690416607/jlnnbuig1g2nrqafs58x.webp"
     }
@@ -7402,7 +8167,7 @@
     "raw_procedure": "Add a generous amount of fresh black pepper as well as cumin and cayenne (to taste) to 1 lb of ground beef. Place the meat into a pan with 1 tbsp of hot vegetable oil. Once both sides are seared, give it a good chop.\nAdd leftover trinity and 4 cloves of crushed garlic to the pan. After the vegetables finish cooking, add leftover roux and let it warm up for a minute before adding \u2153 cup of beer and 2 cups of chicken stock to the pan. Let simmer for about 45 minutes or until the consistency is a bit thicker.\nAdd 3 cups of cooked white rice, a few pinches of salt, garnish with scallions, and enjoy!",
     "source": {
       "episode_id": "cajunfood",
-      "name": "CAJUN FOOD",
+      "name": "Cajun Food",
       "published_date": "2019-09-13",
       "youtube_link": "https://www.youtube.com/watch?v=nORg_aXMsmA",
       "official_link": "https://www.babi.sh/recipes/cajunfood",
@@ -7419,7 +8184,7 @@
       "episode_id": "baobuns",
       "name": "Bao inspired by Pixar's Bao",
       "published_date": "2019-02-19",
-      "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M&amp;t=46s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/OFt3SThGi7M/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M",
       "official_link": "https://www.babi.sh/recipes/baobuns",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695380/babishImages/undefined-293013.png"
     }
@@ -7470,6 +8235,21 @@
     }
   },
   {
+    "recipe_id": 1132,
+    "name": "Double Chocolate Orange Biscotti",
+    "image_link": null,
+    "raw_ingredient_list": "As needed nonstick spray\n200 g all purpose flour\n50 g cocoa powder\n1 tsp baking powder\n\u00bc tsp baking soda\n\u00bd tsp kosher salt\n120 g dark chocolate\n3 large eggs\n175 g granulated sugar\nZest of 1 large orange\nOptional: \u00bc tsp orange extract\n1 tsp vanilla extract\nOrange glaze (see recipe below)",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "biscotti",
+      "name": "Biscotti",
+      "published_date": "2021-09-24",
+      "youtube_link": "https://www.youtube.com/watch?v=g4EkzEKlGOA",
+      "official_link": "https://www.babi.sh/recipes/biscotti",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695295/babishImages/undefined-256401.png"
+    }
+  },
+  {
     "recipe_id": 907,
     "name": "Double-Decker Welsh Rarebit",
     "image_link": null,
@@ -7477,7 +8257,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "advanced-grilled-cheese",
-      "name": "ADVANCED GRILLED CHEESE",
+      "name": "Advanced Grilled Cheese",
       "published_date": "2021-02-19",
       "youtube_link": "https://www.youtube.com/watch?v=Zo7sRijXG00",
       "official_link": "https://www.babi.sh/recipes/advanced-grilled-cheese",
@@ -7494,7 +8274,7 @@
       "episode_id": "applefritters",
       "name": "Double-Glazed Apple Fritters inspired by Regular Show",
       "published_date": "2019-08-27",
-      "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YYSP1D6GJ30/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30",
       "official_link": "https://www.babi.sh/recipes/applefritters",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695467/babishImages/undefined-689012.png"
     }
@@ -7552,9 +8332,9 @@
     "raw_procedure": "Shake and strain into a chilled martini glass. Serve neat.",
     "source": {
       "episode_id": "baressentials",
-      "name": "BAR ESSENTIALS",
+      "name": "Bar Essentials",
       "published_date": "2018-03-15",
-      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/iZUfPIKbgUM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM",
       "official_link": "https://www.babi.sh/recipes/baressentials",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690416607/jlnnbuig1g2nrqafs58x.webp"
     }
@@ -7575,8 +8355,38 @@
     }
   },
   {
+    "recipe_id": 1577,
+    "name": "duck",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "3-course-dinner-inspired-by-drop",
+      "name": "3 Course Dinner inspired by Drop",
+      "published_date": "2025-05-03",
+      "youtube_link": "https://www.youtube.com/watch?v=23lKOTVYRGc&t=673s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/3-course-dinner-inspired-by-drop",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1746310289/sxhsw0jiihdjo9tibmw5.webp"
+    }
+  },
+  {
+    "recipe_id": 1576,
+    "name": "duck breast salad",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "3-course-dinner-inspired-by-drop",
+      "name": "3 Course Dinner inspired by Drop",
+      "published_date": "2025-05-03",
+      "youtube_link": "https://www.youtube.com/watch?v=23lKOTVYRGc&t=673s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/3-course-dinner-inspired-by-drop",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1746310289/sxhsw0jiihdjo9tibmw5.webp"
+    }
+  },
+  {
     "recipe_id": 1314,
-    "name": "duck cake:",
+    "name": "Duck Cake",
     "image_link": null,
     "raw_ingredient_list": "butter\nsugar\nflour\nmilk\nbuttermilk\neggs",
     "raw_procedure": "",
@@ -7725,6 +8535,21 @@
     }
   },
   {
+    "recipe_id": 1566,
+    "name": "eggplant sandwich",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv",
+      "name": "Quadruple Stacked Ham Sandwich inspired by Final Fantasy XV",
+      "published_date": "2025-08-19",
+      "youtube_link": "https://www.youtube.com/watch?v=ouJL4FGGbuc",
+      "official_link": "https://www.babi.sh/recipes/quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1755625602/nnowpvarxiludykiovik.webp"
+    }
+  },
+  {
     "recipe_id": 1285,
     "name": "eggs",
     "image_link": null,
@@ -7737,6 +8562,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=LcMYQtVchPA",
       "official_link": "https://www.babi.sh/recipes/transforming-furikake-gohan-inspired-by-food-wars!",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1724877203/bcpv95p0gnazhatj7qqv.webp"
+    }
+  },
+  {
+    "recipe_id": 1606,
+    "name": "egg salad",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "egg-salad-inspired-by-futurama",
+      "name": "Egg Salad inspired by Futurama",
+      "published_date": "2025-03-07",
+      "youtube_link": "https://www.youtube.com/watch?v=cgLi9t6w9Qc&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/egg-salad-inspired-by-futurama",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741383035/fhpr01pnfwh4o1lpeje9.webp"
     }
   },
   {
@@ -7830,21 +8670,6 @@
     }
   },
   {
-    "recipe_id": 1398,
-    "name": "egg wash",
-    "image_link": null,
-    "raw_ingredient_list": "flour\nmilk\nunsalted european style butter\nchocolate\nsugar\nbutter",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "chocolate-croissants-its-complicated",
-      "name": "Chocolate Croissants inspired by It's Complicated",
-      "published_date": "2022-08-01",
-      "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
-      "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png"
-    }
-  },
-  {
     "recipe_id": 1304,
     "name": "egg wash:",
     "image_link": null,
@@ -7890,6 +8715,21 @@
     }
   },
   {
+    "recipe_id": 1598,
+    "name": "egg whites mixture",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "cheesecake-inspired-by-junior's-cheesecakes",
+      "name": "Cheesecake inspired by Junior's Cheesecakes",
+      "published_date": "2025-03-11",
+      "youtube_link": "https://www.youtube.com/watch?v=gQeY_wx9bsI&t=26s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/cheesecake-inspired-by-junior's-cheesecakes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741657095/qjrimy3opynb08w9zudl.webp"
+    }
+  },
+  {
     "recipe_id": 1348,
     "name": "el burdigato hot dog",
     "image_link": null,
@@ -7927,7 +8767,7 @@
     "raw_procedure": "Start by husking 4 ears of corn and then slice all the kernels off the cob. Next finely dice \u00bd a small yellow onion.\nIn a pan, melt 2 Tbsp butter and saute your onion until soft and then add most of your corn kernels and saute for a few minutes. Add 1 cup of chicken stock and season with paprika, cumin, and cayenne pepper. Bring to a simmer. Cook for 15 minutes or until corn is soft.\nIn another saucepan, brown 6 Tbsp butter and add the rest of your corn to the butter. Saute for 3-4 minutes. Place in a small bowl and set aside.\nAdd the corn and chicken stock mixture to a high powered blender and blend to combine. Once lightly blended, add \u00bd cup of heavy cream and 1-2 Tbsp of sugar. Add white pepper and salt to taste, and add any more cream or sugar if needed.\nPrepare your toppings: Fry up some bacon and then chop into small pieces and set aside as a garnish. Next thinly slice some jalapenos and set aside. Also add some cotija cheese to a bowl.\nPour your blended corn mixture into a bowl and add whichever of the toppings you\u2019d like.\nServe and enjoy.",
     "source": {
       "episode_id": "blendersoups",
-      "name": "BLENDER SOUPS",
+      "name": "Blender Soups",
       "published_date": "2019-03-05",
       "youtube_link": "https://www.youtube.com/watch?v=S-gUFvpRQoU",
       "official_link": "https://www.babi.sh/recipes/blendersoups",
@@ -7965,6 +8805,36 @@
     }
   },
   {
+    "recipe_id": 809,
+    "name": "Elote Spoon Bread",
+    "image_link": null,
+    "raw_ingredient_list": "1 \u2154 cups fresh or frozen corn kernels",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "andrewsohlathanksgiving",
+      "name": "Thanksgiving Recipe Livestream with Sohla El-Waylly",
+      "published_date": "2020-11-20",
+      "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
+      "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715526/babishImages/undefined-665559.jpg"
+    }
+  },
+  {
+    "recipe_id": 808,
+    "name": "Elote Spoon Bread Pan Prep",
+    "image_link": null,
+    "raw_ingredient_list": "2 tbsp mayonnaise\n\u00bc cup finely crumbled cotija cheese",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "andrewsohlathanksgiving",
+      "name": "Thanksgiving Recipe Livestream with Sohla El-Waylly",
+      "published_date": "2020-11-20",
+      "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
+      "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715526/babishImages/undefined-665559.jpg"
+    }
+  },
+  {
     "recipe_id": 1118,
     "name": "English Muffins",
     "image_link": null,
@@ -7992,6 +8862,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=g1j-5UkZyL0&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/g1j-5UkZyL0/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
       "official_link": "https://www.babi.sh/recipes/marmalade",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695964/babishImages/undefined-95417.png"
+    }
+  },
+  {
+    "recipe_id": 1482,
+    "name": "eomuk guk",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "kpop-demon-hunters-airplane-feast",
+      "name": "KPop Demon Hunters Airplane Feast",
+      "published_date": "2026-04-11",
+      "youtube_link": "https://youtube.com/watch?v=W8kIAgoqDAI&si=65fH6Fh3e8T6yGu_",
+      "official_link": "https://www.babi.sh/recipes/kpop-demon-hunters-airplane-feast",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1775873571/sifq1hxehqudhjdfchik.webp"
     }
   },
   {
@@ -8085,6 +8970,21 @@
     }
   },
   {
+    "recipe_id": 1306,
+    "name": "Everything Bagel",
+    "image_link": null,
+    "raw_ingredient_list": "milk\nflour\nsalt\nsugar\nwhite vinegar\nwhite sesame seeds",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "bagelwithlox",
+      "name": "Everything Bagel with Lox Inspired By Mr. & Mrs. Smith",
+      "published_date": "2024-03-27",
+      "youtube_link": "https://youtu.be/ZOZ2qkcfWe0",
+      "official_link": "https://www.babi.sh/recipes/bagelwithlox",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1711553048/yyeo9skkrkvuloahw7lm.webp"
+    }
+  },
+  {
     "recipe_id": 1415,
     "name": "everything bagel filling",
     "image_link": null,
@@ -8097,21 +8997,6 @@
       "youtube_link": "https://www.youtube.com/watch?v=PHheRDVn3e8",
       "official_link": "https://www.babi.sh/recipes/sweet-and-savory-babka",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695584/babishImages/undefined-67986.png"
-    }
-  },
-  {
-    "recipe_id": 1306,
-    "name": "everything bagel ingredients:",
-    "image_link": null,
-    "raw_ingredient_list": "milk\nflour\nsalt\nsugar\nwhite vinegar\nwhite sesame seeds",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "bagelwithlox",
-      "name": "Everything Bagel with Lox Inspired By Mr. & Mrs. Smith",
-      "published_date": "2024-03-27",
-      "youtube_link": "https://youtu.be/ZOZ2qkcfWe0",
-      "official_link": "https://www.babi.sh/recipes/bagelwithlox",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1711553048/yyeo9skkrkvuloahw7lm.webp"
     }
   },
   {
@@ -8139,7 +9024,7 @@
       "episode_id": "bagelsandwiches",
       "name": "Bagel Sandwiches inspired by Steven Universe",
       "published_date": "2019-07-23",
-      "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
       "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png"
     }
@@ -8167,11 +9052,26 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "corn-dogs",
-      "name": "CORN DOGS",
+      "name": "Corn Dogs",
       "published_date": "2021-05-27",
       "youtube_link": "https://www.youtube.com/watch?v=zGT45vVJNso",
       "official_link": "https://www.babi.sh/recipes/corn-dogs",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695001/babishImages/undefined-765280.png"
+    }
+  },
+  {
+    "recipe_id": 1546,
+    "name": "fallout: the vault dweller's official cookbook",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "name": "Fallout Fancy Lad Snack Cakes inspired by Fallout 76",
+      "published_date": "2025-10-01",
+      "youtube_link": "https://www.youtube.com/watch?v=v1f835eNhUc",
+      "official_link": "https://www.babi.sh/recipes/fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759334763/qv57em4y8nloxgzztjrs.webp"
     }
   },
   {
@@ -8197,11 +9097,41 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "bacon",
-      "name": "HOMEMADE BACON",
+      "name": "Homemade Bacon",
       "published_date": "2021-04-30",
       "youtube_link": "https://www.youtube.com/watch?v=TUh4Z2li1UM",
       "official_link": "https://www.babi.sh/recipes/bacon",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715746/babishImages/undefined-294937.png"
+    }
+  },
+  {
+    "recipe_id": 1624,
+    "name": "fennel salad",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "my-top-5-easy-sexy-dishes",
+      "name": "My Top 5 Easy, Sexy Dishes",
+      "published_date": "2025-02-14",
+      "youtube_link": "https://www.youtube.com/watch?v=BAxICJRICNU&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/my-top-5-easy-sexy-dishes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1739562469/nya8wka5lyucenir6wez.webp"
+    }
+  },
+  {
+    "recipe_id": 1235,
+    "name": "fettuccine alfredo",
+    "image_link": null,
+    "raw_ingredient_list": "eggs\ndouble zero flour\nsemolina flour\ntwenty four month aged parmigiano reggiano\nunsalted high quality butter",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "classic-fettucine-alfredo",
+      "name": "Classic Fettuccine Alfredo",
+      "published_date": "2025-06-06",
+      "youtube_link": "https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo",
+      "official_link": "https://www.babi.sh/recipes/classic-fettucine-alfredo",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749216590/llpz2sobgkra4ttgl9kx.webp"
     }
   },
   {
@@ -8217,21 +9147,6 @@
       "youtube_link": "https://www.youtube.com/watch?v=WS6_CeuSn_s",
       "official_link": "https://www.babi.sh/recipes/fettuccine-alfredo-the-office",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695651/babishImages/undefined-454337.png"
-    }
-  },
-  {
-    "recipe_id": 1235,
-    "name": "fettucine alfredo",
-    "image_link": null,
-    "raw_ingredient_list": "eggs\ndouble zero flour\nsemolina flour\ntwenty four month aged parmigiano reggiano\nunsalted high quality butter",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "classic-fettucine-alfredo",
-      "name": "Classic Fettucine Alfredo",
-      "published_date": "2025-06-06",
-      "youtube_link": "https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo",
-      "official_link": "https://www.babi.sh/recipes/classic-fettucine-alfredo",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749216590/llpz2sobgkra4ttgl9kx.webp"
     }
   },
   {
@@ -8265,18 +9180,33 @@
     }
   },
   {
-    "recipe_id": 680,
-    "name": "Filling",
+    "recipe_id": 1544,
+    "name": "filet mignon: steak tartare",
     "image_link": null,
-    "raw_ingredient_list": "2lbs honey crisp apples, peeled and sliced\n1 lemon, juiced\n\u00be cup sugar\n1 \u00bd Tbsp cornstarch\n\u00bc cup brown sugar\n2 tsp cinnamon\n\u00bd tsp ground ginger\n\u00bd tsp allspice\n\u00bc tsp ground clove\nZest of 1 lemon\n1 tsp kosher salt\n1 egg white\nDemerara sugar",
+    "raw_ingredient_list": "",
     "raw_procedure": "",
     "source": {
-      "episode_id": "ben-wyatt-calzones",
-      "name": "Calzones inspired by Parks & Rec",
-      "published_date": "2020-04-15",
-      "youtube_link": "https://www.youtube.com/watch?v=PvgCEifW7Jo",
-      "official_link": "https://www.babi.sh/recipes/ben-wyatt-calzones",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695309/babishImages/undefined-56906.png"
+      "episode_id": "steak",
+      "name": "Steak",
+      "published_date": "2025-10-03",
+      "youtube_link": "https://www.youtube.com/watch?v=peAbYlvP6rU",
+      "official_link": "https://www.babi.sh/recipes/steak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759667611/ivsyx6hgxw8cwudn9brl.webp"
+    }
+  },
+  {
+    "recipe_id": 1625,
+    "name": "filet mignon with chimichurri",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "my-top-5-easy-sexy-dishes",
+      "name": "My Top 5 Easy, Sexy Dishes",
+      "published_date": "2025-02-14",
+      "youtube_link": "https://www.youtube.com/watch?v=BAxICJRICNU&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/my-top-5-easy-sexy-dishes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1739562469/nya8wka5lyucenir6wez.webp"
     }
   },
   {
@@ -8332,7 +9262,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "chicken-parmesan",
-      "name": "CHICKEN PARMESAN",
+      "name": "Chicken Parmesan",
       "published_date": "2020-12-10",
       "youtube_link": "https://www.youtube.com/watch?v=ZrR0VbqNdW8",
       "official_link": "https://www.babi.sh/recipes/chicken-parmesan",
@@ -8460,18 +9390,18 @@
     }
   },
   {
-    "recipe_id": 1440,
-    "name": "fonduta",
+    "recipe_id": 1554,
+    "name": "fondant coating",
     "image_link": null,
-    "raw_ingredient_list": "desired cheese\nyellow & white cheddar\nfontina cheese\ndry white wine\nbeer\nmilk\nbutter",
+    "raw_ingredient_list": "",
     "raw_procedure": "",
     "source": {
-      "episode_id": "cheese-fondue",
-      "name": "CHEEESE FONDUE",
-      "published_date": "2020-07-23",
-      "youtube_link": "https://www.youtube.com/watch?v=_X-Mm8h1AHM",
-      "official_link": "https://www.babi.sh/recipes/cheese-fondue",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715730/babishImages/undefined-469596.png"
+      "episode_id": "fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "name": "Fallout Fancy Lad Snack Cakes inspired by Fallout 76",
+      "published_date": "2025-10-01",
+      "youtube_link": "https://www.youtube.com/watch?v=v1f835eNhUc",
+      "official_link": "https://www.babi.sh/recipes/fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759334763/qv57em4y8nloxgzztjrs.webp"
     }
   },
   {
@@ -8512,7 +9442,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "birria-tacos",
-      "name": "BIRRIA TACOS",
+      "name": "Birria Tacos",
       "published_date": "2021-03-11",
       "youtube_link": "https://www.youtube.com/watch?v=pQmSrlIbULk",
       "official_link": "https://www.babi.sh/recipes/birria-tacos",
@@ -8753,7 +9683,7 @@
     "source": {
       "episode_id": "cocktail-special",
       "name": "Cocktail Special",
-      "published_date": "2017-06-28",
+      "published_date": "2017-06-27",
       "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
       "official_link": "https://www.babi.sh/recipes/cocktail-special",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -8797,7 +9727,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "calistyle-burrito",
-      "name": "CALI-STYLE BURRITO",
+      "name": "California Style Burritos",
       "published_date": "2021-09-13",
       "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
       "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
@@ -8827,7 +9757,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "advanced-grilled-cheese",
-      "name": "ADVANCED GRILLED CHEESE",
+      "name": "Advanced Grilled Cheese",
       "published_date": "2021-02-19",
       "youtube_link": "https://www.youtube.com/watch?v=Zo7sRijXG00",
       "official_link": "https://www.babi.sh/recipes/advanced-grilled-cheese",
@@ -8880,6 +9810,21 @@
     }
   },
   {
+    "recipe_id": 1516,
+    "name": "french toast custard",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ultimate-french-toast-or-with-babish",
+      "name": "Ultimate French Toast | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=t0nTt7Dm5Og&pp=ygUhYmluZ2luZyB3aXRoIGJhYmlzaCBmcmVuY2ggdG9hc2R0",
+      "official_link": "https://www.babi.sh/recipes/ultimate-french-toast-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769735233/hleoccmfkh4lbwvu6gzz.webp"
+    }
+  },
+  {
     "recipe_id": 509,
     "name": "Fried Chicken",
     "image_link": null,
@@ -8902,11 +9847,26 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "chicken-parmesan",
-      "name": "CHICKEN PARMESAN",
+      "name": "Chicken Parmesan",
       "published_date": "2020-12-10",
       "youtube_link": "https://www.youtube.com/watch?v=ZrR0VbqNdW8",
       "official_link": "https://www.babi.sh/recipes/chicken-parmesan",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715495/babishImages/undefined-30590.png"
+    }
+  },
+  {
+    "recipe_id": 1337,
+    "name": "fried chicken cutlets",
+    "image_link": null,
+    "raw_ingredient_list": "boneless skinless chicken breast butterfied\nbuttermilk\nflour",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "crispiest-sandwich-kidnapped-on-christmas",
+      "name": "The Crispiest Sandwich inspired by They Kidnapped my Son on Christmas",
+      "published_date": "2023-08-09",
+      "youtube_link": "https://www.youtube.com/watch?v=mhLM0FUlhJg",
+      "official_link": "https://www.babi.sh/recipes/crispiest-sandwich-kidnapped-on-christmas",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1695094920/vr0vqmqsilm4by7affx7.webp"
     }
   },
   {
@@ -9007,7 +9967,7 @@
     "raw_procedure": "Start by peeling your potatoes. Slice into planks and then slice the planks into french fry-like shapes as thick or as thin as you\u2019d like.\nOnce your fries are cut, immediately put them into peanut oil (or vegetable oil) at 375\u00b0F and par-fry them for about 8 minutes. Lay them on a paper towel lined baking sheet and place in freezer for 30 minutes.\nRemove from freezer and place back in fryer for 4-6 minutes. Cook until golden brown. Drain for 30 seconds.\nPlace in a bowl with kosher salt and mix until coated.",
     "source": {
       "episode_id": "burgers",
-      "name": "BURGERS",
+      "name": "Burgers",
       "published_date": "2018-06-14",
       "youtube_link": "https://www.youtube.com/watch?v=nbCgfiqq-5c",
       "official_link": "https://www.babi.sh/recipes/burgers",
@@ -9174,7 +10134,7 @@
       "episode_id": "avengersicecream",
       "name": "Ice Cream Flavors inspired by Avengers: Infinity War",
       "published_date": "2019-04-30",
-      "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Ukjat70Iyt4/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4",
       "official_link": "https://www.babi.sh/recipes/avengersicecream",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695805/babishImages/undefined-987247.png"
     }
@@ -9255,6 +10215,21 @@
     }
   },
   {
+    "recipe_id": 1496,
+    "name": "garlic butter",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "super-bowl-snacks-for-the-win-or-with-babish",
+      "name": "Super Bowl Snacks for the Win | With Babish",
+      "published_date": "2026-02-02",
+      "youtube_link": "https://youtube.com/watch?v=YIf161LjodE",
+      "official_link": "https://www.babi.sh/recipes/super-bowl-snacks-for-the-win-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1770071325/fy1ppzw7ndz0jh29hkmh.webp"
+    }
+  },
+  {
     "recipe_id": 1136,
     "name": "Garlic Chili Sauce",
     "image_link": null,
@@ -9285,6 +10260,21 @@
     }
   },
   {
+    "recipe_id": 1270,
+    "name": "Garlic Fried Rice",
+    "image_link": null,
+    "raw_ingredient_list": "garlic thinly\nparsley\nbeef tallow butter\nbutter\nsalt",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "a5-wagyu-roti-don-inspired-by-food-wars!",
+      "name": "A5 Wagyu Roti Don inspired by Food Wars!",
+      "published_date": "2024-09-12",
+      "youtube_link": "https://www.youtube.com/watch?v=VzPJE4LUxC4",
+      "official_link": "https://www.babi.sh/recipes/a5-wagyu-roti-don-inspired-by-food-wars!",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1726150996/cqreovarq8cekj22lfnt.webp"
+    }
+  },
+  {
     "recipe_id": 389,
     "name": "Garlic Sauce (Toum)",
     "image_link": null,
@@ -9297,21 +10287,6 @@
       "youtube_link": "https://www.youtube.com/watch?v=XIZxT7iI-QI",
       "official_link": "https://www.babi.sh/recipes/curbyourenthusiasm",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715468/babishImages/undefined-615321.png"
-    }
-  },
-  {
-    "recipe_id": 1264,
-    "name": "garnish",
-    "image_link": null,
-    "raw_ingredient_list": "corn starch\npotato starch\nblack sea bass\nneutral oil\nshaoxing cooking wine\nsalt\n40g white vinegar",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "blooming-fish-inspired-by-cinderella-chef",
-      "name": "Blooming Fish inspired by Cinderella Chef",
-      "published_date": "2024-10-02",
-      "youtube_link": "https://www.youtube.com/watch?v=DAwamRa8m9Y",
-      "official_link": "https://www.babi.sh/recipes/blooming-fish-inspired-by-cinderella-chef",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727902497/v0e6pzds2idrfzg2dqbj.webp"
     }
   },
   {
@@ -9375,6 +10350,21 @@
     }
   },
   {
+    "recipe_id": 1485,
+    "name": "gimbap",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "kpop-demon-hunters-airplane-feast",
+      "name": "KPop Demon Hunters Airplane Feast",
+      "published_date": "2026-04-11",
+      "youtube_link": "https://youtube.com/watch?v=W8kIAgoqDAI&si=65fH6Fh3e8T6yGu_",
+      "official_link": "https://www.babi.sh/recipes/kpop-demon-hunters-airplane-feast",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1775873571/sifq1hxehqudhjdfchik.webp"
+    }
+  },
+  {
     "recipe_id": 298,
     "name": "Gin and Tonic",
     "image_link": null,
@@ -9382,9 +10372,9 @@
     "raw_procedure": "Mix and serve.",
     "source": {
       "episode_id": "baressentials",
-      "name": "BAR ESSENTIALS",
+      "name": "Bar Essentials",
       "published_date": "2018-03-15",
-      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/iZUfPIKbgUM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM",
       "official_link": "https://www.babi.sh/recipes/baressentials",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690416607/jlnnbuig1g2nrqafs58x.webp"
     }
@@ -9429,7 +10419,7 @@
       "episode_id": "brocksdonuts",
       "name": "Brock's Donuts inspired by Pok\u00e9mon",
       "published_date": "2019-04-02",
-      "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/RentKWlhUXc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc",
       "official_link": "https://www.babi.sh/recipes/brocksdonuts",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695178/babishImages/undefined-56205.png"
     }
@@ -9615,6 +10605,21 @@
     }
   },
   {
+    "recipe_id": 1611,
+    "name": "gourmet egg salad",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "egg-salad-inspired-by-futurama",
+      "name": "Egg Salad inspired by Futurama",
+      "published_date": "2025-03-07",
+      "youtube_link": "https://www.youtube.com/watch?v=cgLi9t6w9Qc&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/egg-salad-inspired-by-futurama",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741383035/fhpr01pnfwh4o1lpeje9.webp"
+    }
+  },
+  {
     "recipe_id": 1254,
     "name": "Gourmet Meat Stew inspired by Breath of the Wild",
     "image_link": null,
@@ -9765,6 +10770,21 @@
     }
   },
   {
+    "recipe_id": 1660,
+    "name": "gremolata",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "date-night-2",
+      "name": "DATE NIGHT II",
+      "published_date": "2022-01-11",
+      "youtube_link": "https://www.youtube.com/watch?v=dlATzLk8Nh8",
+      "official_link": "https://www.babi.sh/recipes/date-night-2",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1680979695/cbadjt8l6pkrdiadhks1.webp"
+    }
+  },
+  {
     "recipe_id": 346,
     "name": "Gremolata",
     "image_link": null,
@@ -9864,7 +10884,7 @@
       "episode_id": "alwayssunny",
       "name": "It's Always Sunny in Philadelphia Special (Part II)",
       "published_date": "2019-06-12",
-      "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/_fnhy5xO9vQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ",
       "official_link": "https://www.babi.sh/recipes/alwayssunny",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696347/babishImages/undefined-129032.png"
     }
@@ -9922,7 +10942,7 @@
     "raw_procedure": "Start by getting your grill ready and making a two zone fire. That means keeping the coals to one side of your charcoal grill super hot thus creating two separate zones. You can also do this on a propane grill by just turning half the burners on high.\nNext you\u2019re going to take your pork chops, stand them up by the bones, and place two wooden or metal skewers through them. Make two small slices through the fat cap of each pork chop to keep the pork from curling.\nPlace the chops on the cooler side of the fire, bone side down and cook until they reach an internal temperature of 115\u00b0F. Remove skewers and place on the hot side of the grill.\nLayer pork chops with barbecue sauce, flipping continually until they reach an internal temperature of 145\u00b0F. Once they\u2019ve reached that temperature, remove from grill and place on a baking sheet to rest for 3 minutes.\nCoat them with one final layer of sauce. Serve and enjoy!",
     "source": {
       "episode_id": "barbecueporkchops",
-      "name": "BARBECUE PORK CHOPS",
+      "name": "Barbecue Pork Chops",
       "published_date": "2018-06-28",
       "youtube_link": "https://www.youtube.com/watch?v=YV9XuvfIudY",
       "official_link": "https://www.babi.sh/recipes/barbecueporkchops",
@@ -9997,7 +11017,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "calistyle-burrito",
-      "name": "CALI-STYLE BURRITO",
+      "name": "California Style Burritos",
       "published_date": "2021-09-13",
       "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
       "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
@@ -10027,7 +11047,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "bacon",
-      "name": "HOMEMADE BACON",
+      "name": "Homemade Bacon",
       "published_date": "2021-04-30",
       "youtube_link": "https://www.youtube.com/watch?v=TUh4Z2li1UM",
       "official_link": "https://www.babi.sh/recipes/bacon",
@@ -10065,18 +11085,18 @@
     }
   },
   {
-    "recipe_id": 1276,
-    "name": "ham cheese croissants",
+    "recipe_id": 1567,
+    "name": "ham & sweet potato sandwich",
     "image_link": null,
-    "raw_ingredient_list": "croissant dough scraps\ncroissant dough\nlayer croissant dough",
+    "raw_ingredient_list": "",
     "raw_procedure": "",
     "source": {
-      "episode_id": "324-layer-croissant-inspired-by-yakitate!!-japan",
-      "name": "324 Layer Croissant inspired by Yakitate!! Japan",
-      "published_date": "2024-09-04",
-      "youtube_link": "https://www.youtube.com/watch?v=Ni8BsXyln_Q",
-      "official_link": "https://www.babi.sh/recipes/324-layer-croissant-inspired-by-yakitate!!-japan",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1725483449/qdfiijvciz0hlmgz6qrs.webp"
+      "episode_id": "quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv",
+      "name": "Quadruple Stacked Ham Sandwich inspired by Final Fantasy XV",
+      "published_date": "2025-08-19",
+      "youtube_link": "https://www.youtube.com/watch?v=ouJL4FGGbuc",
+      "official_link": "https://www.babi.sh/recipes/quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1755625602/nnowpvarxiludykiovik.webp"
     }
   },
   {
@@ -10110,6 +11130,36 @@
     }
   },
   {
+    "recipe_id": 1543,
+    "name": "hanger steak",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "steak",
+      "name": "Steak",
+      "published_date": "2025-10-03",
+      "youtube_link": "https://www.youtube.com/watch?v=peAbYlvP6rU",
+      "official_link": "https://www.babi.sh/recipes/steak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759667611/ivsyx6hgxw8cwudn9brl.webp"
+    }
+  },
+  {
+    "recipe_id": 1627,
+    "name": "hard boiled eggs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "the-egg-bar-inspired-by-severance",
+      "name": "The Egg Bar inspired by Severance",
+      "published_date": "2025-02-05",
+      "youtube_link": "https://www.youtube.com/watch?v=pTt4BjY34gk&t=151s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/the-egg-bar-inspired-by-severance",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1738792005/emlcx8fw10frbl32t7lq.webp"
+    }
+  },
+  {
     "recipe_id": 740,
     "name": "Hash Brown Patties",
     "image_link": null,
@@ -10140,29 +11190,14 @@
     }
   },
   {
-    "recipe_id": 1431,
-    "name": "hazelnuts baklava",
-    "image_link": null,
-    "raw_ingredient_list": "phyllo dough\nhazelnuts\npistachio de shelled\nbutter\nsugar\ndark chocolate\nhoney",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "baklava",
-      "name": "BAKLAVA",
-      "published_date": "2020-10-15",
-      "youtube_link": "https://www.youtube.com/watch?v=OkzpwHodaAs",
-      "official_link": "https://www.babi.sh/recipes/baklava",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715500/babishImages/undefined-703057.png"
-    }
-  },
-  {
     "recipe_id": 996,
-    "name": "Healthy-esque BLT ingredients",
+    "name": "Healthy-esque BLT",
     "image_link": null,
     "raw_ingredient_list": "2 classic bacon slices\n2 slices tomato\nAs needed kosher salt\n2 slices seeded whole wheat bread\n1 Tbsp unsalted butter\n1 Tbsp avocado mayonnaise\n\u00bc cup (loosely packed) alfalfa sprouts\nTo taste kosher salt\nTo taste freshly ground black pepper",
     "raw_procedure": "",
     "source": {
       "episode_id": "bacon",
-      "name": "HOMEMADE BACON",
+      "name": "Homemade Bacon",
       "published_date": "2021-04-30",
       "youtube_link": "https://www.youtube.com/watch?v=TUh4Z2li1UM",
       "official_link": "https://www.babi.sh/recipes/bacon",
@@ -10312,7 +11347,7 @@
     "raw_procedure": "Combine \u00bd cup ketchup, \u00bd a small onion finely grated, 1-2 Tbsp of worcestershire sauce, \u00bd tsp smoked paprika, 1 Tbsp of apple cider vinegar, 2 Tbsp of dijon mustard, and 1-2 Tbsp of dark brown sugar. Whisk to combine. Simmer for 30 minutes on low heat.",
     "source": {
       "episode_id": "barbecueporkchops",
-      "name": "BARBECUE PORK CHOPS",
+      "name": "Barbecue Pork Chops",
       "published_date": "2018-06-28",
       "youtube_link": "https://www.youtube.com/watch?v=YV9XuvfIudY",
       "official_link": "https://www.babi.sh/recipes/barbecueporkchops",
@@ -10342,7 +11377,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "biscuits-and-gravy",
-      "name": "BISCUITS AND GRAVY",
+      "name": "Biscuits & Gravy",
       "published_date": "2021-02-25",
       "youtube_link": "https://www.youtube.com/watch?v=NMbMT9tY8-Q",
       "official_link": "https://www.babi.sh/recipes/biscuits-and-gravy",
@@ -10392,6 +11427,36 @@
       "youtube_link": "https://www.youtube.com/watch?v=_SObOsXrDRc",
       "official_link": "https://www.babi.sh/recipes/pulledpork",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1685913479/ewsxvdz9xce9hohksnmc.webp"
+    }
+  },
+  {
+    "recipe_id": 1498,
+    "name": "homemade mayo",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "super-bowl-snacks-for-the-win-or-with-babish",
+      "name": "Super Bowl Snacks for the Win | With Babish",
+      "published_date": "2026-02-02",
+      "youtube_link": "https://youtube.com/watch?v=YIf161LjodE",
+      "official_link": "https://www.babi.sh/recipes/super-bowl-snacks-for-the-win-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1770071325/fy1ppzw7ndz0jh29hkmh.webp"
+    }
+  },
+  {
+    "recipe_id": 1628,
+    "name": "homemade mayo",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "the-egg-bar-inspired-by-severance",
+      "name": "The Egg Bar inspired by Severance",
+      "published_date": "2025-02-05",
+      "youtube_link": "https://www.youtube.com/watch?v=pTt4BjY34gk&t=151s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/the-egg-bar-inspired-by-severance",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1738792005/emlcx8fw10frbl32t7lq.webp"
     }
   },
   {
@@ -10530,6 +11595,21 @@
     }
   },
   {
+    "recipe_id": 127,
+    "name": "Homemade Ritz Crackers",
+    "image_link": null,
+    "raw_ingredient_list": "10 ounces all purpose flour\n3 tsp baking powder\n\u00bd tsp kosher salt\n1 Tbsp granulated sugar\n6 Tbsp cold butter\n2 Tbsp vegetable oil\n\u2154 cup ice water",
+    "raw_procedure": "In a food processor add 10 ounces of all purpose flour along with 3 tsp of baking powder, \u00bd tsp of kosher salt, and 1 Tbsp of granulated sugar. Pulse to combine.\nNext add 6 Tbsp of sliced cold butter along with 2 Tbsp of vegetable oil and mix to combine before drizzling \u2154 cup of ice cold water into the food processor while it\u2019s processing. When a ball of dough forms, remove and immediately wrap in plastic wrap and place in the fridge for 10-15 minutes.\nRemove dough from the fridge and liberally flour your work surface. Roll out your dough as thin as possible. Using a fluted biscuit cutter, cut out cracker shapes and place them on a parchment lined baking sheet. Using a toothpick add the signature Ritz Cracker 7 holes and then brush all of them down with some melted butter. Place in a 400\u00b0F oven for 10-15 minutes.\nOnce they are golden brown in the oven, remove and brush with butter and immediately sprinkle with some salt.",
+    "source": {
+      "episode_id": "aristocats",
+      "name": "Cr\u00e8me de la Cr\u00e8me \u00e0 la Edgar inspired by The Aristocats",
+      "published_date": "2019-01-23",
+      "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0",
+      "official_link": "https://www.babi.sh/recipes/aristocats",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696317/babishImages/undefined-541474.png"
+    }
+  },
+  {
     "recipe_id": 957,
     "name": "Homemade Sausage Churrasco",
     "image_link": null,
@@ -10538,10 +11618,25 @@
     "source": {
       "episode_id": "chefs-choice-platter-monster-hunter-world",
       "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-      "published_date": "2021-03-31",
+      "published_date": "2021-03-30",
       "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
       "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png"
+    }
+  },
+  {
+    "recipe_id": 1650,
+    "name": "homemade sour cream",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "pierogis",
+      "name": "PIEROGIS",
+      "published_date": "2023-02-24",
+      "youtube_link": "https://www.youtube.com/watch?v=58hC3MCVwkw",
+      "official_link": "https://www.babi.sh/recipes/pierogis",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690353185/d6hdqdddrsens6ovoe07.webp"
     }
   },
   {
@@ -10552,7 +11647,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "apple-cider-donuts",
-      "name": "APPLE CIDER DONUTS",
+      "name": "Apple Cider Donuts",
       "published_date": "2021-11-09",
       "youtube_link": "https://www.youtube.com/watch?v=baZoJYAQjfI",
       "official_link": "https://www.babi.sh/recipes/apple-cider-donuts",
@@ -10617,6 +11712,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=4BTm1Ezl6XE",
       "official_link": "https://www.babi.sh/recipes/chili-two-ways",
       "image_link": "https://images.squarespace-cdn.com/content/v1/59d40133017db2fd8a60b3fe/1580394251048-E9PK1EUOJW3TS4QI6DYT/BWB+Meatiest+Chili.jpg"
+    }
+  },
+  {
+    "recipe_id": 1610,
+    "name": "homemade yolk mayo",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "egg-salad-inspired-by-futurama",
+      "name": "Egg Salad inspired by Futurama",
+      "published_date": "2025-03-07",
+      "youtube_link": "https://www.youtube.com/watch?v=cgLi9t6w9Qc&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/egg-salad-inspired-by-futurama",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741383035/fhpr01pnfwh4o1lpeje9.webp"
     }
   },
   {
@@ -10749,7 +11859,7 @@
       "episode_id": "beer-steamed-chili-dogs",
       "name": "Chili Dogs inspired by The Irishman",
       "published_date": "2019-12-17",
-      "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/c0A1bkF4mKM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM",
       "official_link": "https://www.babi.sh/recipes/beer-steamed-chili-dogs",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695792/babishImages/undefined-202970.png"
     }
@@ -10764,7 +11874,7 @@
       "episode_id": "beer-steamed-chili-dogs",
       "name": "Chili Dogs inspired by The Irishman",
       "published_date": "2019-12-17",
-      "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/c0A1bkF4mKM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM",
       "official_link": "https://www.babi.sh/recipes/beer-steamed-chili-dogs",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695792/babishImages/undefined-202970.png"
     }
@@ -10782,6 +11892,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=2QljlPEwe98",
       "official_link": "https://www.babi.sh/recipes/footlong-taco-dogs-bobs-burgers",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695168/babishImages/undefined-41817.png"
+    }
+  },
+  {
+    "recipe_id": 1640,
+    "name": "hot fudge sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "whimsical-parfait-inspired-by-darker-than-black",
+      "name": "Whimsical Parfait inspired by Darker than Black",
+      "published_date": "2024-10-02",
+      "youtube_link": "https://www.youtube.com/watch?v=GHwZqJYYB80",
+      "official_link": "https://www.babi.sh/recipes/whimsical-parfait-inspired-by-darker-than-black",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727903480/ek6bh07lnnblfomgfhdy.webp"
     }
   },
   {
@@ -10815,18 +11940,18 @@
     }
   },
   {
-    "recipe_id": 936,
-    "name": "https://www.seriouseats.com/recipes/2016/05/dry-toasted-sugar-granulated-caramel-recipe.html",
+    "recipe_id": 1540,
+    "name": "hot jus",
     "image_link": null,
-    "raw_ingredient_list": "4 cups white granulated sugar",
+    "raw_ingredient_list": "",
     "raw_procedure": "",
     "source": {
-      "episode_id": "biscuits-ted-lasso",
-      "name": "Biscuits inspired by Ted Lasso",
-      "published_date": "2021-03-16",
-      "youtube_link": "https://www.youtube.com/watch?v=r_yBqWHtWMo",
-      "official_link": "https://www.babi.sh/recipes/biscuits-ted-lasso",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695315/babishImages/undefined-343517.png"
+      "episode_id": "steak",
+      "name": "Steak",
+      "published_date": "2025-10-03",
+      "youtube_link": "https://www.youtube.com/watch?v=peAbYlvP6rU",
+      "official_link": "https://www.babi.sh/recipes/steak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759667611/ivsyx6hgxw8cwudn9brl.webp"
     }
   },
   {
@@ -10869,7 +11994,7 @@
       "episode_id": "avengersicecream",
       "name": "Ice Cream Flavors inspired by Avengers: Infinity War",
       "published_date": "2019-04-30",
-      "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Ukjat70Iyt4/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4",
       "official_link": "https://www.babi.sh/recipes/avengersicecream",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695805/babishImages/undefined-987247.png"
     }
@@ -10887,6 +12012,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=Ya2_Khcdwsk",
       "official_link": "https://www.babi.sh/recipes/sundae-spongebob",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696021/babishImages/undefined-630114.png"
+    }
+  },
+  {
+    "recipe_id": 1635,
+    "name": "ice cream flavors:",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "whimsical-parfait-inspired-by-darker-than-black",
+      "name": "Whimsical Parfait inspired by Darker than Black",
+      "published_date": "2024-10-02",
+      "youtube_link": "https://www.youtube.com/watch?v=GHwZqJYYB80",
+      "official_link": "https://www.babi.sh/recipes/whimsical-parfait-inspired-by-darker-than-black",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727903480/ek6bh07lnnblfomgfhdy.webp"
     }
   },
   {
@@ -10942,7 +12082,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "biscuits-and-gravy",
-      "name": "BISCUITS AND GRAVY",
+      "name": "Biscuits & Gravy",
       "published_date": "2021-02-25",
       "youtube_link": "https://www.youtube.com/watch?v=NMbMT9tY8-Q",
       "official_link": "https://www.babi.sh/recipes/biscuits-and-gravy",
@@ -11040,6 +12180,21 @@
     }
   },
   {
+    "recipe_id": 1294,
+    "name": "Italian beef (Al's-style top sirloin)",
+    "image_link": null,
+    "raw_ingredient_list": "top sirloin butt",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "chicago-style-italian-beef-inspired-by-the-bear",
+      "name": "Chicago-Style Italian Beef inspired by The Bear",
+      "published_date": "2024-07-08",
+      "youtube_link": "https://www.youtube.com/watch?v=xrXDdlrcuKs",
+      "official_link": "https://www.babi.sh/recipes/chicago-style-italian-beef-inspired-by-the-bear",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1720451211/caje3wf74d8gwuq8hbjn.webp"
+    }
+  },
+  {
     "recipe_id": 1045,
     "name": "Italian Meringue",
     "image_link": null,
@@ -11107,7 +12262,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "advanced-grilled-cheese",
-      "name": "ADVANCED GRILLED CHEESE",
+      "name": "Advanced Grilled Cheese",
       "published_date": "2021-02-19",
       "youtube_link": "https://www.youtube.com/watch?v=Zo7sRijXG00",
       "official_link": "https://www.babi.sh/recipes/advanced-grilled-cheese",
@@ -11167,7 +12322,7 @@
     "raw_procedure": "Reheat the leftover dirty rice and add 1 lb of andouille sausage (sliced into coins) as well as 4 boneless chicken thighs (whole or cut up).\nGarnish with scallions and enjoy!",
     "source": {
       "episode_id": "cajunfood",
-      "name": "CAJUN FOOD",
+      "name": "Cajun Food",
       "published_date": "2019-09-13",
       "youtube_link": "https://www.youtube.com/watch?v=nORg_aXMsmA",
       "official_link": "https://www.babi.sh/recipes/cajunfood",
@@ -11190,6 +12345,21 @@
     }
   },
   {
+    "recipe_id": 1607,
+    "name": "japanese-inspired egg salad sandwich",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "egg-salad-inspired-by-futurama",
+      "name": "Egg Salad inspired by Futurama",
+      "published_date": "2025-03-07",
+      "youtube_link": "https://www.youtube.com/watch?v=cgLi9t6w9Qc&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/egg-salad-inspired-by-futurama",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741383035/fhpr01pnfwh4o1lpeje9.webp"
+    }
+  },
+  {
     "recipe_id": 238,
     "name": "Japanese Mayo",
     "image_link": null,
@@ -11202,6 +12372,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=DNg7Obo-DDM",
       "official_link": "https://www.babi.sh/recipes/okonomiyaki",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715489/babishImages/undefined-265247.png"
+    }
+  },
+  {
+    "recipe_id": 1588,
+    "name": "japanese-style big mac",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "japanese-style-big-mac-inspired-by-weathering-with-you",
+      "name": "Japanese-Style Big Mac inspired by Weathering with You",
+      "published_date": "2025-03-19",
+      "youtube_link": "https://www.youtube.com/watch?v=BzKBag59duU&pp=ygUTYWx2aW4gamFwYW4gYmlnIG1hYw%3D%3D",
+      "official_link": "https://www.babi.sh/recipes/japanese-style-big-mac-inspired-by-weathering-with-you",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1742407838/ofwjdoqrkbbijmlqiu7e.webp"
     }
   },
   {
@@ -11805,6 +12990,36 @@
     }
   },
   {
+    "recipe_id": 1503,
+    "name": "lentil meatball mixture",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-levels-of-spaghetti-or-with-babish",
+      "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
+      "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769797846/qlt7lmqzvuonokq8elpd.webp"
+    }
+  },
+  {
+    "recipe_id": 1505,
+    "name": "lentil meatballs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-levels-of-spaghetti-or-with-babish",
+      "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
+      "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769797846/qlt7lmqzvuonokq8elpd.webp"
+    }
+  },
+  {
     "recipe_id": 1213,
     "name": "lentil sloppy joes",
     "image_link": null,
@@ -11835,6 +13050,21 @@
     }
   },
   {
+    "recipe_id": 1568,
+    "name": "lettuce & honey ham sandwich",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv",
+      "name": "Quadruple Stacked Ham Sandwich inspired by Final Fantasy XV",
+      "published_date": "2025-08-19",
+      "youtube_link": "https://www.youtube.com/watch?v=ouJL4FGGbuc",
+      "official_link": "https://www.babi.sh/recipes/quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1755625602/nnowpvarxiludykiovik.webp"
+    }
+  },
+  {
     "recipe_id": 27,
     "name": "Lettuce Wraps",
     "image_link": null,
@@ -11847,6 +13077,276 @@
       "youtube_link": "https://www.youtube.com/watch?v=VweTeaGwiXQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/VweTeaGwiXQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
       "official_link": "https://www.babi.sh/recipes/larbstickyrice",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695424/babishImages/undefined-405036.png"
+    }
+  },
+  {
+    "recipe_id": 1492,
+    "name": "level 10: fine dining chicken noodle soup",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-chicken-noodle-soup",
+      "name": "10 Levels of Chicken Noodle Soup",
+      "published_date": "2026-03-28",
+      "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
+      "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1774738409/btugut1heyus4wsry467.webp"
+    }
+  },
+  {
+    "recipe_id": 1555,
+    "name": "level 3: blue box",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-mac-and-cheese",
+      "name": "10 Levels of Mac and Cheese",
+      "published_date": "2025-09-20",
+      "youtube_link": "https://youtube.com/watch?v=XpL2ZyyF55U&si=Ji3keCq-hmDoiCDS",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-mac-and-cheese",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1758370413/qtua6ccyjtklttjssedd.webp"
+    }
+  },
+  {
+    "recipe_id": 1477,
+    "name": "level 4: cheesesteak kit style",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-cheesesteak",
+      "name": "10 Levels of Philly Cheesesteak",
+      "published_date": "2026-04-30",
+      "youtube_link": "https://www.youtube.com/watch?v=jNan4FWeQEE",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-cheesesteak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1777507861/icg9k8c02j1h9nfo5qb7.webp"
+    }
+  },
+  {
+    "recipe_id": 1558,
+    "name": "level 4: evaporated milk",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-mac-and-cheese",
+      "name": "10 Levels of Mac and Cheese",
+      "published_date": "2025-09-20",
+      "youtube_link": "https://youtube.com/watch?v=XpL2ZyyF55U&si=Ji3keCq-hmDoiCDS",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-mac-and-cheese",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1758370413/qtua6ccyjtklttjssedd.webp"
+    }
+  },
+  {
+    "recipe_id": 1478,
+    "name": "level 5: classic homemade cheesesteak",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-cheesesteak",
+      "name": "10 Levels of Philly Cheesesteak",
+      "published_date": "2026-04-30",
+      "youtube_link": "https://www.youtube.com/watch?v=jNan4FWeQEE",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-cheesesteak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1777507861/icg9k8c02j1h9nfo5qb7.webp"
+    }
+  },
+  {
+    "recipe_id": 1559,
+    "name": "level 5: one pot inspired by america's test kitchen",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-mac-and-cheese",
+      "name": "10 Levels of Mac and Cheese",
+      "published_date": "2025-09-20",
+      "youtube_link": "https://youtube.com/watch?v=XpL2ZyyF55U&si=Ji3keCq-hmDoiCDS",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-mac-and-cheese",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1758370413/qtua6ccyjtklttjssedd.webp"
+    }
+  },
+  {
+    "recipe_id": 1479,
+    "name": "level 6: chicken cheesesteak",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-cheesesteak",
+      "name": "10 Levels of Philly Cheesesteak",
+      "published_date": "2026-04-30",
+      "youtube_link": "https://www.youtube.com/watch?v=jNan4FWeQEE",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-cheesesteak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1777507861/icg9k8c02j1h9nfo5qb7.webp"
+    }
+  },
+  {
+    "recipe_id": 1560,
+    "name": "level 6: deep fried mac & cheese",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-mac-and-cheese",
+      "name": "10 Levels of Mac and Cheese",
+      "published_date": "2025-09-20",
+      "youtube_link": "https://youtube.com/watch?v=XpL2ZyyF55U&si=Ji3keCq-hmDoiCDS",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-mac-and-cheese",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1758370413/qtua6ccyjtklttjssedd.webp"
+    }
+  },
+  {
+    "recipe_id": 1486,
+    "name": "level 6: no prep chicken noodle soup",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-chicken-noodle-soup",
+      "name": "10 Levels of Chicken Noodle Soup",
+      "published_date": "2026-03-28",
+      "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
+      "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1774738409/btugut1heyus4wsry467.webp"
+    }
+  },
+  {
+    "recipe_id": 1561,
+    "name": "level 7: classic mornay",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-mac-and-cheese",
+      "name": "10 Levels of Mac and Cheese",
+      "published_date": "2025-09-20",
+      "youtube_link": "https://youtube.com/watch?v=XpL2ZyyF55U&si=Ji3keCq-hmDoiCDS",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-mac-and-cheese",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1758370413/qtua6ccyjtklttjssedd.webp"
+    }
+  },
+  {
+    "recipe_id": 1480,
+    "name": "level 7: proper homemade cheesesteak",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-cheesesteak",
+      "name": "10 Levels of Philly Cheesesteak",
+      "published_date": "2026-04-30",
+      "youtube_link": "https://www.youtube.com/watch?v=jNan4FWeQEE",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-cheesesteak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1777507861/icg9k8c02j1h9nfo5qb7.webp"
+    }
+  },
+  {
+    "recipe_id": 1487,
+    "name": "level 7: simple from-scratch",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-chicken-noodle-soup",
+      "name": "10 Levels of Chicken Noodle Soup",
+      "published_date": "2026-03-28",
+      "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
+      "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1774738409/btugut1heyus4wsry467.webp"
+    }
+  },
+  {
+    "recipe_id": 1490,
+    "name": "level 8: matzo ball soup",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-chicken-noodle-soup",
+      "name": "10 Levels of Chicken Noodle Soup",
+      "published_date": "2026-03-28",
+      "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
+      "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1774738409/btugut1heyus4wsry467.webp"
+    }
+  },
+  {
+    "recipe_id": 1562,
+    "name": "level 8: molecular gastronomy - sodium citrate",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-mac-and-cheese",
+      "name": "10 Levels of Mac and Cheese",
+      "published_date": "2025-09-20",
+      "youtube_link": "https://youtube.com/watch?v=XpL2ZyyF55U&si=Ji3keCq-hmDoiCDS",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-mac-and-cheese",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1758370413/qtua6ccyjtklttjssedd.webp"
+    }
+  },
+  {
+    "recipe_id": 1481,
+    "name": "level 8: shop-style ribeye cheesesteak",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-cheesesteak",
+      "name": "10 Levels of Philly Cheesesteak",
+      "published_date": "2026-04-30",
+      "youtube_link": "https://www.youtube.com/watch?v=jNan4FWeQEE",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-cheesesteak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1777507861/icg9k8c02j1h9nfo5qb7.webp"
+    }
+  },
+  {
+    "recipe_id": 1491,
+    "name": "level 9: avgolemono",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-chicken-noodle-soup",
+      "name": "10 Levels of Chicken Noodle Soup",
+      "published_date": "2026-03-28",
+      "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
+      "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1774738409/btugut1heyus4wsry467.webp"
+    }
+  },
+  {
+    "recipe_id": 1563,
+    "name": "level 9: sparing no expense",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-mac-and-cheese",
+      "name": "10 Levels of Mac and Cheese",
+      "published_date": "2025-09-20",
+      "youtube_link": "https://youtube.com/watch?v=XpL2ZyyF55U&si=Ji3keCq-hmDoiCDS",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-mac-and-cheese",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1758370413/qtua6ccyjtklttjssedd.webp"
+    }
+  },
+  {
+    "recipe_id": 1312,
+    "name": "Loaded Baked Potato Lasagna",
+    "image_link": null,
+    "raw_ingredient_list": "flour rolling\nfrozen hashbrowns according package instructions\nthick cut bacon\nbeef\ncheddar cheese",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "bobsburgers-potato-lasagna",
+      "name": "Loaded Baked Potato Lasagna Inspired by Bob's Burgers",
+      "published_date": "2024-03-01",
+      "youtube_link": "youtube.com/watch?v=jts_NfZu2vY",
+      "official_link": "https://www.babi.sh/recipes/bobsburgers-potato-lasagna",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1709308712/bfjgjzbwq9dstzpukvxo.webp"
     }
   },
   {
@@ -11932,11 +13432,26 @@
     "raw_procedure": "Start by laying out your chicken wings and patting them dry with a paper towel.\nFor the drummet (the upper, meaty, one-bone part of the wing), cut along the circumference of the thin end so that the bone and the meat are no longer connected. Then push down the meat so the drummet becomes a lollipop.\nFor the winglet (the middle, two-bone part of the wing), separate where the two bones join, and also cut along the circumferences of both ends, so the bone and the meat are no longer connected. Take out the thinner bone, and push down the meat into one end of the thinner bone.\nIn a bowl combine 2 parts Frank\u2019s Red Hot to 1 part melted unsalted butter. Whisk to combine.\nIn a large pot over medium high heat bring 1 quart of vegetable or peanut oil to 375\u00b0F and then add your wings. Slowly move around and stir for 10 minutes before removing and placing on a wire rack for about 5 minutes to get any excess oil off.\nPlace wings in a bowl and then add a healthy glug of the buffalo sauce and toss to combine.\nServe and enjoy!",
     "source": {
       "episode_id": "biggamesnacks",
-      "name": "BIG GAME SNACKS",
+      "name": "Big Game Snacks",
       "published_date": "2019-01-31",
       "youtube_link": "https://www.youtube.com/watch?v=8ckxhlDFNkg",
       "official_link": "https://www.babi.sh/recipes/biggamesnacks",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1686007959/eyt2lwmqnjme9flte5ai.webp"
+    }
+  },
+  {
+    "recipe_id": 1541,
+    "name": "london broil",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "steak",
+      "name": "Steak",
+      "published_date": "2025-10-03",
+      "youtube_link": "https://www.youtube.com/watch?v=peAbYlvP6rU",
+      "official_link": "https://www.babi.sh/recipes/steak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759667611/ivsyx6hgxw8cwudn9brl.webp"
     }
   },
   {
@@ -11967,6 +13482,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=iX7Dzr2whWQ",
       "official_link": "https://www.youtube.com/watch?v=iX7Dzr2whWQ",
       "image_link": "https://img.youtube.com/vi/iX7Dzr2whWQ/mqdefault.jpg"
+    }
+  },
+  {
+    "recipe_id": 1556,
+    "name": "mac",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-of-mac-and-cheese",
+      "name": "10 Levels of Mac and Cheese",
+      "published_date": "2025-09-20",
+      "youtube_link": "https://youtube.com/watch?v=XpL2ZyyF55U&si=Ji3keCq-hmDoiCDS",
+      "official_link": "https://www.babi.sh/recipes/10-levels-of-mac-and-cheese",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1758370413/qtua6ccyjtklttjssedd.webp"
     }
   },
   {
@@ -12075,21 +13605,6 @@
     }
   },
   {
-    "recipe_id": 1391,
-    "name": "maconara",
-    "image_link": null,
-    "raw_ingredient_list": "dried spaghetti\npanko breadcrumbs\naged yellow cheddar cheese\nguanciale\nhen of the woods or maitake mushrooms cut/torn into bite size pieces\nthick cut bacon\ndried macaroni or cavatappi",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "carbonara-anything",
-      "name": "CARBONARA ANYTHING",
-      "published_date": "2022-09-19",
-      "youtube_link": "https://www.youtube.com/watch?v=wrweyL0YS8Y",
-      "official_link": "https://www.babi.sh/recipes/carbonara-anything",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695332/babishImages/undefined-714411.png"
-    }
-  },
-  {
     "recipe_id": 48,
     "name": "Mac\u2019s Mac and Cheese",
     "image_link": null,
@@ -12099,7 +13614,7 @@
       "episode_id": "alwayssunny",
       "name": "It's Always Sunny in Philadelphia Special (Part II)",
       "published_date": "2019-06-12",
-      "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/_fnhy5xO9vQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ",
       "official_link": "https://www.babi.sh/recipes/alwayssunny",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696347/babishImages/undefined-129032.png"
     }
@@ -12117,6 +13632,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=6JFVKnrE_d8",
       "official_link": "https://www.babi.sh/recipes/bop-egg-sandwich",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696111/babishImages/undefined-691801.png"
+    }
+  },
+  {
+    "recipe_id": 1579,
+    "name": "mango ginger sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "3-course-dinner-inspired-by-drop",
+      "name": "3 Course Dinner inspired by Drop",
+      "published_date": "2025-05-03",
+      "youtube_link": "https://www.youtube.com/watch?v=23lKOTVYRGc&t=673s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/3-course-dinner-inspired-by-drop",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1746310289/sxhsw0jiihdjo9tibmw5.webp"
     }
   },
   {
@@ -12196,15 +13726,15 @@
   },
   {
     "recipe_id": 304,
-    "name": "Margaretta",
+    "name": "Margarita",
     "image_link": null,
     "raw_ingredient_list": "4 oz Tequila\n1 oz Triple Sec\nLime juice\nSalt",
     "raw_procedure": "Salt the rim of a glass using lime juice.\nMix and serve.",
     "source": {
       "episode_id": "baressentials",
-      "name": "BAR ESSENTIALS",
+      "name": "Bar Essentials",
       "published_date": "2018-03-15",
-      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/iZUfPIKbgUM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM",
       "official_link": "https://www.babi.sh/recipes/baressentials",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690416607/jlnnbuig1g2nrqafs58x.webp"
     }
@@ -12255,6 +13785,21 @@
     }
   },
   {
+    "recipe_id": 1548,
+    "name": "marshmallow cream cheese frosting",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "name": "Fallout Fancy Lad Snack Cakes inspired by Fallout 76",
+      "published_date": "2025-10-01",
+      "youtube_link": "https://www.youtube.com/watch?v=v1f835eNhUc",
+      "official_link": "https://www.babi.sh/recipes/fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759334763/qv57em4y8nloxgzztjrs.webp"
+    }
+  },
+  {
     "recipe_id": 71,
     "name": "Marshmallows",
     "image_link": null,
@@ -12294,7 +13839,7 @@
       "episode_id": "brocksdonuts",
       "name": "Brock's Donuts inspired by Pok\u00e9mon",
       "published_date": "2019-04-02",
-      "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/RentKWlhUXc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc",
       "official_link": "https://www.babi.sh/recipes/brocksdonuts",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695178/babishImages/undefined-56205.png"
     }
@@ -12312,6 +13857,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=25Od-bcv6vM",
       "official_link": "https://www.babi.sh/recipes/stollen",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715445/babishImages/undefined-35277.png"
+    }
+  },
+  {
+    "recipe_id": 1520,
+    "name": "mashed potatoes",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ultimate-pot-roast-or-with-babish",
+      "name": "Ultimate Pot Roast | With Babish",
+      "published_date": "2026-01-15",
+      "youtube_link": "https://www.youtube.com/watch?v=5_7pC4K-Y1g",
+      "official_link": "https://www.babi.sh/recipes/ultimate-pot-roast-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768506428/gryanukvd2zeutfh9ibh.webp"
     }
   },
   {
@@ -12405,6 +13965,21 @@
     }
   },
   {
+    "recipe_id": 1638,
+    "name": "matcha flavor",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "whimsical-parfait-inspired-by-darker-than-black",
+      "name": "Whimsical Parfait inspired by Darker than Black",
+      "published_date": "2024-10-02",
+      "youtube_link": "https://www.youtube.com/watch?v=GHwZqJYYB80",
+      "official_link": "https://www.babi.sh/recipes/whimsical-parfait-inspired-by-darker-than-black",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727903480/ek6bh07lnnblfomgfhdy.webp"
+    }
+  },
+  {
     "recipe_id": 978,
     "name": "Mayonnaise",
     "image_link": null,
@@ -12427,7 +14002,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "bacon",
-      "name": "HOMEMADE BACON",
+      "name": "Homemade Bacon",
       "published_date": "2021-04-30",
       "youtube_link": "https://www.youtube.com/watch?v=TUh4Z2li1UM",
       "official_link": "https://www.babi.sh/recipes/bacon",
@@ -12570,6 +14145,21 @@
     }
   },
   {
+    "recipe_id": 1583,
+    "name": "medallions",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-weeknight-recipes-for-pork-tenderloin",
+      "name": "5 Weeknight Recipes for Pork Tenderloin",
+      "published_date": "2025-04-08",
+      "youtube_link": "https://www.youtube.com/watch?v=VEAmtpkxXXQ&t=21s",
+      "official_link": "https://www.babi.sh/recipes/5-weeknight-recipes-for-pork-tenderloin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1744118544/yh4iqwlo6kyfxad3flzw.webp"
+    }
+  },
+  {
     "recipe_id": 1273,
     "name": "Mega Beef Bowl inspired by Persona 4",
     "image_link": null,
@@ -12660,6 +14250,21 @@
     }
   },
   {
+    "recipe_id": 1643,
+    "name": "milk mixture",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "whimsical-parfait-inspired-by-darker-than-black",
+      "name": "Whimsical Parfait inspired by Darker than Black",
+      "published_date": "2024-10-02",
+      "youtube_link": "https://www.youtube.com/watch?v=GHwZqJYYB80",
+      "official_link": "https://www.babi.sh/recipes/whimsical-parfait-inspired-by-darker-than-black",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727903480/ek6bh07lnnblfomgfhdy.webp"
+    }
+  },
+  {
     "recipe_id": 477,
     "name": "Milk Steak",
     "image_link": null,
@@ -12672,6 +14277,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=Q2ezpExQ_k0",
       "official_link": "https://www.babi.sh/recipes/itsalwayssunnyspecial",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992050/vganhazfptuo0aqxbyfm.webp"
+    }
+  },
+  {
+    "recipe_id": 1501,
+    "name": "million dollar deviled eggs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "super-bowl-snacks-for-the-win-or-with-babish",
+      "name": "Super Bowl Snacks for the Win | With Babish",
+      "published_date": "2026-02-02",
+      "youtube_link": "https://youtube.com/watch?v=YIf161LjodE",
+      "official_link": "https://www.babi.sh/recipes/super-bowl-snacks-for-the-win-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1770071325/fy1ppzw7ndz0jh29hkmh.webp"
     }
   },
   {
@@ -12773,7 +14393,7 @@
     "source": {
       "episode_id": "cocktail-special",
       "name": "Cocktail Special",
-      "published_date": "2017-06-28",
+      "published_date": "2017-06-27",
       "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
       "official_link": "https://www.babi.sh/recipes/cocktail-special",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -12952,9 +14572,9 @@
     "raw_procedure": "Muddle sugar and limes in the bottom of a glass.\nAdd ice and rum and mix with a spoon.\nTop with ice and club soda.\nGarnish with a lime.\nMetal straw recommended.",
     "source": {
       "episode_id": "baressentials",
-      "name": "BAR ESSENTIALS",
+      "name": "Bar Essentials",
       "published_date": "2018-03-15",
-      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/iZUfPIKbgUM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM",
       "official_link": "https://www.babi.sh/recipes/baressentials",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690416607/jlnnbuig1g2nrqafs58x.webp"
     }
@@ -12968,7 +14588,7 @@
     "source": {
       "episode_id": "chefs-choice-platter-monster-hunter-world",
       "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-      "published_date": "2021-03-31",
+      "published_date": "2021-03-30",
       "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
       "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png"
@@ -13017,6 +14637,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=bK0NdaDOsG0",
       "official_link": "https://www.babi.sh/recipes/monicas-candy-friends",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696037/babishImages/undefined-162081.png"
+    }
+  },
+  {
+    "recipe_id": 1495,
+    "name": "monkey bread",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "super-bowl-snacks-for-the-win-or-with-babish",
+      "name": "Super Bowl Snacks for the Win | With Babish",
+      "published_date": "2026-02-02",
+      "youtube_link": "https://youtube.com/watch?v=YIf161LjodE",
+      "official_link": "https://www.babi.sh/recipes/super-bowl-snacks-for-the-win-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1770071325/fy1ppzw7ndz0jh29hkmh.webp"
     }
   },
   {
@@ -13117,9 +14752,9 @@
     "raw_procedure": "Mix and serve.",
     "source": {
       "episode_id": "baressentials",
-      "name": "BAR ESSENTIALS",
+      "name": "Bar Essentials",
       "published_date": "2018-03-15",
-      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/iZUfPIKbgUM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM",
       "official_link": "https://www.babi.sh/recipes/baressentials",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690416607/jlnnbuig1g2nrqafs58x.webp"
     }
@@ -13148,7 +14783,7 @@
     "source": {
       "episode_id": "christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
       "name": "Christmas Turkey inspired by National Lampoon's Christmas Vacation",
-      "published_date": "2025-11-26",
+      "published_date": "2025-11-29",
       "youtube_link": "https://youtube.com/watch?v=w0pZ7MWajW8&si=r2TmnS9oJhDHIbp5",
       "official_link": "https://www.babi.sh/recipes/christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1764189007/giyklwlgdj7x3nwbi38c.webp"
@@ -13238,10 +14873,40 @@
     "source": {
       "episode_id": "crepessuzette",
       "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-      "published_date": "2019-10-24",
-      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "published_date": "2019-10-22",
+      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
       "official_link": "https://www.babi.sh/recipes/crepessuzette",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png"
+    }
+  },
+  {
+    "recipe_id": 1526,
+    "name": "mushroom duxelle",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "beef-wellington-or-with-babish",
+      "name": "$20 vs $200 Beef Wellington | With Babish",
+      "published_date": "2025-12-23",
+      "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
+      "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
+    }
+  },
+  {
+    "recipe_id": 1523,
+    "name": "mushroom duxelles",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "beef-wellington-or-with-babish",
+      "name": "$20 vs $200 Beef Wellington | With Babish",
+      "published_date": "2025-12-23",
+      "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
+      "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
     }
   },
   {
@@ -13257,6 +14922,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=BagY2Mnz-TU&amp;t=278s",
       "official_link": "https://www.babi.sh/recipes/madmen",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715463/babishImages/undefined-566441.png"
+    }
+  },
+  {
+    "recipe_id": 1648,
+    "name": "mushroom sauerkraut filling",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "pierogis",
+      "name": "PIEROGIS",
+      "published_date": "2023-02-24",
+      "youtube_link": "https://www.youtube.com/watch?v=58hC3MCVwkw",
+      "official_link": "https://www.babi.sh/recipes/pierogis",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690353185/d6hdqdddrsens6ovoe07.webp"
     }
   },
   {
@@ -13372,11 +15052,26 @@
     "raw_procedure": "Mix and serve.",
     "source": {
       "episode_id": "baressentials",
-      "name": "BAR ESSENTIALS",
+      "name": "Bar Essentials",
       "published_date": "2018-03-15",
-      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/iZUfPIKbgUM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM",
       "official_link": "https://www.babi.sh/recipes/baressentials",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690416607/jlnnbuig1g2nrqafs58x.webp"
+    }
+  },
+  {
+    "recipe_id": 1538,
+    "name": "new york strip steak",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "steak",
+      "name": "Steak",
+      "published_date": "2025-10-03",
+      "youtube_link": "https://www.youtube.com/watch?v=peAbYlvP6rU",
+      "official_link": "https://www.babi.sh/recipes/steak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759667611/ivsyx6hgxw8cwudn9brl.webp"
     }
   },
   {
@@ -13392,6 +15087,36 @@
       "youtube_link": "https://www.youtube.com/watch?v=n1O3uHPCOLA",
       "official_link": "https://www.babi.sh/recipes/pizza-dough",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715535/babishImages/undefined-397821.png"
+    }
+  },
+  {
+    "recipe_id": 1603,
+    "name": "nilla wafer crumble",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "cheesecake-inspired-by-junior's-cheesecakes",
+      "name": "Cheesecake inspired by Junior's Cheesecakes",
+      "published_date": "2025-03-11",
+      "youtube_link": "https://www.youtube.com/watch?v=gQeY_wx9bsI&t=26s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/cheesecake-inspired-by-junior's-cheesecakes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741657095/qjrimy3opynb08w9zudl.webp"
+    }
+  },
+  {
+    "recipe_id": 1601,
+    "name": "nilla wafer crust",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "cheesecake-inspired-by-junior's-cheesecakes",
+      "name": "Cheesecake inspired by Junior's Cheesecakes",
+      "published_date": "2025-03-11",
+      "youtube_link": "https://www.youtube.com/watch?v=gQeY_wx9bsI&t=26s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/cheesecake-inspired-by-junior's-cheesecakes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741657095/qjrimy3opynb08w9zudl.webp"
     }
   },
   {
@@ -13508,8 +15233,8 @@
     "source": {
       "episode_id": "crepessuzette",
       "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-      "published_date": "2019-10-24",
-      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "published_date": "2019-10-22",
+      "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
       "official_link": "https://www.babi.sh/recipes/crepessuzette",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png"
     }
@@ -13613,7 +15338,7 @@
     "source": {
       "episode_id": "cocktail-special",
       "name": "Cocktail Special",
-      "published_date": "2017-06-28",
+      "published_date": "2017-06-27",
       "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
       "official_link": "https://www.babi.sh/recipes/cocktail-special",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -13627,7 +15352,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "biscuits-and-gravy",
-      "name": "BISCUITS AND GRAVY",
+      "name": "Biscuits & Gravy",
       "published_date": "2021-02-25",
       "youtube_link": "https://www.youtube.com/watch?v=NMbMT9tY8-Q",
       "official_link": "https://www.babi.sh/recipes/biscuits-and-gravy",
@@ -13762,7 +15487,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "andrewsohlathanksgiving",
-      "name": "ANDREW & SOHLA THANKSGIVING RECIPES",
+      "name": "Thanksgiving Recipe Livestream with Sohla El-Waylly",
       "published_date": "2020-11-20",
       "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
       "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
@@ -13785,21 +15510,6 @@
     }
   },
   {
-    "recipe_id": 1132,
-    "name": "Orange Chocolate Biscotti",
-    "image_link": null,
-    "raw_ingredient_list": "As needed nonstick spray\n200 g all purpose flour\n50 g cocoa powder\n1 tsp baking powder\n\u00bc tsp baking soda\n\u00bd tsp kosher salt\n120 g dark chocolate\n3 large eggs\n175 g granulated sugar\nZest of 1 large orange\nOptional: \u00bc tsp orange extract\n1 tsp vanilla extract\nOrange glaze (see recipe below)",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "biscotti",
-      "name": "BISCOTTI",
-      "published_date": "2021-09-24",
-      "youtube_link": "https://www.youtube.com/watch?v=g4EkzEKlGOA",
-      "official_link": "https://www.babi.sh/recipes/biscotti",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695295/babishImages/undefined-256401.png"
-    }
-  },
-  {
     "recipe_id": 1133,
     "name": "Orange Glaze",
     "image_link": null,
@@ -13807,7 +15517,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "biscotti",
-      "name": "BISCOTTI",
+      "name": "Biscotti",
       "published_date": "2021-09-24",
       "youtube_link": "https://www.youtube.com/watch?v=g4EkzEKlGOA",
       "official_link": "https://www.babi.sh/recipes/biscotti",
@@ -13867,7 +15577,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "biscotti",
-      "name": "BISCOTTI",
+      "name": "Biscotti",
       "published_date": "2021-09-24",
       "youtube_link": "https://www.youtube.com/watch?v=g4EkzEKlGOA",
       "official_link": "https://www.babi.sh/recipes/biscotti",
@@ -14033,7 +15743,7 @@
     "source": {
       "episode_id": "chefs-choice-platter-monster-hunter-world",
       "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-      "published_date": "2021-03-31",
+      "published_date": "2021-03-30",
       "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
       "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png"
@@ -14052,6 +15762,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=ZY63ZSUdywY",
       "official_link": "https://www.babi.sh/recipes/breakingbadspecial",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715452/babishImages/undefined-411961.png"
+    }
+  },
+  {
+    "recipe_id": 1511,
+    "name": "pain de mie",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ultimate-french-toast-or-with-babish",
+      "name": "Ultimate French Toast | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=t0nTt7Dm5Og&pp=ygUhYmluZ2luZyB3aXRoIGJhYmlzaCBmcmVuY2ggdG9hc2R0",
+      "official_link": "https://www.babi.sh/recipes/ultimate-french-toast-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769735233/hleoccmfkh4lbwvu6gzz.webp"
     }
   },
   {
@@ -14097,6 +15822,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=XIZxT7iI-QI",
       "official_link": "https://www.babi.sh/recipes/curbyourenthusiasm",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715468/babishImages/undefined-615321.png"
+    }
+  },
+  {
+    "recipe_id": 1504,
+    "name": "panade",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-levels-of-spaghetti-or-with-babish",
+      "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
+      "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769797846/qlt7lmqzvuonokq8elpd.webp"
     }
   },
   {
@@ -14319,7 +16059,7 @@
       "episode_id": "alwayssunny",
       "name": "It's Always Sunny in Philadelphia Special (Part II)",
       "published_date": "2019-06-12",
-      "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/_fnhy5xO9vQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ",
       "official_link": "https://www.babi.sh/recipes/alwayssunny",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696347/babishImages/undefined-129032.png"
     }
@@ -14400,6 +16140,21 @@
     }
   },
   {
+    "recipe_id": 1493,
+    "name": "pasta dough",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-chicken-noodle-soup",
+      "name": "10 Levels of Chicken Noodle Soup",
+      "published_date": "2026-03-28",
+      "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
+      "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1774738409/btugut1heyus4wsry467.webp"
+    }
+  },
+  {
     "recipe_id": 882,
     "name": "Pasta Dough",
     "image_link": null,
@@ -14412,6 +16167,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=dFh7tZoGYA4",
       "official_link": "https://www.babi.sh/recipes/date-night",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715470/babishImages/undefined-416418.png"
+    }
+  },
+  {
+    "recipe_id": 1619,
+    "name": "pasta puttanesca",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "my-top-5-easy-sexy-dishes",
+      "name": "My Top 5 Easy, Sexy Dishes",
+      "published_date": "2025-02-14",
+      "youtube_link": "https://www.youtube.com/watch?v=BAxICJRICNU&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/my-top-5-easy-sexy-dishes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1739562469/nya8wka5lyucenir6wez.webp"
     }
   },
   {
@@ -14442,6 +16212,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=lMAVnI-2MIA",
       "official_link": "https://www.babi.sh/recipes/picnic-food",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695917/babishImages/undefined-81738.png"
+    }
+  },
+  {
+    "recipe_id": 1309,
+    "name": "Past\u00e9is de Nata",
+    "image_link": null,
+    "raw_ingredient_list": "milk\nsweet cherries\nsugar\nflour\negg yolks\nbrown sugar or sugar\ncognac or grand marnier",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "2024oscarsspecial",
+      "name": "2024 Oscars Special",
+      "published_date": "2024-03-15",
+      "youtube_link": "https://youtu.be/NVwgZhjspxo",
+      "official_link": "https://www.babi.sh/recipes/2024oscarsspecial",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1710510271/ny7ovkakrtfei4odwnfd.webp"
     }
   },
   {
@@ -14482,7 +16267,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "bacon",
-      "name": "HOMEMADE BACON",
+      "name": "Homemade Bacon",
       "published_date": "2021-04-30",
       "youtube_link": "https://www.youtube.com/watch?v=TUh4Z2li1UM",
       "official_link": "https://www.babi.sh/recipes/bacon",
@@ -14502,6 +16287,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=uyjq9wJCaGE&pp=ygUjYmluZ2luZyB3aXRoIGJhYmlzaCBkZWxpIHNhbmR3aWNoZXM%3D",
       "official_link": "https://www.babi.sh/recipes/katz's-corned-beef-and-pastrami",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749065565/t20xd8xbngcehg55xfwh.webp"
+    }
+  },
+  {
+    "recipe_id": 1642,
+    "name": "pastry cream",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "whimsical-parfait-inspired-by-darker-than-black",
+      "name": "Whimsical Parfait inspired by Darker than Black",
+      "published_date": "2024-10-02",
+      "youtube_link": "https://www.youtube.com/watch?v=GHwZqJYYB80",
+      "official_link": "https://www.babi.sh/recipes/whimsical-parfait-inspired-by-darker-than-black",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727903480/ek6bh07lnnblfomgfhdy.webp"
     }
   },
   {
@@ -14562,6 +16362,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=NHA9Ffaal2M&amp;t=252s",
       "official_link": "https://www.babi.sh/recipes/michaelscottpretzel",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715698/babishImages/undefined-89396.png"
+    }
+  },
+  {
+    "recipe_id": 1534,
+    "name": "pearl onions",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "coq-au-vin",
+      "name": "Coq au Vin",
+      "published_date": "2025-10-11",
+      "youtube_link": "https://www.youtube.com/watch?v=cf1H6ylUFH4",
+      "official_link": "https://www.babi.sh/recipes/coq-au-vin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1760217634/qggynlnkmhze8roieemn.webp"
     }
   },
   {
@@ -14662,8 +16477,8 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "cake-pops",
-      "name": "CAKE POPS",
-      "published_date": "2021-11-02",
+      "name": "Cake Pops",
+      "published_date": "2021-10-21",
       "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
       "official_link": "https://www.babi.sh/recipes/cake-pops",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
@@ -14738,7 +16553,7 @@
     "source": {
       "episode_id": "chefs-choice-platter-monster-hunter-world",
       "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-      "published_date": "2021-03-31",
+      "published_date": "2021-03-30",
       "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
       "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png"
@@ -14805,6 +16620,21 @@
     }
   },
   {
+    "recipe_id": 1578,
+    "name": "pickled red onion",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "3-course-dinner-inspired-by-drop",
+      "name": "3 Course Dinner inspired by Drop",
+      "published_date": "2025-05-03",
+      "youtube_link": "https://www.youtube.com/watch?v=23lKOTVYRGc&t=673s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/3-course-dinner-inspired-by-drop",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1746310289/sxhsw0jiihdjo9tibmw5.webp"
+    }
+  },
+  {
     "recipe_id": 981,
     "name": "Pickled Red Onions",
     "image_link": null,
@@ -14859,7 +16689,7 @@
       "episode_id": "charliebrownthanksgiving",
       "name": "Charlie Brown Thanksgiving",
       "published_date": "2018-11-20",
-      "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5FyKxVJmsdE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE",
       "official_link": "https://www.babi.sh/recipes/charliebrownthanksgiving",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg"
     }
@@ -14970,6 +16800,51 @@
     }
   },
   {
+    "recipe_id": 679,
+    "name": "Pie Dough Crust",
+    "image_link": null,
+    "raw_ingredient_list": "300 grams all-purpose flour\n2 Tbsp sugar\n1 tsp kosher salt\n225 grams unsalted butter, cold & cubed\n6-8 Tbsp ice water",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ben-wyatt-calzones",
+      "name": "Ben Wyatt's Calzones",
+      "published_date": "2020-04-15",
+      "youtube_link": "https://www.youtube.com/watch?v=PvgCEifW7Jo",
+      "official_link": "https://www.babi.sh/recipes/ben-wyatt-calzones",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695309/babishImages/undefined-56906.png"
+    }
+  },
+  {
+    "recipe_id": 1645,
+    "name": "pierogoi dough",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "pierogis",
+      "name": "PIEROGIS",
+      "published_date": "2023-02-24",
+      "youtube_link": "https://www.youtube.com/watch?v=58hC3MCVwkw",
+      "official_link": "https://www.babi.sh/recipes/pierogis",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690353185/d6hdqdddrsens6ovoe07.webp"
+    }
+  },
+  {
+    "recipe_id": 1644,
+    "name": "pierogoi dough & assembly",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "pierogis",
+      "name": "PIEROGIS",
+      "published_date": "2023-02-24",
+      "youtube_link": "https://www.youtube.com/watch?v=58hC3MCVwkw",
+      "official_link": "https://www.babi.sh/recipes/pierogis",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690353185/d6hdqdddrsens6ovoe07.webp"
+    }
+  },
+  {
     "recipe_id": 423,
     "name": "Pigeon Pie with Wild Game",
     "image_link": null,
@@ -15022,7 +16897,7 @@
     "raw_procedure": "Into the bowl of a food processor, add: 4 ounces cream cheese, 8 ounces sharp yellow cheddar, 4 ounces diced pimento peppers, and a dash each of hot sauce and worcestershire sauce. Process and scrape down the sides until you have a nice smooth cheese.\nWrap the cheese and plastic wrap and mold into a ball. Once it\u2019s the shape you want, place in a bowl and place everything in the fridge for at least one hour.\nRoughly chop 6-8 pieces of cooked bacon. Remove cheese ball from the fridge and the plastic wrap and roll in the chopped bacon.\nGarnish with some finely chopped chives and serve with crackers of your choice.",
     "source": {
       "episode_id": "cheesdips",
-      "name": "CHEESE DIPS",
+      "name": "Cheese Dips",
       "published_date": "2019-05-02",
       "youtube_link": "https://www.youtube.com/watch?v=9toK5UUGeok",
       "official_link": "https://www.babi.sh/recipes/cheesdips",
@@ -15069,7 +16944,7 @@
       "episode_id": "bubbashrimp2",
       "name": "Shrimp inspired by Forrest Gump Part II",
       "published_date": "2019-04-23",
-      "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/mF6JUfczaO8/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8",
       "official_link": "https://www.babi.sh/recipes/bubbashrimp2",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696055/babishImages/undefined-252668.png"
     }
@@ -15097,7 +16972,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "biscotti",
-      "name": "BISCOTTI",
+      "name": "Biscotti",
       "published_date": "2021-09-24",
       "youtube_link": "https://www.youtube.com/watch?v=g4EkzEKlGOA",
       "official_link": "https://www.babi.sh/recipes/biscotti",
@@ -15480,6 +17355,36 @@
     }
   },
   {
+    "recipe_id": 1580,
+    "name": "pomegranate sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "3-course-dinner-inspired-by-drop",
+      "name": "3 Course Dinner inspired by Drop",
+      "published_date": "2025-05-03",
+      "youtube_link": "https://www.youtube.com/watch?v=23lKOTVYRGc&t=673s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/3-course-dinner-inspired-by-drop",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1746310289/sxhsw0jiihdjo9tibmw5.webp"
+    }
+  },
+  {
+    "recipe_id": 1512,
+    "name": "poolish",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ultimate-french-toast-or-with-babish",
+      "name": "Ultimate French Toast | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=t0nTt7Dm5Og&pp=ygUhYmluZ2luZyB3aXRoIGJhYmlzaCBmcmVuY2ggdG9hc2R0",
+      "official_link": "https://www.babi.sh/recipes/ultimate-french-toast-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769735233/hleoccmfkh4lbwvu6gzz.webp"
+    }
+  },
+  {
     "recipe_id": 398,
     "name": "Popcorn",
     "image_link": null,
@@ -15645,6 +17550,81 @@
     }
   },
   {
+    "recipe_id": 1585,
+    "name": "pork schnitzel",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-weeknight-recipes-for-pork-tenderloin",
+      "name": "5 Weeknight Recipes for Pork Tenderloin",
+      "published_date": "2025-04-08",
+      "youtube_link": "https://www.youtube.com/watch?v=VEAmtpkxXXQ&t=21s",
+      "official_link": "https://www.babi.sh/recipes/5-weeknight-recipes-for-pork-tenderloin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1744118544/yh4iqwlo6kyfxad3flzw.webp"
+    }
+  },
+  {
+    "recipe_id": 1586,
+    "name": "pork souvlaki",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-weeknight-recipes-for-pork-tenderloin",
+      "name": "5 Weeknight Recipes for Pork Tenderloin",
+      "published_date": "2025-04-08",
+      "youtube_link": "https://www.youtube.com/watch?v=VEAmtpkxXXQ&t=21s",
+      "official_link": "https://www.babi.sh/recipes/5-weeknight-recipes-for-pork-tenderloin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1744118544/yh4iqwlo6kyfxad3flzw.webp"
+    }
+  },
+  {
+    "recipe_id": 1623,
+    "name": "pork tenderloin",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "my-top-5-easy-sexy-dishes",
+      "name": "My Top 5 Easy, Sexy Dishes",
+      "published_date": "2025-02-14",
+      "youtube_link": "https://www.youtube.com/watch?v=BAxICJRICNU&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/my-top-5-easy-sexy-dishes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1739562469/nya8wka5lyucenir6wez.webp"
+    }
+  },
+  {
+    "recipe_id": 1582,
+    "name": "pork tenderloin medallions with bourbon sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-weeknight-recipes-for-pork-tenderloin",
+      "name": "5 Weeknight Recipes for Pork Tenderloin",
+      "published_date": "2025-04-08",
+      "youtube_link": "https://www.youtube.com/watch?v=VEAmtpkxXXQ&t=21s",
+      "official_link": "https://www.babi.sh/recipes/5-weeknight-recipes-for-pork-tenderloin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1744118544/yh4iqwlo6kyfxad3flzw.webp"
+    }
+  },
+  {
+    "recipe_id": 1621,
+    "name": "pork tenderloin with romesco saucerom",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "my-top-5-easy-sexy-dishes",
+      "name": "My Top 5 Easy, Sexy Dishes",
+      "published_date": "2025-02-14",
+      "youtube_link": "https://www.youtube.com/watch?v=BAxICJRICNU&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/my-top-5-easy-sexy-dishes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1739562469/nya8wka5lyucenir6wez.webp"
+    }
+  },
+  {
     "recipe_id": 105,
     "name": "Portal Cake",
     "image_link": null,
@@ -15750,6 +17730,36 @@
     }
   },
   {
+    "recipe_id": 1500,
+    "name": "potato cups",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "super-bowl-snacks-for-the-win-or-with-babish",
+      "name": "Super Bowl Snacks for the Win | With Babish",
+      "published_date": "2026-02-02",
+      "youtube_link": "https://youtube.com/watch?v=YIf161LjodE",
+      "official_link": "https://www.babi.sh/recipes/super-bowl-snacks-for-the-win-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1770071325/fy1ppzw7ndz0jh29hkmh.webp"
+    }
+  },
+  {
+    "recipe_id": 1646,
+    "name": "potato filling",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "pierogis",
+      "name": "PIEROGIS",
+      "published_date": "2023-02-24",
+      "youtube_link": "https://www.youtube.com/watch?v=58hC3MCVwkw",
+      "official_link": "https://www.babi.sh/recipes/pierogis",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690353185/d6hdqdddrsens6ovoe07.webp"
+    }
+  },
+  {
     "recipe_id": 1437,
     "name": "POTATO HASH",
     "image_link": null,
@@ -15825,6 +17835,21 @@
     }
   },
   {
+    "recipe_id": 1499,
+    "name": "poutine bites",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "super-bowl-snacks-for-the-win-or-with-babish",
+      "name": "Super Bowl Snacks for the Win | With Babish",
+      "published_date": "2026-02-02",
+      "youtube_link": "https://youtube.com/watch?v=YIf161LjodE",
+      "official_link": "https://www.babi.sh/recipes/super-bowl-snacks-for-the-win-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1770071325/fy1ppzw7ndz0jh29hkmh.webp"
+    }
+  },
+  {
     "recipe_id": 661,
     "name": "Pre-Ferment",
     "image_link": null,
@@ -15840,6 +17865,21 @@
     }
   },
   {
+    "recipe_id": 1513,
+    "name": "preserved lemon blueberry compote",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ultimate-french-toast-or-with-babish",
+      "name": "Ultimate French Toast | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=t0nTt7Dm5Og&pp=ygUhYmluZ2luZyB3aXRoIGJhYmlzaCBmcmVuY2ggdG9hc2R0",
+      "official_link": "https://www.babi.sh/recipes/ultimate-french-toast-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769735233/hleoccmfkh4lbwvu6gzz.webp"
+    }
+  },
+  {
     "recipe_id": 1184,
     "name": "Pressed Apple Cider",
     "image_link": null,
@@ -15847,7 +17887,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "apple-cider-donuts",
-      "name": "APPLE CIDER DONUTS",
+      "name": "Apple Cider Donuts",
       "published_date": "2021-11-09",
       "youtube_link": "https://www.youtube.com/watch?v=baZoJYAQjfI",
       "official_link": "https://www.babi.sh/recipes/apple-cider-donuts",
@@ -16089,7 +18129,7 @@
       "episode_id": "charliebrownthanksgiving",
       "name": "Charlie Brown Thanksgiving",
       "published_date": "2018-11-20",
-      "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5FyKxVJmsdE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE",
       "official_link": "https://www.babi.sh/recipes/charliebrownthanksgiving",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg"
     }
@@ -16104,7 +18144,7 @@
       "episode_id": "charliebrownthanksgiving",
       "name": "Charlie Brown Thanksgiving",
       "published_date": "2018-11-20",
-      "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5FyKxVJmsdE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE",
       "official_link": "https://www.babi.sh/recipes/charliebrownthanksgiving",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg"
     }
@@ -16117,8 +18157,8 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "cake-pops",
-      "name": "CAKE POPS",
-      "published_date": "2021-11-02",
+      "name": "Cake Pops",
+      "published_date": "2021-10-21",
       "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
       "official_link": "https://www.babi.sh/recipes/cake-pops",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
@@ -16132,8 +18172,8 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "cake-pops",
-      "name": "CAKE POPS",
-      "published_date": "2021-11-02",
+      "name": "Cake Pops",
+      "published_date": "2021-10-21",
       "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
       "official_link": "https://www.babi.sh/recipes/cake-pops",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
@@ -16152,6 +18192,51 @@
       "youtube_link": "https://www.youtube.com/watch?v=r4HxTcF98MU",
       "official_link": "https://www.babi.sh/recipes/puppy-paw-hashbrowns",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696185/babishImages/undefined-27552.png"
+    }
+  },
+  {
+    "recipe_id": 1630,
+    "name": "purple deviled eggs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "the-egg-bar-inspired-by-severance",
+      "name": "The Egg Bar inspired by Severance",
+      "published_date": "2025-02-05",
+      "youtube_link": "https://www.youtube.com/watch?v=pTt4BjY34gk&t=151s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/the-egg-bar-inspired-by-severance",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1738792005/emlcx8fw10frbl32t7lq.webp"
+    }
+  },
+  {
+    "recipe_id": 1620,
+    "name": "puttanesca",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "my-top-5-easy-sexy-dishes",
+      "name": "My Top 5 Easy, Sexy Dishes",
+      "published_date": "2025-02-14",
+      "youtube_link": "https://www.youtube.com/watch?v=BAxICJRICNU&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/my-top-5-easy-sexy-dishes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1739562469/nya8wka5lyucenir6wez.webp"
+    }
+  },
+  {
+    "recipe_id": 1564,
+    "name": "quadruple stacked ham sandwich",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv",
+      "name": "Quadruple Stacked Ham Sandwich inspired by Final Fantasy XV",
+      "published_date": "2025-08-19",
+      "youtube_link": "https://www.youtube.com/watch?v=ouJL4FGGbuc",
+      "official_link": "https://www.babi.sh/recipes/quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1755625602/nnowpvarxiludykiovik.webp"
     }
   },
   {
@@ -16222,7 +18307,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "andrewsohlathanksgiving",
-      "name": "ANDREW & SOHLA THANKSGIVING RECIPES",
+      "name": "Thanksgiving Recipe Livestream with Sohla El-Waylly",
       "published_date": "2020-11-20",
       "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
       "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
@@ -16237,7 +18322,7 @@
     "raw_procedure": "Shred 8 ounces each of monterrey jack and sharp cheddar cheese. Place it all in a broiler safe serving dish.\nPlace in the oven at 425\u00b0F for about 12 minutes until it becomes bubbly, brown, and melted.\nServe and enjoy!",
     "source": {
       "episode_id": "cheesdips",
-      "name": "CHEESE DIPS",
+      "name": "Cheese Dips",
       "published_date": "2019-05-02",
       "youtube_link": "https://www.youtube.com/watch?v=9toK5UUGeok",
       "official_link": "https://www.babi.sh/recipes/cheesdips",
@@ -16362,21 +18447,6 @@
       "youtube_link": "https://www.youtube.com/watch?v=GXDQOSbcmv4",
       "official_link": "https://www.babi.sh/recipes/tampoporamen",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992061/ccr1etzxylurvtxgqoax.webp"
-    }
-  },
-  {
-    "recipe_id": 1265,
-    "name": "ramen in hotpot broth",
-    "image_link": null,
-    "raw_ingredient_list": "rice\nchrysanthemum\neggs\nboneless skinless chicken thighs",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "chicken-meatball-hotpot-inspired-by-jujutsu-kaisen",
-      "name": "Chicken Meatball Hotpot inspired By Jujutsu Kaisen",
-      "published_date": "2024-10-02",
-      "youtube_link": "https://www.youtube.com/watch?v=GymqadVYSXk&t=34s",
-      "official_link": "https://www.babi.sh/recipes/chicken-meatball-hotpot-inspired-by-jujutsu-kaisen",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727887830/cnkxewktxghxefrnq6xa.webp"
     }
   },
   {
@@ -16509,7 +18579,7 @@
       "episode_id": "avengersicecream",
       "name": "Ice Cream Flavors inspired by Avengers: Infinity War",
       "published_date": "2019-04-30",
-      "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Ukjat70Iyt4/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4",
       "official_link": "https://www.babi.sh/recipes/avengersicecream",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695805/babishImages/undefined-987247.png"
     }
@@ -16557,6 +18627,36 @@
       "youtube_link": "https://www.youtube.com/watch?v=l7VRSINAEQo",
       "official_link": "https://www.babi.sh/recipes/poke-bowls",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695359/babishImages/undefined-263359.png"
+    }
+  },
+  {
+    "recipe_id": 1514,
+    "name": "red miso maple syrup",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ultimate-french-toast-or-with-babish",
+      "name": "Ultimate French Toast | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=t0nTt7Dm5Og&pp=ygUhYmluZ2luZyB3aXRoIGJhYmlzaCBmcmVuY2ggdG9hc2R0",
+      "official_link": "https://www.babi.sh/recipes/ultimate-french-toast-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769735233/hleoccmfkh4lbwvu6gzz.webp"
+    }
+  },
+  {
+    "recipe_id": 1528,
+    "name": "red miso puff pastry",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "beef-wellington-or-with-babish",
+      "name": "$20 vs $200 Beef Wellington | With Babish",
+      "published_date": "2025-12-23",
+      "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
+      "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
     }
   },
   {
@@ -16613,7 +18713,7 @@
     "source": {
       "episode_id": "chefs-choice-platter-monster-hunter-world",
       "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-      "published_date": "2021-03-31",
+      "published_date": "2021-03-30",
       "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
       "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png"
@@ -16632,6 +18732,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=Izvd-iztaQk",
       "official_link": "https://www.babi.sh/recipes/iloveyoumanfishtacos",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992053/i2v9bvcwkfxgilag83vt.webp"
+    }
+  },
+  {
+    "recipe_id": 1629,
+    "name": "regular deviled eggs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "the-egg-bar-inspired-by-severance",
+      "name": "The Egg Bar inspired by Severance",
+      "published_date": "2025-02-05",
+      "youtube_link": "https://www.youtube.com/watch?v=pTt4BjY34gk&t=151s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/the-egg-bar-inspired-by-severance",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1738792005/emlcx8fw10frbl32t7lq.webp"
     }
   },
   {
@@ -16662,6 +18777,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=akO6D_tc0lo",
       "official_link": "https://www.babi.sh/recipes/reversesearsteak",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992080/orgwxidbhkpqwrhg9ogf.webp"
+    }
+  },
+  {
+    "recipe_id": 1542,
+    "name": "ribeye",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "steak",
+      "name": "Steak",
+      "published_date": "2025-10-03",
+      "youtube_link": "https://www.youtube.com/watch?v=peAbYlvP6rU",
+      "official_link": "https://www.babi.sh/recipes/steak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759667611/ivsyx6hgxw8cwudn9brl.webp"
     }
   },
   {
@@ -16807,7 +18937,7 @@
     "raw_procedure": "Remove all of the skin from 2 lbs of pork belly and add the skin to the roux.\nTake the fat from the pork belly and cut into chunks. Add the pork belly to a baking pan and season it with a few pinches of salt. Lightly mix to let the salt soak in. Set it aside and start preparing the red wine caramel.\nAdd 2 cups of sugar and 2 cups of red wine to a pot. Bring to a rolling boil and whisk to create a syrup-like consistency.\nSprinkle fresh thyme onto the pork belly.\nTake the pot of red wine caramel and pour it straight on top of the pork belly. Make sure that the mixture is compact before placing it into a 400 degree Fahrenheit oven for 25-35 minutes and stir occasionally.",
     "source": {
       "episode_id": "cajunfood",
-      "name": "CAJUN FOOD",
+      "name": "Cajun Food",
       "published_date": "2019-09-13",
       "youtube_link": "https://www.youtube.com/watch?v=nORg_aXMsmA",
       "official_link": "https://www.babi.sh/recipes/cajunfood",
@@ -16928,10 +19058,40 @@
     "source": {
       "episode_id": "chefs-choice-platter-monster-hunter-world",
       "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-      "published_date": "2021-03-31",
+      "published_date": "2021-03-30",
       "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
       "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png"
+    }
+  },
+  {
+    "recipe_id": 1521,
+    "name": "roasted vegetables",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ultimate-pot-roast-or-with-babish",
+      "name": "Ultimate Pot Roast | With Babish",
+      "published_date": "2026-01-15",
+      "youtube_link": "https://www.youtube.com/watch?v=5_7pC4K-Y1g",
+      "official_link": "https://www.babi.sh/recipes/ultimate-pot-roast-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768506428/gryanukvd2zeutfh9ibh.webp"
+    }
+  },
+  {
+    "recipe_id": 1622,
+    "name": "romesco sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "my-top-5-easy-sexy-dishes",
+      "name": "My Top 5 Easy, Sexy Dishes",
+      "published_date": "2025-02-14",
+      "youtube_link": "https://www.youtube.com/watch?v=BAxICJRICNU&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/my-top-5-easy-sexy-dishes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1739562469/nya8wka5lyucenir6wez.webp"
     }
   },
   {
@@ -17002,7 +19162,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "cajunfood",
-      "name": "CAJUN FOOD",
+      "name": "Cajun Food",
       "published_date": "2019-09-13",
       "youtube_link": "https://www.youtube.com/watch?v=nORg_aXMsmA",
       "official_link": "https://www.babi.sh/recipes/cajunfood",
@@ -17145,6 +19305,21 @@
     }
   },
   {
+    "recipe_id": 1581,
+    "name": "salad",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "3-course-dinner-inspired-by-drop",
+      "name": "3 Course Dinner inspired by Drop",
+      "published_date": "2025-05-03",
+      "youtube_link": "https://www.youtube.com/watch?v=23lKOTVYRGc&t=673s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/3-course-dinner-inspired-by-drop",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1746310289/sxhsw0jiihdjo9tibmw5.webp"
+    }
+  },
+  {
     "recipe_id": 268,
     "name": "Salmon",
     "image_link": null,
@@ -17227,7 +19402,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "chiles-rellenos",
-      "name": "CHILES RELLENOS",
+      "name": "Chiles Rellenos",
       "published_date": "2021-08-26",
       "youtube_link": "https://www.youtube.com/watch?v=gAKW8RB6aeU",
       "official_link": "https://www.babi.sh/recipes/chiles-rellenos",
@@ -17272,7 +19447,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "calistyle-burrito",
-      "name": "CALI-STYLE BURRITO",
+      "name": "California Style Burritos",
       "published_date": "2021-09-13",
       "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
       "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
@@ -17287,7 +19462,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "calistyle-burrito",
-      "name": "CALI-STYLE BURRITO",
+      "name": "California Style Burritos",
       "published_date": "2021-09-13",
       "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
       "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
@@ -17325,6 +19500,21 @@
     }
   },
   {
+    "recipe_id": 1605,
+    "name": "sandwich",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "egg-salad-inspired-by-futurama",
+      "name": "Egg Salad inspired by Futurama",
+      "published_date": "2025-03-07",
+      "youtube_link": "https://www.youtube.com/watch?v=cgLi9t6w9Qc&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/egg-salad-inspired-by-futurama",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741383035/fhpr01pnfwh4o1lpeje9.webp"
+    }
+  },
+  {
     "recipe_id": 1225,
     "name": "sandwich assembly",
     "image_link": null,
@@ -17337,6 +19527,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=oHEYV2rHu1Y&t=24s&ab_channel=BabishCulinaryUniverse",
       "official_link": "https://www.babi.sh/recipes/the-ultimate-steak-sandwich",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1750701480/jlorutwp35q6pflkibej.webp"
+    }
+  },
+  {
+    "recipe_id": 1612,
+    "name": "sandwich assembly",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "egg-salad-inspired-by-futurama",
+      "name": "Egg Salad inspired by Futurama",
+      "published_date": "2025-03-07",
+      "youtube_link": "https://www.youtube.com/watch?v=cgLi9t6w9Qc&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/egg-salad-inspired-by-futurama",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741383035/fhpr01pnfwh4o1lpeje9.webp"
     }
   },
   {
@@ -17377,7 +19582,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "chicken-parmesan",
-      "name": "CHICKEN PARMESAN",
+      "name": "Chicken Parmesan",
       "published_date": "2020-12-10",
       "youtube_link": "https://www.youtube.com/watch?v=ZrR0VbqNdW8",
       "official_link": "https://www.babi.sh/recipes/chicken-parmesan",
@@ -17437,7 +19642,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "biscuits-and-gravy",
-      "name": "BISCUITS AND GRAVY",
+      "name": "Biscuits & Gravy",
       "published_date": "2021-02-25",
       "youtube_link": "https://www.youtube.com/watch?v=NMbMT9tY8-Q",
       "official_link": "https://www.babi.sh/recipes/biscuits-and-gravy",
@@ -17520,6 +19725,21 @@
     }
   },
   {
+    "recipe_id": 1565,
+    "name": "scampi shrimp",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv",
+      "name": "Quadruple Stacked Ham Sandwich inspired by Final Fantasy XV",
+      "published_date": "2025-08-19",
+      "youtube_link": "https://www.youtube.com/watch?v=ouJL4FGGbuc",
+      "official_link": "https://www.babi.sh/recipes/quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1755625602/nnowpvarxiludykiovik.webp"
+    }
+  },
+  {
     "recipe_id": 213,
     "name": "Scones",
     "image_link": null,
@@ -17532,6 +19752,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=yiElOt9cI8k",
       "official_link": "https://www.babi.sh/recipes/phantomthread-l42pw",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715433/babishImages/undefined-513534.png"
+    }
+  },
+  {
+    "recipe_id": 1633,
+    "name": "scotch eggs",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "the-egg-bar-inspired-by-severance",
+      "name": "The Egg Bar inspired by Severance",
+      "published_date": "2025-02-05",
+      "youtube_link": "https://www.youtube.com/watch?v=pTt4BjY34gk&t=151s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/the-egg-bar-inspired-by-severance",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1738792005/emlcx8fw10frbl32t7lq.webp"
     }
   },
   {
@@ -17790,21 +20025,6 @@
     }
   },
   {
-    "recipe_id": 1242,
-    "name": "serving",
-    "image_link": null,
-    "raw_ingredient_list": "dried sorrel\ncinnamon orange peel, or a few cloves,\nheavy cream\nsweetened condensed milk",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "agua-de-jamaica-granita",
-      "name": "Agua de Jamaica Granita",
-      "published_date": "2025-04-29",
-      "youtube_link": "https://www.youtube.com/shorts/NYPxT4K-jEw",
-      "official_link": "https://www.babi.sh/recipes/agua-de-jamaica-granita",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1745960432/nlcsou9whnpdevviupw4.webp"
-    }
-  },
-  {
     "recipe_id": 1353,
     "name": "serving",
     "image_link": null,
@@ -17812,7 +20032,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "barbacoa-de-res",
-      "name": "BARBACOA DE RES CON CONSOM\u00c9",
+      "name": "Barbacoa Tacos and Gringas de Barbacoa with Consom\u00e9 | Pru\u00e9balo with Rick Martinez",
       "published_date": "2023-05-05",
       "youtube_link": "https://www.youtube.com/watch?v=Ya5u2uC3d2U",
       "official_link": "https://www.babi.sh/recipes/barbacoa-de-res",
@@ -17880,18 +20100,48 @@
     }
   },
   {
-    "recipe_id": 1309,
-    "name": "short cut past\u00e9is de nata ingredients:",
+    "recipe_id": 1608,
+    "name": "shokupan dough",
     "image_link": null,
-    "raw_ingredient_list": "milk\nsweet cherries\nsugar\nflour\negg yolks\nbrown sugar or sugar\ncognac or grand marnier",
+    "raw_ingredient_list": "",
     "raw_procedure": "",
     "source": {
-      "episode_id": "2024oscarsspecial",
-      "name": "2024 Oscars Special",
-      "published_date": "2024-03-15",
-      "youtube_link": "https://youtu.be/NVwgZhjspxo",
-      "official_link": "https://www.babi.sh/recipes/2024oscarsspecial",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1710510271/ny7ovkakrtfei4odwnfd.webp"
+      "episode_id": "egg-salad-inspired-by-futurama",
+      "name": "Egg Salad inspired by Futurama",
+      "published_date": "2025-03-07",
+      "youtube_link": "https://www.youtube.com/watch?v=cgLi9t6w9Qc&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/egg-salad-inspired-by-futurama",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741383035/fhpr01pnfwh4o1lpeje9.webp"
+    }
+  },
+  {
+    "recipe_id": 1574,
+    "name": "short rib bones snack",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "deep-fried-burger-bomb",
+      "name": "Deep Fried Burger Bomb",
+      "published_date": "2025-06-06",
+      "youtube_link": "https://www.youtube.com/watch?v=dhRkD9u0C48&pp=ygUYZnJpZWQgYnVyZ2VyIGJvbWIgYmFiaXNo",
+      "official_link": "https://www.babi.sh/recipes/deep-fried-burger-bomb",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749219273/tfuzfxhkivkjrmtvcjam.webp"
+    }
+  },
+  {
+    "recipe_id": 1615,
+    "name": "shrimp",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "shrimp-7-ways",
+      "name": "Shrimp 7 Ways",
+      "published_date": "2025-03-05",
+      "youtube_link": "https://www.youtube.com/watch?v=Uct0-gkfEsk&t=324s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/shrimp-7-ways",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741134166/kwu0dmfwjm9sr0h9zabd.webp"
     }
   },
   {
@@ -17910,6 +20160,21 @@
     }
   },
   {
+    "recipe_id": 1569,
+    "name": "shrimp & avocado sandwich",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv",
+      "name": "Quadruple Stacked Ham Sandwich inspired by Final Fantasy XV",
+      "published_date": "2025-08-19",
+      "youtube_link": "https://www.youtube.com/watch?v=ouJL4FGGbuc",
+      "official_link": "https://www.babi.sh/recipes/quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1755625602/nnowpvarxiludykiovik.webp"
+    }
+  },
+  {
     "recipe_id": 86,
     "name": "Shrimp Burger",
     "image_link": null,
@@ -17919,9 +20184,24 @@
       "episode_id": "bubbashrimp2",
       "name": "Shrimp inspired by Forrest Gump Part II",
       "published_date": "2019-04-23",
-      "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/mF6JUfczaO8/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8",
       "official_link": "https://www.babi.sh/recipes/bubbashrimp2",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696055/babishImages/undefined-252668.png"
+    }
+  },
+  {
+    "recipe_id": 1614,
+    "name": "shrimp cocktail",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "shrimp-7-ways",
+      "name": "Shrimp 7 Ways",
+      "published_date": "2025-03-05",
+      "youtube_link": "https://www.youtube.com/watch?v=Uct0-gkfEsk&t=324s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/shrimp-7-ways",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741134166/kwu0dmfwjm9sr0h9zabd.webp"
     }
   },
   {
@@ -18000,6 +20280,21 @@
     }
   },
   {
+    "recipe_id": 1613,
+    "name": "shrimp stock",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "shrimp-7-ways",
+      "name": "Shrimp 7 Ways",
+      "published_date": "2025-03-05",
+      "youtube_link": "https://www.youtube.com/watch?v=Uct0-gkfEsk&t=324s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/shrimp-7-ways",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741134166/kwu0dmfwjm9sr0h9zabd.webp"
+    }
+  },
+  {
     "recipe_id": 963,
     "name": "Shrimp Stock",
     "image_link": null,
@@ -18008,7 +20303,7 @@
     "source": {
       "episode_id": "chefs-choice-platter-monster-hunter-world",
       "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-      "published_date": "2021-03-31",
+      "published_date": "2021-03-30",
       "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
       "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png"
@@ -18037,11 +20332,26 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "biscuits-and-gravy",
-      "name": "BISCUITS AND GRAVY",
+      "name": "Biscuits & Gravy",
       "published_date": "2021-02-25",
       "youtube_link": "https://www.youtube.com/watch?v=NMbMT9tY8-Q",
       "official_link": "https://www.babi.sh/recipes/biscuits-and-gravy",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695440/babishImages/undefined-307049.png"
+    }
+  },
+  {
+    "recipe_id": 1659,
+    "name": "simple mustard pan sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "date-night-2",
+      "name": "DATE NIGHT II",
+      "published_date": "2022-01-11",
+      "youtube_link": "https://www.youtube.com/watch?v=dlATzLk8Nh8",
+      "official_link": "https://www.babi.sh/recipes/date-night-2",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1680979695/cbadjt8l6pkrdiadhks1.webp"
     }
   },
   {
@@ -18087,6 +20397,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=yr6ts2AH04g",
       "official_link": "https://www.babi.sh/recipes/sweet-potato-casserole-friends",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695844/babishImages/undefined-200135.png"
+    }
+  },
+  {
+    "recipe_id": 1483,
+    "name": "skewers",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "kpop-demon-hunters-airplane-feast",
+      "name": "KPop Demon Hunters Airplane Feast",
+      "published_date": "2026-04-11",
+      "youtube_link": "https://youtube.com/watch?v=W8kIAgoqDAI&si=65fH6Fh3e8T6yGu_",
+      "official_link": "https://www.babi.sh/recipes/kpop-demon-hunters-airplane-feast",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1775873571/sifq1hxehqudhjdfchik.webp"
     }
   },
   {
@@ -18345,6 +20670,21 @@
     }
   },
   {
+    "recipe_id": 1489,
+    "name": "soup base",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-chicken-noodle-soup",
+      "name": "10 Levels of Chicken Noodle Soup",
+      "published_date": "2026-03-28",
+      "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
+      "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1774738409/btugut1heyus4wsry467.webp"
+    }
+  },
+  {
     "recipe_id": 175,
     "name": "Sour Cream Donuts",
     "image_link": null,
@@ -18397,7 +20737,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "andrewsohlathanksgiving",
-      "name": "ANDREW & SOHLA THANKSGIVING RECIPES",
+      "name": "Thanksgiving Recipe Livestream with Sohla El-Waylly",
       "published_date": "2020-11-20",
       "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
       "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
@@ -18432,6 +20772,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=jeCk5e0YsF0",
       "official_link": "https://www.babi.sh/recipes/souvlaki",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695876/babishImages/undefined-636748.png"
+    }
+  },
+  {
+    "recipe_id": 1587,
+    "name": "souvlaki spice mix",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "5-weeknight-recipes-for-pork-tenderloin",
+      "name": "5 Weeknight Recipes for Pork Tenderloin",
+      "published_date": "2025-04-08",
+      "youtube_link": "https://www.youtube.com/watch?v=VEAmtpkxXXQ&t=21s",
+      "official_link": "https://www.babi.sh/recipes/5-weeknight-recipes-for-pork-tenderloin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1744118544/yh4iqwlo6kyfxad3flzw.webp"
     }
   },
   {
@@ -18570,6 +20925,21 @@
     }
   },
   {
+    "recipe_id": 1553,
+    "name": "spiced cake soak",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "name": "Fallout Fancy Lad Snack Cakes inspired by Fallout 76",
+      "published_date": "2025-10-01",
+      "youtube_link": "https://www.youtube.com/watch?v=v1f835eNhUc",
+      "official_link": "https://www.babi.sh/recipes/fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759334763/qv57em4y8nloxgzztjrs.webp"
+    }
+  },
+  {
     "recipe_id": 1324,
     "name": "spiced rum",
     "image_link": null,
@@ -18675,6 +21045,21 @@
     }
   },
   {
+    "recipe_id": 1497,
+    "name": "spinach artichoke dip",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "super-bowl-snacks-for-the-win-or-with-babish",
+      "name": "Super Bowl Snacks for the Win | With Babish",
+      "published_date": "2026-02-02",
+      "youtube_link": "https://youtube.com/watch?v=YIf161LjodE",
+      "official_link": "https://www.babi.sh/recipes/super-bowl-snacks-for-the-win-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1770071325/fy1ppzw7ndz0jh29hkmh.webp"
+    }
+  },
+  {
     "recipe_id": 78,
     "name": "Spinach Artichoke Dip",
     "image_link": null,
@@ -18682,11 +21067,26 @@
     "raw_procedure": "Into a large bowl add 8 ounces of softened cream cheese, 8 ounces of shredded low moisture of mozzarella, 2 ounces of shredded romano, and 2 ounces of parmesan.\nPreheat a nonstick pan with 1 Tbsp of olive oil before adding 2 cups of frozen spinach over a medium heat for 4-5 minutes.\nNext grate in 3 cloves of garlic and add \u00bd a cup of artichoke hearts. Cook for 1-2 minutes.\nOnce cooked add the veggies to a large bowl with shredded cheese. Season with salt and pepper and then mix to combine.\nPlace mixture into an oven safe serving vessel. Top with a generous grating of parmesan cheese before placing into a 375\u00b0F oven for about 20-25 minutes. Remove once golden brown.\nServe and enjoy!",
     "source": {
       "episode_id": "cheesdips",
-      "name": "CHEESE DIPS",
+      "name": "Cheese Dips",
       "published_date": "2019-05-02",
       "youtube_link": "https://www.youtube.com/watch?v=9toK5UUGeok",
       "official_link": "https://www.babi.sh/recipes/cheesdips",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1686005952/sgzpqqlxhdnjser57r5j.webp"
+    }
+  },
+  {
+    "recipe_id": 1494,
+    "name": "spinach artichoke dip monkey bread",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "super-bowl-snacks-for-the-win-or-with-babish",
+      "name": "Super Bowl Snacks for the Win | With Babish",
+      "published_date": "2026-02-02",
+      "youtube_link": "https://youtube.com/watch?v=YIf161LjodE",
+      "official_link": "https://www.babi.sh/recipes/super-bowl-snacks-for-the-win-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1770071325/fy1ppzw7ndz0jh29hkmh.webp"
     }
   },
   {
@@ -18717,6 +21117,51 @@
       "youtube_link": "https://www.youtube.com/watch?v=x5-QoCicNfI",
       "official_link": "https://www.babi.sh/recipes/spinachpuffs",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715538/babishImages/undefined-469060.png"
+    }
+  },
+  {
+    "recipe_id": 1596,
+    "name": "sponge cake",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "cheesecake-inspired-by-junior's-cheesecakes",
+      "name": "Cheesecake inspired by Junior's Cheesecakes",
+      "published_date": "2025-03-11",
+      "youtube_link": "https://www.youtube.com/watch?v=gQeY_wx9bsI&t=26s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/cheesecake-inspired-by-junior's-cheesecakes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741657095/qjrimy3opynb08w9zudl.webp"
+    }
+  },
+  {
+    "recipe_id": 1551,
+    "name": "sponge cake batter",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "name": "Fallout Fancy Lad Snack Cakes inspired by Fallout 76",
+      "published_date": "2025-10-01",
+      "youtube_link": "https://www.youtube.com/watch?v=v1f835eNhUc",
+      "official_link": "https://www.babi.sh/recipes/fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759334763/qv57em4y8nloxgzztjrs.webp"
+    }
+  },
+  {
+    "recipe_id": 1597,
+    "name": "sponge cake batter",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "cheesecake-inspired-by-junior's-cheesecakes",
+      "name": "Cheesecake inspired by Junior's Cheesecakes",
+      "published_date": "2025-03-11",
+      "youtube_link": "https://www.youtube.com/watch?v=gQeY_wx9bsI&t=26s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/cheesecake-inspired-by-junior's-cheesecakes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741657095/qjrimy3opynb08w9zudl.webp"
     }
   },
   {
@@ -18804,9 +21249,24 @@
       "episode_id": "avengersicecream",
       "name": "Ice Cream Flavors inspired by Avengers: Infinity War",
       "published_date": "2019-04-30",
-      "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Ukjat70Iyt4/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4",
       "official_link": "https://www.babi.sh/recipes/avengersicecream",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695805/babishImages/undefined-987247.png"
+    }
+  },
+  {
+    "recipe_id": 1545,
+    "name": "steak",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "steak",
+      "name": "Steak",
+      "published_date": "2025-10-03",
+      "youtube_link": "https://www.youtube.com/watch?v=peAbYlvP6rU",
+      "official_link": "https://www.babi.sh/recipes/steak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759667611/ivsyx6hgxw8cwudn9brl.webp"
     }
   },
   {
@@ -18822,6 +21282,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=tCJ_VV0FEZM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/tCJ_VV0FEZM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
       "official_link": "https://www.babi.sh/recipes/steak-au-poivre",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696147/babishImages/undefined-20273.png"
+    }
+  },
+  {
+    "recipe_id": 1537,
+    "name": "steak cuts: technique",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "steak",
+      "name": "Steak",
+      "published_date": "2025-10-03",
+      "youtube_link": "https://www.youtube.com/watch?v=peAbYlvP6rU",
+      "official_link": "https://www.babi.sh/recipes/steak",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759667611/ivsyx6hgxw8cwudn9brl.webp"
     }
   },
   {
@@ -18930,6 +21405,21 @@
     }
   },
   {
+    "recipe_id": 1488,
+    "name": "stock",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "10-levels-chicken-noodle-soup",
+      "name": "10 Levels of Chicken Noodle Soup",
+      "published_date": "2026-03-28",
+      "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
+      "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1774738409/btugut1heyus4wsry467.webp"
+    }
+  },
+  {
     "recipe_id": 785,
     "name": "Stock",
     "image_link": null,
@@ -18967,7 +21457,7 @@
     "raw_procedure": "Start by making a dry rub for your pork by combining 1 Tbsp of dark brown sugar, 1 tsp of paprika, \u00bd tsp smoked paprika, \u00bd tsp ground coriander, 1 tsp ground cumin, and freshly ground pepper.\nRemove pork chops from brine and pat them dry. Make sure you get them as dry as possible. Once dry, coat them evenly on all sides with the spice rub. Set aside.\nNext, you\u2019re going to make a barbeque sauce by combining \u00bd cup ketchup, \u00bd a small onion finely grated, 1-2 Tbsp of worcestershire sauce, \u00bd tsp smoked paprika, 1 Tbsp of apple cider vinegar, 2 Tbsp of dijon mustard, and 1-2 Tbsp of dark brown sugar. Whisk to combine. Simmer for 30 minutes on low heat.\nAdd vegetable oil over medium high heat to a non-stick pan. Make two small slices through the fat cap of the pork chop a few inches apart to keep the pork from curling. Add pork chops to the pan and cook until internal temperature reaches 130\u00b0F.\nRemove pork from the pan and set aside. Wipe out pan and put back on medium high heat with vegetable oil.\nBrush the pork chops down with a layer of barbecue sauce. Place sauce side down onto the preheated pan, brushing the exposed side with barbeque sauce. Flip and sauce until you have a good barbecue crust formed and the internal temperature reaches 145\u00b0F internally. Set aside to rest. Serve with some extra barbecue sauce and enjoy!",
     "source": {
       "episode_id": "barbecueporkchops",
-      "name": "BARBECUE PORK CHOPS",
+      "name": "Barbecue Pork Chops",
       "published_date": "2018-06-28",
       "youtube_link": "https://www.youtube.com/watch?v=YV9XuvfIudY",
       "official_link": "https://www.babi.sh/recipes/barbecueporkchops",
@@ -19005,6 +21495,36 @@
     }
   },
   {
+    "recipe_id": 1600,
+    "name": "strawberry cheesecake",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "cheesecake-inspired-by-junior's-cheesecakes",
+      "name": "Cheesecake inspired by Junior's Cheesecakes",
+      "published_date": "2025-03-11",
+      "youtube_link": "https://www.youtube.com/watch?v=gQeY_wx9bsI&t=26s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/cheesecake-inspired-by-junior's-cheesecakes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741657095/qjrimy3opynb08w9zudl.webp"
+    }
+  },
+  {
+    "recipe_id": 1639,
+    "name": "strawberry flavor",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "whimsical-parfait-inspired-by-darker-than-black",
+      "name": "Whimsical Parfait inspired by Darker than Black",
+      "published_date": "2024-10-02",
+      "youtube_link": "https://www.youtube.com/watch?v=GHwZqJYYB80",
+      "official_link": "https://www.babi.sh/recipes/whimsical-parfait-inspired-by-darker-than-black",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727903480/ek6bh07lnnblfomgfhdy.webp"
+    }
+  },
+  {
     "recipe_id": 899,
     "name": "Strawberry Puree",
     "image_link": null,
@@ -19017,6 +21537,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=KbNRvWfndjA",
       "official_link": "https://www.babi.sh/recipes/cookie-cat-steven-universe",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696201/babishImages/undefined-799954.png"
+    }
+  },
+  {
+    "recipe_id": 1602,
+    "name": "strawberry topping",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "cheesecake-inspired-by-junior's-cheesecakes",
+      "name": "Cheesecake inspired by Junior's Cheesecakes",
+      "published_date": "2025-03-11",
+      "youtube_link": "https://www.youtube.com/watch?v=gQeY_wx9bsI&t=26s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/cheesecake-inspired-by-junior's-cheesecakes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741657095/qjrimy3opynb08w9zudl.webp"
     }
   },
   {
@@ -19044,7 +21579,7 @@
       "episode_id": "charliebrownthanksgiving",
       "name": "Charlie Brown Thanksgiving",
       "published_date": "2018-11-20",
-      "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5FyKxVJmsdE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE",
       "official_link": "https://www.babi.sh/recipes/charliebrownthanksgiving",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg"
     }
@@ -19253,7 +21788,7 @@
     "source": {
       "episode_id": "cocktail-special",
       "name": "Cocktail Special",
-      "published_date": "2017-06-28",
+      "published_date": "2017-06-27",
       "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
       "official_link": "https://www.babi.sh/recipes/cocktail-special",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -19417,7 +21952,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "corn-dogs",
-      "name": "CORN DOGS",
+      "name": "Corn Dogs",
       "published_date": "2021-05-27",
       "youtube_link": "https://www.youtube.com/watch?v=zGT45vVJNso",
       "official_link": "https://www.babi.sh/recipes/corn-dogs",
@@ -19497,6 +22032,36 @@
       "youtube_link": "https://www.youtube.com/watch?v=SntU6-vxzWc",
       "official_link": "https://www.babi.sh/recipes/french-toast",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715739/babishImages/undefined-853707.png"
+    }
+  },
+  {
+    "recipe_id": 1590,
+    "name": "tangzhong",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "japanese-style-big-mac-inspired-by-weathering-with-you",
+      "name": "Japanese-Style Big Mac inspired by Weathering with You",
+      "published_date": "2025-03-19",
+      "youtube_link": "https://www.youtube.com/watch?v=BzKBag59duU&pp=ygUTYWx2aW4gamFwYW4gYmlnIG1hYw%3D%3D",
+      "official_link": "https://www.babi.sh/recipes/japanese-style-big-mac-inspired-by-weathering-with-you",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1742407838/ofwjdoqrkbbijmlqiu7e.webp"
+    }
+  },
+  {
+    "recipe_id": 1609,
+    "name": "tangzhong",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "egg-salad-inspired-by-futurama",
+      "name": "Egg Salad inspired by Futurama",
+      "published_date": "2025-03-07",
+      "youtube_link": "https://www.youtube.com/watch?v=cgLi9t6w9Qc&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/egg-salad-inspired-by-futurama",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741383035/fhpr01pnfwh4o1lpeje9.webp"
     }
   },
   {
@@ -19658,10 +22223,40 @@
     "source": {
       "episode_id": "chefs-choice-platter-monster-hunter-world",
       "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-      "published_date": "2021-03-31",
+      "published_date": "2021-03-30",
       "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
       "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png"
+    }
+  },
+  {
+    "recipe_id": 1592,
+    "name": "teriyaki sauce",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "japanese-style-big-mac-inspired-by-weathering-with-you",
+      "name": "Japanese-Style Big Mac inspired by Weathering with You",
+      "published_date": "2025-03-19",
+      "youtube_link": "https://www.youtube.com/watch?v=BzKBag59duU&pp=ygUTYWx2aW4gamFwYW4gYmlnIG1hYw%3D%3D",
+      "official_link": "https://www.babi.sh/recipes/japanese-style-big-mac-inspired-by-weathering-with-you",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1742407838/ofwjdoqrkbbijmlqiu7e.webp"
+    }
+  },
+  {
+    "recipe_id": 1617,
+    "name": "thai coconut curry",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "shrimp-7-ways",
+      "name": "Shrimp 7 Ways",
+      "published_date": "2025-03-05",
+      "youtube_link": "https://www.youtube.com/watch?v=Uct0-gkfEsk&t=324s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/shrimp-7-ways",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741134166/kwu0dmfwjm9sr0h9zabd.webp"
     }
   },
   {
@@ -19687,7 +22282,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "andrewsohlathanksgiving",
-      "name": "ANDREW & SOHLA THANKSGIVING RECIPES",
+      "name": "Thanksgiving Recipe Livestream with Sohla El-Waylly",
       "published_date": "2020-11-20",
       "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
       "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
@@ -19702,22 +22297,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "andrewsohlathanksgiving",
-      "name": "ANDREW & SOHLA THANKSGIVING RECIPES",
-      "published_date": "2020-11-20",
-      "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
-      "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
-      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715526/babishImages/undefined-665559.jpg"
-    }
-  },
-  {
-    "recipe_id": 809,
-    "name": "The Casserole",
-    "image_link": null,
-    "raw_ingredient_list": "1 \u2154 cups fresh or frozen corn kernels",
-    "raw_procedure": "",
-    "source": {
-      "episode_id": "andrewsohlathanksgiving",
-      "name": "ANDREW & SOHLA THANKSGIVING RECIPES",
+      "name": "Thanksgiving Recipe Livestream with Sohla El-Waylly",
       "published_date": "2020-11-20",
       "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
       "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
@@ -19882,9 +22462,9 @@
     "raw_procedure": "Mix and serve.",
     "source": {
       "episode_id": "baressentials",
-      "name": "BAR ESSENTIALS",
+      "name": "Bar Essentials",
       "published_date": "2018-03-15",
-      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/iZUfPIKbgUM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM",
       "official_link": "https://www.babi.sh/recipes/baressentials",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690416607/jlnnbuig1g2nrqafs58x.webp"
     }
@@ -20017,7 +22597,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "andrewsohlathanksgiving",
-      "name": "ANDREW & SOHLA THANKSGIVING RECIPES",
+      "name": "Thanksgiving Recipe Livestream with Sohla El-Waylly",
       "published_date": "2020-11-20",
       "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
       "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
@@ -20145,6 +22725,21 @@
     }
   },
   {
+    "recipe_id": 1510,
+    "name": "toast",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "ultimate-french-toast-or-with-babish",
+      "name": "Ultimate French Toast | With Babish",
+      "published_date": "2026-01-30",
+      "youtube_link": "https://www.youtube.com/watch?v=t0nTt7Dm5Og&pp=ygUhYmluZ2luZyB3aXRoIGJhYmlzaCBmcmVuY2ggdG9hc2R0",
+      "official_link": "https://www.babi.sh/recipes/ultimate-french-toast-or-with-babish",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769735233/hleoccmfkh4lbwvu6gzz.webp"
+    }
+  },
+  {
     "recipe_id": 124,
     "name": "Toasted Jalape\u00f1o Points",
     "image_link": null,
@@ -20172,6 +22767,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=PAnreKf_9BE",
       "official_link": "https://www.babi.sh/recipes/sticky-buns",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715517/babishImages/undefined-795041.png"
+    }
+  },
+  {
+    "recipe_id": 936,
+    "name": "Toasted Sugar",
+    "image_link": null,
+    "raw_ingredient_list": "4 cups white granulated sugar",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "biscuits-ted-lasso",
+      "name": "Biscuits inspired by Ted Lasso",
+      "published_date": "2021-03-16",
+      "youtube_link": "https://www.youtube.com/watch?v=r_yBqWHtWMo",
+      "official_link": "https://www.babi.sh/recipes/biscuits-ted-lasso",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695315/babishImages/undefined-343517.png"
     }
   },
   {
@@ -20247,6 +22857,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=_SObOsXrDRc",
       "official_link": "https://www.babi.sh/recipes/pulledpork",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1685913479/ewsxvdz9xce9hohksnmc.webp"
+    }
+  },
+  {
+    "recipe_id": 1618,
+    "name": "tomato confit",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "my-top-5-easy-sexy-dishes",
+      "name": "My Top 5 Easy, Sexy Dishes",
+      "published_date": "2025-02-14",
+      "youtube_link": "https://www.youtube.com/watch?v=BAxICJRICNU&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/my-top-5-easy-sexy-dishes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1739562469/nya8wka5lyucenir6wez.webp"
     }
   },
   {
@@ -20347,7 +22972,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "ben-wyatt-calzones",
-      "name": "Calzones inspired by Parks & Rec",
+      "name": "Ben Wyatt's Calzones",
       "published_date": "2020-04-15",
       "youtube_link": "https://www.youtube.com/watch?v=PvgCEifW7Jo",
       "official_link": "https://www.babi.sh/recipes/ben-wyatt-calzones",
@@ -20377,7 +23002,7 @@
     "raw_procedure": "Finely mince a shallot and one clove of garlic. In a pan add 2 Tbsp of butter and melt over medium high heat before adding the minced shallot. Saute for about 3 minutes before adding garlic and then saute that for about 1 minute. Add 1 Tbsp of tomato paste and saute for 30 seconds.\nAdd a shake of oregano and 1 can of whole San Marzano tomatoes. Break the tomatoes up with a wooden spoon and then add 1 cup of water along with 1 tsp of molasses. Bring to a simmer and mix to combine. Let simmer for 30-60 minutes and then add the mixture to a blender.\nTo add to the creaminess of the soup, add 1 piece of torn crustless white bread to the blender and blend on high. As it blends, add olive oil to emulsify the soup. Next add sugar, kosher salt, and more olive oil as necessary until the desired texture and consistency is reached.\nFor the grilled cheese, use mayonnaise on the bread instead of butter along with 2 slices of american cheese. Cook in a pan with melted butter until both sides are nicely golden brown. Remove from pan and cut off crust. Cut the grilled cheese into small crouton-sized pieces.\nAdd the tomato soup to a bowl along with some heavy cream drizzle and grilled cheese croutons.\nServe and enjoy.",
     "source": {
       "episode_id": "blendersoups",
-      "name": "BLENDER SOUPS",
+      "name": "Blender Soups",
       "published_date": "2019-03-05",
       "youtube_link": "https://www.youtube.com/watch?v=S-gUFvpRQoU",
       "official_link": "https://www.babi.sh/recipes/blendersoups",
@@ -20580,6 +23205,21 @@
     }
   },
   {
+    "recipe_id": 1594,
+    "name": "traditional cheesecake",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "cheesecake-inspired-by-junior's-cheesecakes",
+      "name": "Cheesecake inspired by Junior's Cheesecakes",
+      "published_date": "2025-03-11",
+      "youtube_link": "https://www.youtube.com/watch?v=gQeY_wx9bsI&t=26s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/cheesecake-inspired-by-junior's-cheesecakes",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741657095/qjrimy3opynb08w9zudl.webp"
+    }
+  },
+  {
     "recipe_id": 761,
     "name": "Traditional Garlic Bread",
     "image_link": null,
@@ -20754,7 +23394,7 @@
       "episode_id": "charliebrownthanksgiving",
       "name": "Charlie Brown Thanksgiving",
       "published_date": "2018-11-20",
-      "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5FyKxVJmsdE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE",
       "official_link": "https://www.babi.sh/recipes/charliebrownthanksgiving",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg"
     }
@@ -20977,8 +23617,8 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "cake-pops",
-      "name": "CAKE POPS",
-      "published_date": "2021-11-02",
+      "name": "Cake Pops",
+      "published_date": "2021-10-21",
       "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
       "official_link": "https://www.babi.sh/recipes/cake-pops",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
@@ -20997,6 +23637,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=9PWomdbZi2U",
       "official_link": "https://www.babi.sh/recipes/donuts",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1686009926/fywiebobsgyzvnbikdjo.webp"
+    }
+  },
+  {
+    "recipe_id": 1637,
+    "name": "vanilla flavor",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "whimsical-parfait-inspired-by-darker-than-black",
+      "name": "Whimsical Parfait inspired by Darker than Black",
+      "published_date": "2024-10-02",
+      "youtube_link": "https://www.youtube.com/watch?v=GHwZqJYYB80",
+      "official_link": "https://www.babi.sh/recipes/whimsical-parfait-inspired-by-darker-than-black",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727903480/ek6bh07lnnblfomgfhdy.webp"
     }
   },
   {
@@ -21022,8 +23677,8 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "cake-pops",
-      "name": "CAKE POPS",
-      "published_date": "2021-11-02",
+      "name": "Cake Pops",
+      "published_date": "2021-10-21",
       "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
       "official_link": "https://www.babi.sh/recipes/cake-pops",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
@@ -21090,6 +23745,21 @@
     }
   },
   {
+    "recipe_id": 1530,
+    "name": "vegetables",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "coq-au-vin",
+      "name": "Coq au Vin",
+      "published_date": "2025-10-11",
+      "youtube_link": "https://www.youtube.com/watch?v=cf1H6ylUFH4",
+      "official_link": "https://www.babi.sh/recipes/coq-au-vin",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1760217634/qggynlnkmhze8roieemn.webp"
+    }
+  },
+  {
     "recipe_id": 90,
     "name": "Vegetarian Quesadilla",
     "image_link": null,
@@ -21113,7 +23783,7 @@
     "source": {
       "episode_id": "cocktail-special",
       "name": "Cocktail Special",
-      "published_date": "2017-06-28",
+      "published_date": "2017-06-27",
       "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
       "official_link": "https://www.babi.sh/recipes/cocktail-special",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -21240,6 +23910,21 @@
     }
   },
   {
+    "recipe_id": 1631,
+    "name": "waffle soldiers",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "the-egg-bar-inspired-by-severance",
+      "name": "The Egg Bar inspired by Severance",
+      "published_date": "2025-02-05",
+      "youtube_link": "https://www.youtube.com/watch?v=pTt4BjY34gk&t=151s&ab_channel=BabishCulinaryUniverse",
+      "official_link": "https://www.babi.sh/recipes/the-egg-bar-inspired-by-severance",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1738792005/emlcx8fw10frbl32t7lq.webp"
+    }
+  },
+  {
     "recipe_id": 1388,
     "name": "wasabi buffalo wings",
     "image_link": null,
@@ -21337,7 +24022,7 @@
     "raw_procedure": "",
     "source": {
       "episode_id": "advanced-grilled-cheese",
-      "name": "ADVANCED GRILLED CHEESE",
+      "name": "Advanced Grilled Cheese",
       "published_date": "2021-02-19",
       "youtube_link": "https://www.youtube.com/watch?v=Zo7sRijXG00",
       "official_link": "https://www.babi.sh/recipes/advanced-grilled-cheese",
@@ -21399,7 +24084,7 @@
       "episode_id": "charliebrownthanksgiving",
       "name": "Charlie Brown Thanksgiving",
       "published_date": "2018-11-20",
-      "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5FyKxVJmsdE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE",
       "official_link": "https://www.babi.sh/recipes/charliebrownthanksgiving",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg"
     }
@@ -21429,7 +24114,7 @@
       "episode_id": "coffeejelly",
       "name": "Coffee Jelly inspired by The Disastrous Life of Saiki K.",
       "published_date": "2019-09-24",
-      "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YxEcd_wTf5c/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c",
       "official_link": "https://www.babi.sh/recipes/coffeejelly",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png"
     }
@@ -21540,6 +24225,51 @@
     }
   },
   {
+    "recipe_id": 1652,
+    "name": "whipped ricotta",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "date-night-2",
+      "name": "DATE NIGHT II",
+      "published_date": "2022-01-11",
+      "youtube_link": "https://www.youtube.com/watch?v=dlATzLk8Nh8",
+      "official_link": "https://www.babi.sh/recipes/date-night-2",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1680979695/cbadjt8l6pkrdiadhks1.webp"
+    }
+  },
+  {
+    "recipe_id": 1651,
+    "name": "whipped ricotta & toppings",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "date-night-2",
+      "name": "DATE NIGHT II",
+      "published_date": "2022-01-11",
+      "youtube_link": "https://www.youtube.com/watch?v=dlATzLk8Nh8",
+      "official_link": "https://www.babi.sh/recipes/date-night-2",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1680979695/cbadjt8l6pkrdiadhks1.webp"
+    }
+  },
+  {
+    "recipe_id": 1552,
+    "name": "whipped white chocolate ganache",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "name": "Fallout Fancy Lad Snack Cakes inspired by Fallout 76",
+      "published_date": "2025-10-01",
+      "youtube_link": "https://www.youtube.com/watch?v=v1f835eNhUc",
+      "official_link": "https://www.babi.sh/recipes/fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759334763/qv57em4y8nloxgzztjrs.webp"
+    }
+  },
+  {
     "recipe_id": 879,
     "name": "White Bean Dip",
     "image_link": null,
@@ -21585,6 +24315,21 @@
     }
   },
   {
+    "recipe_id": 1549,
+    "name": "white chocolate fondant coating",
+    "image_link": null,
+    "raw_ingredient_list": "",
+    "raw_procedure": "",
+    "source": {
+      "episode_id": "fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "name": "Fallout Fancy Lad Snack Cakes inspired by Fallout 76",
+      "published_date": "2025-10-01",
+      "youtube_link": "https://www.youtube.com/watch?v=v1f835eNhUc",
+      "official_link": "https://www.babi.sh/recipes/fallout-fancy-lad-snack-cakes-inspired-by-fallout-76",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1759334763/qv57em4y8nloxgzztjrs.webp"
+    }
+  },
+  {
     "recipe_id": 1049,
     "name": "White Chocolate Macadamia Nut Cookies",
     "image_link": null,
@@ -21623,7 +24368,7 @@
     "source": {
       "episode_id": "cocktail-special",
       "name": "Cocktail Special",
-      "published_date": "2017-06-28",
+      "published_date": "2017-06-27",
       "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
       "official_link": "https://www.babi.sh/recipes/cocktail-special",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -21717,6 +24462,21 @@
       "youtube_link": "https://www.youtube.com/watch?v=mXtKxjyfRFU",
       "official_link": "https://www.babi.sh/recipes/wings",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690352392/kfj7peybgqxukvxts1ot.webp"
+    }
+  },
+  {
+    "recipe_id": 226,
+    "name": "Winning #BabishPanini Car Panini",
+    "image_link": null,
+    "raw_ingredient_list": "Mole Sauce\nPasilla dried chilis\nGuajillo dried chilis\nAncho dried chilis\n1 tsp whole cloves\n1 tsp peppercorn\n3 bay leaves, crumbled\n1 cinnamon stick\n1 corn tortilla\n1 slice of white bread\n\u2153 cup peanuts\n\u2153 cup pumpkin seeds\n\u2153 cup almonds\n\u2153 cup raisins\n\u00bc cup sesame seeds\n1 large tomato, quartered\n1 large onion\n4 cloves of garlic\n\u00bc tsp dried thyme\n\u00bc tsp marjoram\n\u00bc tsp aniseed\n4 cups chicken stock, hot\n4 ounces bittersweet chocolate, chopped\nSugar (if necessary)\nTomatillos (optional)\nCheddar Crisps\nShredded mild cheddar cheese\nGoat Cheese Cream\n5 ounces goat cheese\n1 Tbsp honey\n2 Tbsp heavy cream\nSandwich Stuff\n2 slices of white bread\nChorizo",
+    "raw_procedure": "Start by stemming and seeding some dried pasilla, guajillo, and ancho chilis. Save a few tablespoons of the seeds.\nHeat a cast iron skillet to a medium heat and add chilis. Dry roast them for about 2 minutes. Place about 12 chilis into a blender and set aside. Remove any extra chilis from skillet.\nIn the same skillet add 1 tsp whole cloves, 1 tsp peppercorns, 3 crumbled bay leaves, 1 cinnamon stick broken into a few pieces, and some of our reserved chili seeds. Dry roast for about 2 minutes or until the seeds darken. Remove from skillet and add to the blender.\nAdd one corn tortilla that has been torn into smaller pieces to the skillet cook with a little bit of oil until they turn brown. Add them to the blender.\nToast 1 piece of white bread and add that to the blender.\nAdd some vegetable oil to the pan along with \u2153 cup each of peanuts, pumpkin seeds, almonds and raisins. Roast for about one minute before adding \u00bc cup of sesame seeds. Let it go for one more minute before placing all of it into the blender.\nAdd some oil to the skillet and turn to a medium high heat. Add 1 large quartered tomato, 1 large chopped onion, and 4 cloves of garlic (If you have tomatillos this is the time to add them). Let them sit undisturbed for about a minute, letting them get nice and brown. Add \u00bc tsp each of dried thyme, marjoram, and aniseed. Cook for about a minute and then add to the blender.\nHeat up 4 cups of chicken stock and add that to the blender. Let everything sit in the blender for 10 minutes. Blend on medium for about 2 minutes or until smooth.\nAdd blended sauce to a large saucepan and cook on medium-low heat for about an hour.\nRun the sauce through a mesh sieve until you have a thick paste in the sieve and a smooth puree below.\nAdd the puree back to saucepan on a medium heat and add 4 ounces of chopped bittersweet chocolate. Taste and add sugar if necessary.\nPreheat oven to 425\u00b0F. Place a small handful of cheddar cheese in six piles on a cookie sheet lined with a silicon mat or parchment paper. Bake the cheese for about 10 minutes, checking constantly just until all cheese is melted and edges begin to brown. Remove from oven and let cool slightly. Transfer crisps to a wire rack to cool.\nIn a blender combine 5 ounces of goat cheese with 1 Tbsp of honey and 2 Tbsp of heavy cream. Blend on high speed until you have a thick spreadable cream.\nIn a skillet cook up one piece of chorizo until your preferred doneness. Cut into 4 pieces.\nButter both slices of bread on the outside. On one piece of bread, slather some mole, top with cooked chorizo sausages, cheese crisps, and goat cheese cream. Top with other piece of bread. Place into your panini press/George Foreman grill. Serve and enjoy!",
+    "source": {
+      "episode_id": "babishpaniniwinner",
+      "name": "#BabishPanini Winning Recipe - Car Panini inspired by Family Guy",
+      "published_date": "2018-08-21",
+      "youtube_link": "https://www.youtube.com/watch?v=4Rz8BPRFeiA",
+      "official_link": "https://www.babi.sh/recipes/babishpaniniwinner",
+      "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715515/babishImages/undefined-702398.png"
     }
   },
   {
@@ -21834,7 +24594,7 @@
       "episode_id": "beer-steamed-chili-dogs",
       "name": "Chili Dogs inspired by The Irishman",
       "published_date": "2019-12-17",
-      "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/c0A1bkF4mKM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+      "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM",
       "official_link": "https://www.babi.sh/recipes/beer-steamed-chili-dogs",
       "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695792/babishImages/undefined-202970.png"
     }

--- a/datasets/ibdb.references.json
+++ b/datasets/ibdb.references.json
@@ -1,5 +1,23 @@
 [
   {
+    "reference_id": 642,
+    "type": null,
+    "name": "2024 Oscars",
+    "description": null,
+    "external_link": null,
+    "image_link": null,
+    "episodes_inspired": [
+      {
+        "episode_id": "2024oscarsspecial",
+        "name": "2024 Oscars Special",
+        "published_date": "2024-03-15",
+        "youtube_link": "https://youtu.be/NVwgZhjspxo",
+        "official_link": "https://www.babi.sh/recipes/2024oscarsspecial",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1710510271/ny7ovkakrtfei4odwnfd.webp"
+      }
+    ]
+  },
+  {
     "reference_id": 50,
     "type": "tv_show",
     "name": "30 Rock",
@@ -94,6 +112,24 @@
     ]
   },
   {
+    "reference_id": 649,
+    "type": null,
+    "name": "Alfredo alla Scrofa",
+    "description": null,
+    "external_link": null,
+    "image_link": null,
+    "episodes_inspired": [
+      {
+        "episode_id": "classic-fettucine-alfredo",
+        "name": "Classic Fettuccine Alfredo",
+        "published_date": "2025-06-06",
+        "youtube_link": "https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo",
+        "official_link": "https://www.babi.sh/recipes/classic-fettucine-alfredo",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1749216590/llpz2sobgkra4ttgl9kx.webp"
+      }
+    ]
+  },
+  {
     "reference_id": 609,
     "type": "movie",
     "name": "Amadeus",
@@ -162,16 +198,7 @@
     "description": "Four teenage boys enter a pact to lose their virginity by prom night. IMDb.",
     "external_link": "https://www.imdb.com/title/tt0163651/",
     "image_link": "https://img.youtube.com/vi/0WRQFUwEpDY/mqdefault.jpg",
-    "episodes_inspired": [
-      {
-        "episode_id": "applepiesmoothie",
-        "name": "Apple Pie Smoothie",
-        "published_date": "2016-03-13",
-        "youtube_link": "https://www.youtube.com/watch?v=mv1z2p3to0U",
-        "official_link": "https://www.babi.sh/recipes/applepiesmoothie",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991771/oz6gen69krvy3tfzijvm.webp"
-      }
-    ]
+    "episodes_inspired": []
   },
   {
     "reference_id": 559,
@@ -487,7 +514,7 @@
         "episode_id": "avengersicecream",
         "name": "Ice Cream Flavors inspired by Avengers: Infinity War",
         "published_date": "2019-04-30",
-        "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Ukjat70Iyt4/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4",
         "official_link": "https://www.babi.sh/recipes/avengersicecream",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695805/babishImages/undefined-987247.png"
       }
@@ -610,6 +637,24 @@
     ]
   },
   {
+    "reference_id": 643,
+    "type": null,
+    "name": "Bluey",
+    "description": null,
+    "external_link": null,
+    "image_link": null,
+    "episodes_inspired": [
+      {
+        "episode_id": "bluey-duck-cake",
+        "name": "Duck Cake Inspired by Bluey",
+        "published_date": "2024-02-08",
+        "youtube_link": "https://www.youtube.com/watch?v=w7B-BGWixm0",
+        "official_link": "https://www.babi.sh/recipes/bluey-duck-cake",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1707408991/nyvglzkdwqrlkvu7qwnb.webp"
+      }
+    ]
+  },
+  {
     "reference_id": 14,
     "type": "tv_show",
     "name": "Bob's Burgers",
@@ -617,6 +662,14 @@
     "external_link": "https://www.imdb.com/title/tt1561755/",
     "image_link": "https://i.ytimg.com/sh/YFIqnn7YyVe01H23BBPlyA/market.jpg",
     "episodes_inspired": [
+      {
+        "episode_id": "bobsburgers-potato-lasagna",
+        "name": "Loaded Baked Potato Lasagna Inspired by Bob's Burgers",
+        "published_date": "2024-03-01",
+        "youtube_link": "youtube.com/watch?v=jts_NfZu2vY",
+        "official_link": "https://www.babi.sh/recipes/bobsburgers-potato-lasagna",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1709308712/bfjgjzbwq9dstzpukvxo.webp"
+      },
       {
         "episode_id": "footlong-taco-dogs-bobs-burgers",
         "name": "Footlong Taco Dog inspired by Bob's Burgers",
@@ -756,7 +809,7 @@
       {
         "episode_id": "churrons-broad-city",
         "name": "Churrons inspired by Broad City",
-        "published_date": "2022-08-17",
+        "published_date": "2022-08-03",
         "youtube_link": "https://www.youtube.com/watch?v=JiUsCTy8nEY",
         "official_link": "https://www.babi.sh/recipes/churrons-broad-city",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695905/babishImages/undefined-290140.png"
@@ -808,7 +861,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -826,7 +879,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -863,7 +916,7 @@
         "episode_id": "charliebrownthanksgiving",
         "name": "Charlie Brown Thanksgiving",
         "published_date": "2018-11-20",
-        "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5FyKxVJmsdE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE",
         "official_link": "https://www.babi.sh/recipes/charliebrownthanksgiving",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg"
       }
@@ -912,7 +965,7 @@
       {
         "episode_id": "cubanos-inspired-by-chef",
         "name": "Cubanos inspired by Chef",
-        "published_date": "2017-03-29",
+        "published_date": "2017-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=hXYoduN0kWs",
         "official_link": "https://www.babi.sh/recipes/cubanos-inspired-by-chef",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992067/etfzgspqjiwp3janr32z.webp"
@@ -1088,7 +1141,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -1157,6 +1210,14 @@
     "external_link": "https://www.imdb.com/title/tt1431045/",
     "image_link": "https://img.youtube.com/vi/AEIKS4IbfNk/mqdefault.jpg",
     "episodes_inspired": [
+      {
+        "episode_id": "chimichangas",
+        "name": "Deadpool's Chimichangas",
+        "published_date": "2020-04-28",
+        "youtube_link": "https://www.youtube.com/watch?v=szFLA4_pwew",
+        "official_link": "https://www.babi.sh/recipes/chimichangas",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715751/babishImages/undefined-916823.png"
+      },
       {
         "episode_id": "deadpoolpizza",
         "name": "Pizza inspired by Deadpool",
@@ -1305,7 +1366,7 @@
         "episode_id": "coqauvin",
         "name": "Coq au Vin inspired by Donnie Brasco",
         "published_date": "2019-01-15",
-        "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/VP1uTgikarU/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU",
         "official_link": "https://www.babi.sh/recipes/coqauvin",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695986/babishImages/undefined-867897.png"
       }
@@ -1478,6 +1539,24 @@
         "youtube_link": "https://www.youtube.com/watch?v=1vOBpRmp8v8",
         "official_link": "https://www.babi.sh/recipes/everything-bagel-eeao",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695667/babishImages/undefined-717015.png"
+      }
+    ]
+  },
+  {
+    "reference_id": 639,
+    "type": null,
+    "name": "Fallout",
+    "description": null,
+    "external_link": null,
+    "image_link": null,
+    "episodes_inspired": [
+      {
+        "episode_id": "jell-o-cake-nuka-cola-and-cram-inspired-by-fallout",
+        "name": "Jell-O Cake, Nuka Cola & Cram Inspired by Fallout",
+        "published_date": "2024-06-05",
+        "youtube_link": "https://www.youtube.com/watch?v=yiR1wqF6IM4",
+        "official_link": "https://www.babi.sh/recipes/jell-o-cake-nuka-cola-and-cram-inspired-by-fallout",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1717609250/oj6zbs3b6k4mxq84duyp.webp"
       }
     ]
   },
@@ -1681,7 +1760,7 @@
         "episode_id": "bubbashrimp2",
         "name": "Shrimp inspired by Forrest Gump Part II",
         "published_date": "2019-04-23",
-        "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/mF6JUfczaO8/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8",
         "official_link": "https://www.babi.sh/recipes/bubbashrimp2",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696055/babishImages/undefined-252668.png"
       },
@@ -1822,6 +1901,22 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1741383035/fhpr01pnfwh4o1lpeje9.webp"
       },
       {
+        "episode_id": "jerk-meat-platter-inspired-by-futurama",
+        "name": "Jerk Meat Platter Inspired by Futurama",
+        "published_date": "2024-04-12",
+        "youtube_link": "https://www.youtube.com/watch?v=EoVha2o6Ldk",
+        "official_link": "https://www.babi.sh/recipes/jerk-meat-platter-inspired-by-futurama",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1712937205/n5fptxykxklglcfoo9xd.webp"
+      },
+      {
+        "episode_id": "futurama-shrimp-popplers",
+        "name": "Popplers Inspired by Futurama",
+        "published_date": "2024-01-03",
+        "youtube_link": "https://www.youtube.com/watch?v=BtGsjkj9DgM",
+        "official_link": "https://www.babi.sh/recipes/futurama-shrimp-popplers",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1704299223/grzo0n3a4v5gakutgodq.webp"
+      },
+      {
         "episode_id": "bachelor-chow-futurama",
         "name": "Bachelor Chow inspired by Futurama",
         "published_date": "2021-01-26",
@@ -1935,7 +2030,7 @@
       },
       {
         "episode_id": "being-with-babish-4",
-        "name": "Training like Kratos for 30 Days | Body by Babish",
+        "name": "Training like Kratos for 30 Days | Being with Babish",
         "published_date": "2019-06-07",
         "youtube_link": "https://www.youtube.com/watch?v=n_aq5TVb0HA",
         "official_link": "https://www.youtube.com/watch?v=n_aq5TVb0HA",
@@ -1990,7 +2085,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -2220,7 +2315,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -2373,7 +2468,7 @@
         "episode_id": "alwayssunny",
         "name": "It's Always Sunny in Philadelphia Special (Part II)",
         "published_date": "2019-06-12",
-        "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/_fnhy5xO9vQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ",
         "official_link": "https://www.babi.sh/recipes/alwayssunny",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696347/babishImages/undefined-129032.png"
       },
@@ -2398,7 +2493,7 @@
       {
         "episode_id": "chocolate-croissants-its-complicated",
         "name": "Chocolate Croissants inspired by It's Complicated",
-        "published_date": "2022-08-01",
+        "published_date": "2022-07-13",
         "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
         "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png"
@@ -2417,7 +2512,7 @@
         "episode_id": "cinnamonrolls",
         "name": "Cinnamon Rolls inspired by Jim Gaffigan's Stand Up (sort of)",
         "published_date": "2018-10-23",
-        "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/jFYi2QRVFOc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc",
         "official_link": "https://www.babi.sh/recipes/cinnamonrolls",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679245506/gyb4qsztcyrv4kjnvwug.webp"
       }
@@ -2476,6 +2571,14 @@
     "image_link": null,
     "episodes_inspired": [
       {
+        "episode_id": "chicken-meatball-hotpot-inspired-by-jujutsu-kaisen",
+        "name": "Chicken Meatball Hotpot inspired By Jujutsu Kaisen",
+        "published_date": "2024-10-02",
+        "youtube_link": "https://www.youtube.com/watch?v=GymqadVYSXk&t=34s",
+        "official_link": "https://www.babi.sh/recipes/chicken-meatball-hotpot-inspired-by-jujutsu-kaisen",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1727887830/cnkxewktxghxefrnq6xa.webp"
+      },
+      {
         "episode_id": "kikufuku-mochi-inspired-by-jujutsu-kaisen",
         "name": "Kikufuku Mochi inspired by Jujutsu Kaisen",
         "published_date": "2024-09-04",
@@ -2533,7 +2636,7 @@
         "episode_id": "chileanseabass",
         "name": "Chilean Sea Bass inspired by Jurassic Park",
         "published_date": "2018-11-27",
-        "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/p73kqpqGqqQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ",
         "official_link": "https://www.babi.sh/recipes/chileanseabass",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695721/babishImages/undefined-408439.png"
       }
@@ -2728,6 +2831,15 @@
     ]
   },
   {
+    "reference_id": 647,
+    "type": null,
+    "name": "LAST-MINUTE",
+    "description": null,
+    "external_link": null,
+    "image_link": null,
+    "episodes_inspired": []
+  },
+  {
     "reference_id": 571,
     "type": "video_game",
     "name": "Legend of Zelda",
@@ -2760,6 +2872,24 @@
         "youtube_link": "https://www.youtube.com/watch?v=-aFrFsn998o",
         "official_link": "https://www.babi.sh/recipes/lotr-feast-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696106/babishImages/undefined-637175.png"
+      }
+    ]
+  },
+  {
+    "reference_id": 648,
+    "type": null,
+    "name": "Lots of Things",
+    "description": null,
+    "external_link": null,
+    "image_link": null,
+    "episodes_inspired": [
+      {
+        "episode_id": "parmhero",
+        "name": "Parm Heros inspired by Lots of Things",
+        "published_date": "2018-03-20",
+        "youtube_link": "https://www.youtube.com/watch?v=DkiyT-dnmv8",
+        "official_link": "https://www.babi.sh/recipes/parmhero",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715733/babishImages/undefined-3296.png"
       }
     ]
   },
@@ -3014,6 +3144,24 @@
     ]
   },
   {
+    "reference_id": 644,
+    "type": null,
+    "name": "Mean Girls",
+    "description": null,
+    "external_link": null,
+    "image_link": null,
+    "episodes_inspired": [
+      {
+        "episode_id": "mean-girls-toaster-strudel",
+        "name": "Homemade Toaster Strudel Inspired by Mean Girls",
+        "published_date": "2024-01-18",
+        "youtube_link": "https://www.youtube.com/watch?v=t78IFIYiQ8M",
+        "official_link": "https://www.babi.sh/recipes/mean-girls-toaster-strudel",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1705545612/ovmommijdvjcueekr5bx.webp"
+      }
+    ]
+  },
+  {
     "reference_id": 583,
     "type": "video_game",
     "name": "Minecraft",
@@ -3042,7 +3190,7 @@
       {
         "episode_id": "chefs-choice-platter-monster-hunter-world",
         "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-        "published_date": "2021-03-31",
+        "published_date": "2021-03-30",
         "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
         "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png"
@@ -3118,6 +3266,33 @@
         "youtube_link": "https://www.youtube.com/watch?v=4QDDxmtbUsw",
         "official_link": "https://www.babi.sh/recipes/egginanest",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715428/babishImages/undefined-266153.png"
+      }
+    ]
+  },
+  {
+    "reference_id": 646,
+    "type": null,
+    "name": "Morty",
+    "description": null,
+    "external_link": null,
+    "image_link": null,
+    "episodes_inspired": []
+  },
+  {
+    "reference_id": 641,
+    "type": null,
+    "name": "Mr. & Mrs. Smith",
+    "description": null,
+    "external_link": null,
+    "image_link": null,
+    "episodes_inspired": [
+      {
+        "episode_id": "bagelwithlox",
+        "name": "Everything Bagel with Lox Inspired By Mr. & Mrs. Smith",
+        "published_date": "2024-03-27",
+        "youtube_link": "https://youtu.be/ZOZ2qkcfWe0",
+        "official_link": "https://www.babi.sh/recipes/bagelwithlox",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1711553048/yyeo9skkrkvuloahw7lm.webp"
       }
     ]
   },
@@ -3204,7 +3379,7 @@
       {
         "episode_id": "christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
         "name": "Christmas Turkey inspired by National Lampoon's Christmas Vacation",
-        "published_date": "2025-11-26",
+        "published_date": "2025-11-29",
         "youtube_link": "https://youtube.com/watch?v=w0pZ7MWajW8&si=r2TmnS9oJhDHIbp5",
         "official_link": "https://www.babi.sh/recipes/christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1764189007/giyklwlgdj7x3nwbi38c.webp"
@@ -3296,6 +3471,14 @@
         "youtube_link": "https://www.youtube.com/watch?v=J16qIo_BrZI",
         "official_link": "https://www.babi.sh/recipes/devil-fruit-inspired-by-one-piece",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1724877134/yezhzbhda6kzcfjslvfr.webp"
+      },
+      {
+        "episode_id": "one-piece-tuna-saute",
+        "name": "Sanji\u2019s Tuna Saute Inspired by One Piece",
+        "published_date": "2024-02-01",
+        "youtube_link": "https://youtu.be/_rk1Foi8E8g",
+        "official_link": "https://www.babi.sh/recipes/one-piece-tuna-saute",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1706827474/slrsvlsvfwr0lwbdtpa0.webp"
       }
     ]
   },
@@ -3377,7 +3560,7 @@
       },
       {
         "episode_id": "ben-wyatt-calzones",
-        "name": "Calzones inspired by Parks & Rec",
+        "name": "Ben Wyatt's Calzones",
         "published_date": "2020-04-15",
         "youtube_link": "https://www.youtube.com/watch?v=PvgCEifW7Jo",
         "official_link": "https://www.babi.sh/recipes/ben-wyatt-calzones",
@@ -3493,7 +3676,7 @@
         "episode_id": "baobuns",
         "name": "Bao inspired by Pixar's Bao",
         "published_date": "2019-02-19",
-        "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M&amp;t=46s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/OFt3SThGi7M/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M",
         "official_link": "https://www.babi.sh/recipes/baobuns",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695380/babishImages/undefined-293013.png"
       }
@@ -3537,7 +3720,7 @@
         "episode_id": "brocksdonuts",
         "name": "Brock's Donuts inspired by Pok\u00e9mon",
         "published_date": "2019-04-02",
-        "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/RentKWlhUXc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc",
         "official_link": "https://www.babi.sh/recipes/brocksdonuts",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695178/babishImages/undefined-56205.png"
       },
@@ -3705,7 +3888,7 @@
         "episode_id": "bearstew",
         "name": "Bear Stew inspired by Red Dead Redemption 2",
         "published_date": "2018-11-06",
-        "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wMxKbkWrvDc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc",
         "official_link": "https://www.babi.sh/recipes/bearstew",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679263840/iyxpvkao4lwi6xqkcwd1.webp"
       }
@@ -3739,7 +3922,7 @@
         "episode_id": "applefritters",
         "name": "Double-Glazed Apple Fritters inspired by Regular Show",
         "published_date": "2019-08-27",
-        "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YYSP1D6GJ30/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30",
         "official_link": "https://www.babi.sh/recipes/applefritters",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695467/babishImages/undefined-689012.png"
       },
@@ -3792,6 +3975,15 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715472/babishImages/undefined-404565.png"
       }
     ]
+  },
+  {
+    "reference_id": 645,
+    "type": null,
+    "name": "Rick",
+    "description": null,
+    "external_link": null,
+    "image_link": null,
+    "episodes_inspired": []
   },
   {
     "reference_id": 83,
@@ -3950,7 +4142,7 @@
       {
         "episode_id": "crab-bisque-seinfeld",
         "name": "Crab Bisque inspired by Seinfeld",
-        "published_date": "2022-05-27",
+        "published_date": "2022-05-24",
         "youtube_link": "https://www.youtube.com/watch?v=5kKMB890ABc",
         "official_link": "https://www.babi.sh/recipes/crab-bisque-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695634/babishImages/undefined-585834.png"
@@ -3990,7 +4182,7 @@
       {
         "episode_id": "babka-inspired-by-seinfeld",
         "name": "Babka inspired by Seinfeld",
-        "published_date": "2017-05-10",
+        "published_date": "2017-05-09",
         "youtube_link": "https://www.youtube.com/watch?v=pw2A03Z91FI",
         "official_link": "https://www.babi.sh/recipes/babka-inspired-by-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp"
@@ -4020,6 +4212,24 @@
         "youtube_link": "https://www.youtube.com/watch?v=pTt4BjY34gk&t=151s&ab_channel=BabishCulinaryUniverse",
         "official_link": "https://www.babi.sh/recipes/the-egg-bar-inspired-by-severance",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1738792005/emlcx8fw10frbl32t7lq.webp"
+      }
+    ]
+  },
+  {
+    "reference_id": 640,
+    "type": null,
+    "name": "Shrek 2",
+    "description": null,
+    "external_link": null,
+    "image_link": null,
+    "episodes_inspired": [
+      {
+        "episode_id": "renaissance-wrap-inspired-by-shrek-2",
+        "name": "Renaissance Wrap Inspired by Shrek 2",
+        "published_date": "2024-06-05",
+        "youtube_link": "https://youtu.be/BY888aujzh0",
+        "official_link": "https://www.babi.sh/recipes/renaissance-wrap-inspired-by-shrek-2",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1717605574/tkax0edrxmko4bwrzv8v.webp"
       }
     ]
   },
@@ -4433,7 +4643,7 @@
         "episode_id": "bagelsandwiches",
         "name": "Bagel Sandwiches inspired by Steven Universe",
         "published_date": "2019-07-23",
-        "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
         "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png"
       },
@@ -4592,8 +4802,8 @@
       {
         "episode_id": "crepessuzette",
         "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-        "published_date": "2019-10-24",
-        "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "published_date": "2019-10-22",
+        "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
         "official_link": "https://www.babi.sh/recipes/crepessuzette",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png"
       }
@@ -4700,7 +4910,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -4719,7 +4929,7 @@
         "episode_id": "aristocats",
         "name": "Cr\u00e8me de la Cr\u00e8me \u00e0 la Edgar inspired by The Aristocats",
         "published_date": "2019-01-23",
-        "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/zNY-qzp7pD0/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0",
         "official_link": "https://www.babi.sh/recipes/aristocats",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696317/babishImages/undefined-541474.png"
       }
@@ -4786,7 +4996,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -4859,7 +5069,7 @@
         "episode_id": "coffeejelly",
         "name": "Coffee Jelly inspired by The Disastrous Life of Saiki K.",
         "published_date": "2019-09-24",
-        "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YxEcd_wTf5c/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c",
         "official_link": "https://www.babi.sh/recipes/coffeejelly",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png"
       }
@@ -4957,7 +5167,7 @@
         "episode_id": "beer-steamed-chili-dogs",
         "name": "Chili Dogs inspired by The Irishman",
         "published_date": "2019-12-17",
-        "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/c0A1bkF4mKM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM",
         "official_link": "https://www.babi.sh/recipes/beer-steamed-chili-dogs",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695792/babishImages/undefined-202970.png"
       }
@@ -5864,16 +6074,7 @@
     "description": "This is a web series from Cooking Channel. They also combined episodes and broadcast on TV. IMDb.",
     "external_link": "https://www.imdb.com/title/tt5195594/",
     "image_link": "https://img.youtube.com/vi/--B_ENKrG-8/mqdefault.jpg",
-    "episodes_inspired": [
-      {
-        "episode_id": "chocolate-cake-inspired-by-matilda",
-        "name": "Chocolate Cake inspired by Matilda",
-        "published_date": "2017-06-06",
-        "youtube_link": "https://www.youtube.com/watch?v=exQ6oGefSiA",
-        "official_link": "https://www.babi.sh/recipes/chocolate-cake-inspired-by-matilda",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991787/cxpb3rjiwrvezbgpjfej.webp"
-      }
-    ]
+    "episodes_inspired": []
   },
   {
     "reference_id": 113,
@@ -5882,16 +6083,7 @@
     "description": "Being taught to cook by a professional chef is everybody's dream. And if not everybody's dream, mostlybody's dream. But chasing your dreams is overrated and often leads to heartbreak. That's why you should throw your dreams in the garbage and learn to cook here, instead. In these cooking tutorial videos youre learn next to nothing, and you'll like it.",
     "external_link": "https://www.youtube.com/channel/UCekQr9znsk2vWxBo3YiLq2w",
     "image_link": "https://yt3.ggpht.com/a/AGF-l7_wVfJ2wHSX9nB-fMjIS7X4nX76KP0oSn3YrQ=s288-c-k-c0xffffffff-no-rj-mo",
-    "episodes_inspired": [
-      {
-        "episode_id": "clayroastedthigh",
-        "name": "Clay-Roasted Thigh inspired by Hannibal",
-        "published_date": "2017-10-31",
-        "youtube_link": "https://www.youtube.com/watch?v=lnB7svFAZBs&amp;t=2s",
-        "official_link": "https://www.babi.sh/recipes/clayroastedthigh",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715438/babishImages/undefined-943571.png"
-      }
-    ]
+    "episodes_inspired": []
   },
   {
     "reference_id": 591,

--- a/datasets/ibdb.tags.json
+++ b/datasets/ibdb.tags.json
@@ -311,7 +311,7 @@
       {
         "episode_id": "churrons-broad-city",
         "name": "Churrons inspired by Broad City",
-        "published_date": "2022-08-17",
+        "published_date": "2022-08-03",
         "youtube_link": "https://www.youtube.com/watch?v=JiUsCTy8nEY",
         "official_link": "https://www.babi.sh/recipes/churrons-broad-city",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695905/babishImages/undefined-290140.png"
@@ -319,7 +319,7 @@
       {
         "episode_id": "chocolate-croissants-its-complicated",
         "name": "Chocolate Croissants inspired by It's Complicated",
-        "published_date": "2022-08-01",
+        "published_date": "2022-07-13",
         "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
         "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png"
@@ -366,7 +366,7 @@
       },
       {
         "episode_id": "apple-cider-donuts",
-        "name": "APPLE CIDER DONUTS",
+        "name": "Apple Cider Donuts",
         "published_date": "2021-11-09",
         "youtube_link": "https://www.youtube.com/watch?v=baZoJYAQjfI",
         "official_link": "https://www.babi.sh/recipes/apple-cider-donuts",
@@ -374,15 +374,15 @@
       },
       {
         "episode_id": "cake-pops",
-        "name": "CAKE POPS",
-        "published_date": "2021-11-02",
+        "name": "Cake Pops",
+        "published_date": "2021-10-21",
         "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
         "official_link": "https://www.babi.sh/recipes/cake-pops",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
       },
       {
         "episode_id": "biscotti",
-        "name": "BISCOTTI",
+        "name": "Biscotti",
         "published_date": "2021-09-24",
         "youtube_link": "https://www.youtube.com/watch?v=g4EkzEKlGOA",
         "official_link": "https://www.babi.sh/recipes/biscotti",
@@ -462,7 +462,7 @@
       },
       {
         "episode_id": "biscuits-and-gravy",
-        "name": "BISCUITS AND GRAVY",
+        "name": "Biscuits & Gravy",
         "published_date": "2021-02-25",
         "youtube_link": "https://www.youtube.com/watch?v=NMbMT9tY8-Q",
         "official_link": "https://www.babi.sh/recipes/biscuits-and-gravy",
@@ -624,7 +624,7 @@
         "episode_id": "applefritters",
         "name": "Double-Glazed Apple Fritters inspired by Regular Show",
         "published_date": "2019-08-27",
-        "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YYSP1D6GJ30/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30",
         "official_link": "https://www.babi.sh/recipes/applefritters",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695467/babishImages/undefined-689012.png"
       },
@@ -656,7 +656,7 @@
         "episode_id": "brocksdonuts",
         "name": "Brock's Donuts inspired by Pok\u00e9mon",
         "published_date": "2019-04-02",
-        "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/RentKWlhUXc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc",
         "official_link": "https://www.babi.sh/recipes/brocksdonuts",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695178/babishImages/undefined-56205.png"
       },
@@ -670,7 +670,7 @@
       },
       {
         "episode_id": "bagels",
-        "name": "BAGELS",
+        "name": "Bagels",
         "published_date": "2019-01-24",
         "youtube_link": "https://www.youtube.com/watch?v=ZrJtpCTZk38",
         "official_link": "https://www.babi.sh/recipes/bagels",
@@ -688,7 +688,7 @@
         "episode_id": "cinnamonrolls",
         "name": "Cinnamon Rolls inspired by Jim Gaffigan's Stand Up (sort of)",
         "published_date": "2018-10-23",
-        "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/jFYi2QRVFOc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc",
         "official_link": "https://www.babi.sh/recipes/cinnamonrolls",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679245506/gyb4qsztcyrv4kjnvwug.webp"
       },
@@ -736,7 +736,7 @@
         "episode_id": "baressentials-7xwwz",
         "name": "CHOCOLATE CHIP COOKIES",
         "published_date": "2018-03-29",
-        "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/ylxzfecackM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM",
         "official_link": "https://www.babi.sh/recipes/baressentials-7xwwz",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690485488/p72d0navvupz8bsaur3g.webp"
       },
@@ -807,7 +807,7 @@
       {
         "episode_id": "babka-inspired-by-seinfeld",
         "name": "Babka inspired by Seinfeld",
-        "published_date": "2017-05-10",
+        "published_date": "2017-05-09",
         "youtube_link": "https://www.youtube.com/watch?v=pw2A03Z91FI",
         "official_link": "https://www.babi.sh/recipes/babka-inspired-by-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp"
@@ -1134,7 +1134,7 @@
       {
         "episode_id": "churrons-broad-city",
         "name": "Churrons inspired by Broad City",
-        "published_date": "2022-08-17",
+        "published_date": "2022-08-03",
         "youtube_link": "https://www.youtube.com/watch?v=JiUsCTy8nEY",
         "official_link": "https://www.babi.sh/recipes/churrons-broad-city",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695905/babishImages/undefined-290140.png"
@@ -1142,7 +1142,7 @@
       {
         "episode_id": "chocolate-croissants-its-complicated",
         "name": "Chocolate Croissants inspired by It's Complicated",
-        "published_date": "2022-08-01",
+        "published_date": "2022-07-13",
         "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
         "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png"
@@ -1197,7 +1197,7 @@
       },
       {
         "episode_id": "apple-cider-donuts",
-        "name": "APPLE CIDER DONUTS",
+        "name": "Apple Cider Donuts",
         "published_date": "2021-11-09",
         "youtube_link": "https://www.youtube.com/watch?v=baZoJYAQjfI",
         "official_link": "https://www.babi.sh/recipes/apple-cider-donuts",
@@ -1205,8 +1205,8 @@
       },
       {
         "episode_id": "cake-pops",
-        "name": "CAKE POPS",
-        "published_date": "2021-11-02",
+        "name": "Cake Pops",
+        "published_date": "2021-10-21",
         "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
         "official_link": "https://www.babi.sh/recipes/cake-pops",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
@@ -1221,7 +1221,7 @@
       },
       {
         "episode_id": "biscotti",
-        "name": "BISCOTTI",
+        "name": "Biscotti",
         "published_date": "2021-09-24",
         "youtube_link": "https://www.youtube.com/watch?v=g4EkzEKlGOA",
         "official_link": "https://www.babi.sh/recipes/biscotti",
@@ -1285,7 +1285,7 @@
       },
       {
         "episode_id": "creme-caramel",
-        "name": "CR\u00c8ME CARAMEL",
+        "name": "Cr\u00e8me Caramel",
         "published_date": "2021-04-08",
         "youtube_link": "https://www.youtube.com/watch?v=ihS8__strtM",
         "official_link": "https://www.babi.sh/recipes/creme-caramel",
@@ -1510,8 +1510,8 @@
       {
         "episode_id": "crepessuzette",
         "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-        "published_date": "2019-10-24",
-        "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "published_date": "2019-10-22",
+        "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
         "official_link": "https://www.babi.sh/recipes/crepessuzette",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png"
       },
@@ -1519,7 +1519,7 @@
         "episode_id": "coffeejelly",
         "name": "Coffee Jelly inspired by The Disastrous Life of Saiki K.",
         "published_date": "2019-09-24",
-        "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YxEcd_wTf5c/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c",
         "official_link": "https://www.babi.sh/recipes/coffeejelly",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png"
       },
@@ -1535,7 +1535,7 @@
         "episode_id": "applefritters",
         "name": "Double-Glazed Apple Fritters inspired by Regular Show",
         "published_date": "2019-08-27",
-        "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YYSP1D6GJ30/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30",
         "official_link": "https://www.babi.sh/recipes/applefritters",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695467/babishImages/undefined-689012.png"
       },
@@ -1591,7 +1591,7 @@
         "episode_id": "avengersicecream",
         "name": "Ice Cream Flavors inspired by Avengers: Infinity War",
         "published_date": "2019-04-30",
-        "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Ukjat70Iyt4/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4",
         "official_link": "https://www.babi.sh/recipes/avengersicecream",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695805/babishImages/undefined-987247.png"
       },
@@ -1599,7 +1599,7 @@
         "episode_id": "brocksdonuts",
         "name": "Brock's Donuts inspired by Pok\u00e9mon",
         "published_date": "2019-04-02",
-        "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/RentKWlhUXc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc",
         "official_link": "https://www.babi.sh/recipes/brocksdonuts",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695178/babishImages/undefined-56205.png"
       },
@@ -1612,18 +1612,10 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695747/babishImages/undefined-449381.png"
       },
       {
-        "episode_id": "baobuns",
-        "name": "Bao inspired by Pixar's Bao",
-        "published_date": "2019-02-19",
-        "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M&amp;t=46s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/OFt3SThGi7M/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
-        "official_link": "https://www.babi.sh/recipes/baobuns",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695380/babishImages/undefined-293013.png"
-      },
-      {
         "episode_id": "aristocats",
         "name": "Cr\u00e8me de la Cr\u00e8me \u00e0 la Edgar inspired by The Aristocats",
         "published_date": "2019-01-23",
-        "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/zNY-qzp7pD0/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0",
         "official_link": "https://www.babi.sh/recipes/aristocats",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696317/babishImages/undefined-541474.png"
       },
@@ -1639,7 +1631,7 @@
         "episode_id": "cinnamonrolls",
         "name": "Cinnamon Rolls inspired by Jim Gaffigan's Stand Up (sort of)",
         "published_date": "2018-10-23",
-        "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/jFYi2QRVFOc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc",
         "official_link": "https://www.babi.sh/recipes/cinnamonrolls",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679245506/gyb4qsztcyrv4kjnvwug.webp"
       },
@@ -1668,28 +1660,12 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715498/babishImages/undefined-178544.png"
       },
       {
-        "episode_id": "bread",
-        "name": "BREAD",
-        "published_date": "2018-07-27",
-        "youtube_link": "https://www.youtube.com/watch?v=Jizr6LR83Kk",
-        "official_link": "https://www.babi.sh/recipes/bread",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1726172192/lyapiyi76tmqk0vfjaez.webp"
-      },
-      {
         "episode_id": "icecream",
         "name": "ICE CREAM",
         "published_date": "2018-07-12",
         "youtube_link": "https://www.youtube.com/watch?v=MdirPsiHnCA",
         "official_link": "https://www.babi.sh/recipes/icecream",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1686072341/ujov0llfgnf2etxpkw0o.webp"
-      },
-      {
-        "episode_id": "burgers",
-        "name": "BURGERS",
-        "published_date": "2018-06-14",
-        "youtube_link": "https://www.youtube.com/watch?v=nbCgfiqq-5c",
-        "official_link": "https://www.babi.sh/recipes/burgers",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1686072856/hopwyczgnd5layejyvpe.webp"
       },
       {
         "episode_id": "thegodfathercannolis",
@@ -1719,7 +1695,7 @@
         "episode_id": "baressentials-7xwwz",
         "name": "CHOCOLATE CHIP COOKIES",
         "published_date": "2018-03-29",
-        "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/ylxzfecackM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM",
         "official_link": "https://www.babi.sh/recipes/baressentials-7xwwz",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690485488/p72d0navvupz8bsaur3g.webp"
       },
@@ -1836,7 +1812,7 @@
     "episodes": [
       {
         "episode_id": "10-levels-chicken-noodle-soup",
-        "name": "10 Levels Chicken Noodle Soup",
+        "name": "10 Levels of Chicken Noodle Soup",
         "published_date": "2026-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
         "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
@@ -1971,7 +1947,7 @@
     "episodes": [
       {
         "episode_id": "10-levels-of-cheesesteak",
-        "name": "10 Levels of Cheesesteak",
+        "name": "10 Levels of Philly Cheesesteak",
         "published_date": "2026-04-30",
         "youtube_link": "https://www.youtube.com/watch?v=jNan4FWeQEE",
         "official_link": "https://www.babi.sh/recipes/10-levels-of-cheesesteak",
@@ -1987,7 +1963,7 @@
       },
       {
         "episode_id": "10-levels-chicken-noodle-soup",
-        "name": "10 Levels Chicken Noodle Soup",
+        "name": "10 Levels of Chicken Noodle Soup",
         "published_date": "2026-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
         "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
@@ -2011,7 +1987,7 @@
       },
       {
         "episode_id": "5-levels-of-spaghetti-or-with-babish",
-        "name": "5 Levels of Spaghetti | With Babish",
+        "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
         "published_date": "2026-01-30",
         "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
         "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
@@ -2026,14 +2002,6 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768506428/gryanukvd2zeutfh9ibh.webp"
       },
       {
-        "episode_id": "beef-wellington-or-with-babish",
-        "name": "Beef Wellington | With Babish",
-        "published_date": "2026-01-14",
-        "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
-        "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
-      },
-      {
         "episode_id": "the-ultimate-marry-me-meals",
         "name": "The Ultimate Marry-Me Meals",
         "published_date": "2026-01-06",
@@ -2042,9 +2010,17 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1767735831/qh0bt5mllxrxbi4kvgsb.webp"
       },
       {
+        "episode_id": "beef-wellington-or-with-babish",
+        "name": "$20 vs $200 Beef Wellington | With Babish",
+        "published_date": "2025-12-23",
+        "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
+        "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
+      },
+      {
         "episode_id": "christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
         "name": "Christmas Turkey inspired by National Lampoon's Christmas Vacation",
-        "published_date": "2025-11-26",
+        "published_date": "2025-11-29",
         "youtube_link": "https://youtube.com/watch?v=w0pZ7MWajW8&si=r2TmnS9oJhDHIbp5",
         "official_link": "https://www.babi.sh/recipes/christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1764189007/giyklwlgdj7x3nwbi38c.webp"
@@ -2346,20 +2322,20 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1687966614/sgzjuqlbuzd8tzonz7pz.webp"
       },
       {
-        "episode_id": "carnitas",
-        "name": "CARNITAS",
-        "published_date": "2023-05-12",
-        "youtube_link": "https://www.youtube.com/watch?v=FEZioC-qMd4",
-        "official_link": "https://www.babi.sh/recipes/carnitas",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690352698/ldnpp7ukrrvaiormf4ux.webp"
-      },
-      {
         "episode_id": "tylers-bull-the-menu",
         "name": "Tyler's Bullsh*t inspired by The Menu",
         "published_date": "2023-05-12",
         "youtube_link": "https://www.youtube.com/watch?v=WAuY3FJaJak",
         "official_link": "https://www.babi.sh/recipes/tylers-bull-the-menu",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1687964874/trtyvkekxwwgyu9fgqwi.webp"
+      },
+      {
+        "episode_id": "carnitas",
+        "name": "Easy Carnitas",
+        "published_date": "2023-05-02",
+        "youtube_link": "https://www.youtube.com/watch?v=FEZioC-qMd4",
+        "official_link": "https://www.babi.sh/recipes/carnitas",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690352698/ldnpp7ukrrvaiormf4ux.webp"
       },
       {
         "episode_id": "duck-fries-john-wick",
@@ -2386,20 +2362,20 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1677044221/nldmt4l5dra69ov0dof0.webp"
       },
       {
-        "episode_id": "beer-can-chicken",
-        "name": "BEER CAN CHICKEN",
-        "published_date": "2022-12-19",
-        "youtube_link": "https://www.youtube.com/watch?v=Xo0v7ZuA9C0",
-        "official_link": "https://www.babi.sh/recipes/beer-can-chicken",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png"
-      },
-      {
         "episode_id": "meatballs-30rock",
         "name": "Meatballs inspired by 30 Rock",
         "published_date": "2022-12-19",
         "youtube_link": "https://www.youtube.com/watch?v=IMvffRnRO0E",
         "official_link": "https://www.babi.sh/recipes/meatballs-30rock",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695628/babishImages/undefined-273552.png"
+      },
+      {
+        "episode_id": "beer-can-chicken",
+        "name": "BEER CAN CHICKEN",
+        "published_date": "2022-12-18",
+        "youtube_link": "https://www.youtube.com/watch?v=Xo0v7ZuA9C0",
+        "official_link": "https://www.babi.sh/recipes/beer-can-chicken",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png"
       },
       {
         "episode_id": "sausages-ragnarok",
@@ -2427,7 +2403,7 @@
       },
       {
         "episode_id": "corned-beef",
-        "name": "CORNED BEEF",
+        "name": "Corned Beef",
         "published_date": "2022-03-17",
         "youtube_link": "https://www.youtube.com/watch?v=IDkuwVvZpWM",
         "official_link": "https://www.babi.sh/recipes/corned-beef",
@@ -2435,7 +2411,7 @@
       },
       {
         "episode_id": "chicken-piccata",
-        "name": "CHICKEN PICCATA",
+        "name": "Chicken Piccata",
         "published_date": "2022-02-18",
         "youtube_link": "https://www.youtube.com/watch?v=ZqEqtmMY1M0",
         "official_link": "https://www.babi.sh/recipes/chicken-piccata",
@@ -2539,7 +2515,7 @@
       },
       {
         "episode_id": "chicken-parmesan",
-        "name": "CHICKEN PARMESAN",
+        "name": "Chicken Parmesan",
         "published_date": "2020-12-10",
         "youtube_link": "https://www.youtube.com/watch?v=ZrR0VbqNdW8",
         "official_link": "https://www.babi.sh/recipes/chicken-parmesan",
@@ -2659,7 +2635,7 @@
       },
       {
         "episode_id": "chickentikkamasala",
-        "name": "CHICKEN TIKKA MASALA",
+        "name": "Chicken Tikka Masala",
         "published_date": "2019-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=Bkd0LxBd2L8",
         "official_link": "https://www.babi.sh/recipes/chickentikkamasala",
@@ -2699,7 +2675,7 @@
       },
       {
         "episode_id": "barbecueporkchops",
-        "name": "BARBECUE PORK CHOPS",
+        "name": "Barbecue Pork Chops",
         "published_date": "2018-06-28",
         "youtube_link": "https://www.youtube.com/watch?v=YV9XuvfIudY",
         "official_link": "https://www.babi.sh/recipes/barbecueporkchops",
@@ -2868,7 +2844,7 @@
       {
         "episode_id": "cubanos-inspired-by-chef",
         "name": "Cubanos inspired by Chef",
-        "published_date": "2017-03-29",
+        "published_date": "2017-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=hXYoduN0kWs",
         "official_link": "https://www.babi.sh/recipes/cubanos-inspired-by-chef",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992067/etfzgspqjiwp3janr32z.webp"
@@ -2978,7 +2954,7 @@
     "episodes": [
       {
         "episode_id": "10-levels-chicken-noodle-soup",
-        "name": "10 Levels Chicken Noodle Soup",
+        "name": "10 Levels of Chicken Noodle Soup",
         "published_date": "2026-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
         "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
@@ -3010,7 +2986,7 @@
       },
       {
         "episode_id": "classic-fettucine-alfredo",
-        "name": "Classic Fettucine Alfredo",
+        "name": "Classic Fettuccine Alfredo",
         "published_date": "2025-06-06",
         "youtube_link": "https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo",
         "official_link": "https://www.babi.sh/recipes/classic-fettucine-alfredo",
@@ -3097,7 +3073,7 @@
       },
       {
         "episode_id": "10-levels-chicken-noodle-soup",
-        "name": "10 Levels Chicken Noodle Soup",
+        "name": "10 Levels of Chicken Noodle Soup",
         "published_date": "2026-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
         "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
@@ -3113,7 +3089,7 @@
       },
       {
         "episode_id": "5-levels-of-spaghetti-or-with-babish",
-        "name": "5 Levels of Spaghetti | With Babish",
+        "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
         "published_date": "2026-01-30",
         "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
         "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
@@ -3361,7 +3337,7 @@
       },
       {
         "episode_id": "advanced-grilled-cheese",
-        "name": "ADVANCED GRILLED CHEESE",
+        "name": "Advanced Grilled Cheese",
         "published_date": "2021-02-19",
         "youtube_link": "https://www.youtube.com/watch?v=Zo7sRijXG00",
         "official_link": "https://www.babi.sh/recipes/advanced-grilled-cheese",
@@ -3544,7 +3520,7 @@
       },
       {
         "episode_id": "5-levels-of-spaghetti-or-with-babish",
-        "name": "5 Levels of Spaghetti | With Babish",
+        "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
         "published_date": "2026-01-30",
         "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
         "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
@@ -3600,7 +3576,7 @@
       },
       {
         "episode_id": "classic-fettucine-alfredo",
-        "name": "Classic Fettucine Alfredo",
+        "name": "Classic Fettuccine Alfredo",
         "published_date": "2025-06-06",
         "youtube_link": "https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo",
         "official_link": "https://www.babi.sh/recipes/classic-fettucine-alfredo",
@@ -4150,7 +4126,7 @@
       },
       {
         "episode_id": "classic-fettucine-alfredo",
-        "name": "Classic Fettucine Alfredo",
+        "name": "Classic Fettuccine Alfredo",
         "published_date": "2025-06-06",
         "youtube_link": "https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo",
         "official_link": "https://www.babi.sh/recipes/classic-fettucine-alfredo",
@@ -4245,14 +4221,6 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1724877413/iljktvuobyynqseesqqt.webp"
       },
       {
-        "episode_id": "bagelwithlox",
-        "name": "Everything Bagel with Lox Inspired By Mr. & Mrs. Smith",
-        "published_date": "2024-03-27",
-        "youtube_link": "https://youtu.be/ZOZ2qkcfWe0",
-        "official_link": "https://www.babi.sh/recipes/bagelwithlox",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1711553048/yyeo9skkrkvuloahw7lm.webp"
-      },
-      {
         "episode_id": "tomato-confit-(ricotta-toast-simple-salad-pasta-with-calabrian-chili)",
         "name": "Tomato Confit (+Ricotta Toast, Simple Salad, Pasta with Calabrian Chili)",
         "published_date": "2024-03-18",
@@ -4311,7 +4279,7 @@
       {
         "episode_id": "beer-can-chicken",
         "name": "BEER CAN CHICKEN",
-        "published_date": "2022-12-19",
+        "published_date": "2022-12-18",
         "youtube_link": "https://www.youtube.com/watch?v=Xo0v7ZuA9C0",
         "official_link": "https://www.babi.sh/recipes/beer-can-chicken",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png"
@@ -4349,14 +4317,6 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696368/babishImages/undefined-443575.png"
       },
       {
-        "episode_id": "churrons-broad-city",
-        "name": "Churrons inspired by Broad City",
-        "published_date": "2022-08-17",
-        "youtube_link": "https://www.youtube.com/watch?v=JiUsCTy8nEY",
-        "official_link": "https://www.babi.sh/recipes/churrons-broad-city",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695905/babishImages/undefined-290140.png"
-      },
-      {
         "episode_id": "go-to-pasta",
         "name": "LATE NIGHT PASTA",
         "published_date": "2022-08-17",
@@ -4390,7 +4350,7 @@
       },
       {
         "episode_id": "chicken-piccata",
-        "name": "CHICKEN PICCATA",
+        "name": "Chicken Piccata",
         "published_date": "2022-02-18",
         "youtube_link": "https://www.youtube.com/watch?v=ZqEqtmMY1M0",
         "official_link": "https://www.babi.sh/recipes/chicken-piccata",
@@ -4422,7 +4382,7 @@
       },
       {
         "episode_id": "calistyle-burrito",
-        "name": "CALI-STYLE BURRITO",
+        "name": "California Style Burritos",
         "published_date": "2021-09-13",
         "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
         "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
@@ -4438,7 +4398,7 @@
       },
       {
         "episode_id": "chiles-rellenos",
-        "name": "CHILES RELLENOS",
+        "name": "Chiles Rellenos",
         "published_date": "2021-08-26",
         "youtube_link": "https://www.youtube.com/watch?v=gAKW8RB6aeU",
         "official_link": "https://www.babi.sh/recipes/chiles-rellenos",
@@ -4486,7 +4446,7 @@
       },
       {
         "episode_id": "corn-dogs",
-        "name": "CORN DOGS",
+        "name": "Corn Dogs",
         "published_date": "2021-05-27",
         "youtube_link": "https://www.youtube.com/watch?v=zGT45vVJNso",
         "official_link": "https://www.babi.sh/recipes/corn-dogs",
@@ -4518,7 +4478,7 @@
       },
       {
         "episode_id": "advanced-grilled-cheese",
-        "name": "ADVANCED GRILLED CHEESE",
+        "name": "Advanced Grilled Cheese",
         "published_date": "2021-02-19",
         "youtube_link": "https://www.youtube.com/watch?v=Zo7sRijXG00",
         "official_link": "https://www.babi.sh/recipes/advanced-grilled-cheese",
@@ -4550,7 +4510,7 @@
       },
       {
         "episode_id": "chicken-parmesan",
-        "name": "CHICKEN PARMESAN",
+        "name": "Chicken Parmesan",
         "published_date": "2020-12-10",
         "youtube_link": "https://www.youtube.com/watch?v=ZrR0VbqNdW8",
         "official_link": "https://www.babi.sh/recipes/chicken-parmesan",
@@ -4694,7 +4654,7 @@
       },
       {
         "episode_id": "burgers",
-        "name": "BURGERS",
+        "name": "Burgers",
         "published_date": "2018-06-14",
         "youtube_link": "https://www.youtube.com/watch?v=nbCgfiqq-5c",
         "official_link": "https://www.babi.sh/recipes/burgers",
@@ -4712,7 +4672,7 @@
         "episode_id": "baressentials-7xwwz",
         "name": "CHOCOLATE CHIP COOKIES",
         "published_date": "2018-03-29",
-        "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/ylxzfecackM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM",
         "official_link": "https://www.babi.sh/recipes/baressentials-7xwwz",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690485488/p72d0navvupz8bsaur3g.webp"
       },
@@ -4727,7 +4687,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -4797,7 +4757,7 @@
     "episodes": [
       {
         "episode_id": "10-levels-of-cheesesteak",
-        "name": "10 Levels of Cheesesteak",
+        "name": "10 Levels of Philly Cheesesteak",
         "published_date": "2026-04-30",
         "youtube_link": "https://www.youtube.com/watch?v=jNan4FWeQEE",
         "official_link": "https://www.babi.sh/recipes/10-levels-of-cheesesteak",
@@ -5031,7 +4991,7 @@
         "episode_id": "bagelsandwiches",
         "name": "Bagel Sandwiches inspired by Steven Universe",
         "published_date": "2019-07-23",
-        "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
         "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png"
       },
@@ -5069,7 +5029,7 @@
       },
       {
         "episode_id": "burgers",
-        "name": "BURGERS",
+        "name": "Burgers",
         "published_date": "2018-06-14",
         "youtube_link": "https://www.youtube.com/watch?v=nbCgfiqq-5c",
         "official_link": "https://www.babi.sh/recipes/burgers",
@@ -5118,7 +5078,7 @@
       {
         "episode_id": "cubanos-inspired-by-chef",
         "name": "Cubanos inspired by Chef",
-        "published_date": "2017-03-29",
+        "published_date": "2017-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=hXYoduN0kWs",
         "official_link": "https://www.babi.sh/recipes/cubanos-inspired-by-chef",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992067/etfzgspqjiwp3janr32z.webp"
@@ -5301,7 +5261,7 @@
       {
         "episode_id": "crab-bisque-seinfeld",
         "name": "Crab Bisque inspired by Seinfeld",
-        "published_date": "2022-05-27",
+        "published_date": "2022-05-24",
         "youtube_link": "https://www.youtube.com/watch?v=5kKMB890ABc",
         "official_link": "https://www.babi.sh/recipes/crab-bisque-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695634/babishImages/undefined-585834.png"
@@ -5334,7 +5294,7 @@
         "episode_id": "chileanseabass",
         "name": "Chilean Sea Bass inspired by Jurassic Park",
         "published_date": "2018-11-27",
-        "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/p73kqpqGqqQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ",
         "official_link": "https://www.babi.sh/recipes/chileanseabass",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695721/babishImages/undefined-408439.png"
       },
@@ -5426,14 +5386,6 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1769735233/hleoccmfkh4lbwvu6gzz.webp"
       },
       {
-        "episode_id": "babish's-ultimate-fried-chicken",
-        "name": "Babish\u2019s Ultimate Fried Chicken",
-        "published_date": "2025-10-23",
-        "youtube_link": "https://www.youtube.com/watch?v=yvKf6aDxBLk",
-        "official_link": "https://www.babi.sh/recipes/babish's-ultimate-fried-chicken",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1761246372/oljov21inpdw2zrpqypy.webp"
-      },
-      {
         "episode_id": "korean-garlic-fried-chicken-inspired-by-korean-street-food",
         "name": "Korean Garlic Fried Chicken inspired by Korean Street Food",
         "published_date": "2025-08-19",
@@ -5472,14 +5424,6 @@
         "youtube_link": "https://www.youtube.com/watch?v=23lKOTVYRGc&t=673s&ab_channel=BabishCulinaryUniverse",
         "official_link": "https://www.babi.sh/recipes/3-course-dinner-inspired-by-drop",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1746310289/sxhsw0jiihdjo9tibmw5.webp"
-      },
-      {
-        "episode_id": "agua-de-jamaica-granita",
-        "name": "Agua de Jamaica Granita",
-        "published_date": "2025-04-29",
-        "youtube_link": "https://www.youtube.com/shorts/NYPxT4K-jEw",
-        "official_link": "https://www.babi.sh/recipes/agua-de-jamaica-granita",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1745960432/nlcsou9whnpdevviupw4.webp"
       },
       {
         "episode_id": "panna-cotta-with-poached-pears",
@@ -5715,7 +5659,7 @@
       },
       {
         "episode_id": "biscuits-and-gravy",
-        "name": "BISCUITS AND GRAVY",
+        "name": "Biscuits & Gravy",
         "published_date": "2021-02-25",
         "youtube_link": "https://www.youtube.com/watch?v=NMbMT9tY8-Q",
         "official_link": "https://www.babi.sh/recipes/biscuits-and-gravy",
@@ -5803,7 +5747,7 @@
       },
       {
         "episode_id": "cheese-fondue",
-        "name": "CHEEESE FONDUE",
+        "name": "Cheese Fondue",
         "published_date": "2020-07-23",
         "youtube_link": "https://www.youtube.com/watch?v=_X-Mm8h1AHM",
         "official_link": "https://www.babi.sh/recipes/cheese-fondue",
@@ -5867,7 +5811,7 @@
       },
       {
         "episode_id": "cheesdips",
-        "name": "CHEESE DIPS",
+        "name": "Cheese Dips",
         "published_date": "2019-05-02",
         "youtube_link": "https://www.youtube.com/watch?v=9toK5UUGeok",
         "official_link": "https://www.babi.sh/recipes/cheesdips",
@@ -5962,7 +5906,7 @@
       },
       {
         "episode_id": "10-levels-chicken-noodle-soup",
-        "name": "10 Levels Chicken Noodle Soup",
+        "name": "10 Levels of Chicken Noodle Soup",
         "published_date": "2026-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
         "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
@@ -6042,7 +5986,7 @@
       },
       {
         "episode_id": "blendersoups",
-        "name": "BLENDER SOUPS",
+        "name": "Blender Soups",
         "published_date": "2019-03-05",
         "youtube_link": "https://www.youtube.com/watch?v=S-gUFvpRQoU",
         "official_link": "https://www.babi.sh/recipes/blendersoups",
@@ -6060,7 +6004,7 @@
         "episode_id": "coqauvin",
         "name": "Coq au Vin inspired by Donnie Brasco",
         "published_date": "2019-01-15",
-        "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/VP1uTgikarU/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU",
         "official_link": "https://www.babi.sh/recipes/coqauvin",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695986/babishImages/undefined-867897.png"
       },
@@ -6068,7 +6012,7 @@
         "episode_id": "bearstew",
         "name": "Bear Stew inspired by Red Dead Redemption 2",
         "published_date": "2018-11-06",
-        "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wMxKbkWrvDc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc",
         "official_link": "https://www.babi.sh/recipes/bearstew",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679263840/iyxpvkao4lwi6xqkcwd1.webp"
       },
@@ -6129,7 +6073,7 @@
     "episodes": [
       {
         "episode_id": "5-levels-of-spaghetti-or-with-babish",
-        "name": "5 Levels of Spaghetti | With Babish",
+        "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
         "published_date": "2026-01-30",
         "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
         "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
@@ -6279,16 +6223,8 @@
     "name": "Beginner",
     "episodes": [
       {
-        "episode_id": "10-levels-of-cheesesteak",
-        "name": "10 Levels of Cheesesteak",
-        "published_date": "2026-04-30",
-        "youtube_link": "https://www.youtube.com/watch?v=jNan4FWeQEE",
-        "official_link": "https://www.babi.sh/recipes/10-levels-of-cheesesteak",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1777507861/icg9k8c02j1h9nfo5qb7.webp"
-      },
-      {
         "episode_id": "10-levels-chicken-noodle-soup",
-        "name": "10 Levels Chicken Noodle Soup",
+        "name": "10 Levels of Chicken Noodle Soup",
         "published_date": "2026-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
         "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
@@ -6304,7 +6240,7 @@
       },
       {
         "episode_id": "5-levels-of-spaghetti-or-with-babish",
-        "name": "5 Levels of Spaghetti | With Babish",
+        "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
         "published_date": "2026-01-30",
         "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
         "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
@@ -6327,20 +6263,20 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768506428/gryanukvd2zeutfh9ibh.webp"
       },
       {
-        "episode_id": "beef-wellington-or-with-babish",
-        "name": "Beef Wellington | With Babish",
-        "published_date": "2026-01-14",
-        "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
-        "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
-      },
-      {
         "episode_id": "the-ultimate-marry-me-meals",
         "name": "The Ultimate Marry-Me Meals",
         "published_date": "2026-01-06",
         "youtube_link": "https://www.youtube.com/watch?v=TggSdedcLJo",
         "official_link": "https://www.babi.sh/recipes/the-ultimate-marry-me-meals",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1767735831/qh0bt5mllxrxbi4kvgsb.webp"
+      },
+      {
+        "episode_id": "beef-wellington-or-with-babish",
+        "name": "$20 vs $200 Beef Wellington | With Babish",
+        "published_date": "2025-12-23",
+        "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
+        "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
       },
       {
         "episode_id": "meatball-smashwich-with-babish",
@@ -6357,14 +6293,6 @@
         "youtube_link": "https://www.youtube.com/watch?v=dzw6JO-yz34&pp=ygUTYmluZ2luZyB3aXRoIGJhYmlzaA%3D%3D",
         "official_link": "https://www.babi.sh/recipes/10-levels-of-chocolate-chip-cookies-or-with-babish",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1761497423/go8m6uokvxy6qiayhnst.webp"
-      },
-      {
-        "episode_id": "babish's-ultimate-fried-chicken",
-        "name": "Babish\u2019s Ultimate Fried Chicken",
-        "published_date": "2025-10-23",
-        "youtube_link": "https://www.youtube.com/watch?v=yvKf6aDxBLk",
-        "official_link": "https://www.babi.sh/recipes/babish's-ultimate-fried-chicken",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1761246372/oljov21inpdw2zrpqypy.webp"
       },
       {
         "episode_id": "coq-au-vin",
@@ -6496,7 +6424,7 @@
       },
       {
         "episode_id": "classic-fettucine-alfredo",
-        "name": "Classic Fettucine Alfredo",
+        "name": "Classic Fettuccine Alfredo",
         "published_date": "2025-06-06",
         "youtube_link": "https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo",
         "official_link": "https://www.babi.sh/recipes/classic-fettucine-alfredo",
@@ -6831,20 +6759,20 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695375/babishImages/undefined-708307.png"
       },
       {
-        "episode_id": "beer-can-chicken",
-        "name": "BEER CAN CHICKEN",
-        "published_date": "2022-12-19",
-        "youtube_link": "https://www.youtube.com/watch?v=Xo0v7ZuA9C0",
-        "official_link": "https://www.babi.sh/recipes/beer-can-chicken",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png"
-      },
-      {
         "episode_id": "meatballs-30rock",
         "name": "Meatballs inspired by 30 Rock",
         "published_date": "2022-12-19",
         "youtube_link": "https://www.youtube.com/watch?v=IMvffRnRO0E",
         "official_link": "https://www.babi.sh/recipes/meatballs-30rock",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695628/babishImages/undefined-273552.png"
+      },
+      {
+        "episode_id": "beer-can-chicken",
+        "name": "BEER CAN CHICKEN",
+        "published_date": "2022-12-18",
+        "youtube_link": "https://www.youtube.com/watch?v=Xo0v7ZuA9C0",
+        "official_link": "https://www.babi.sh/recipes/beer-can-chicken",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png"
       },
       {
         "episode_id": "healthier-crunchwrap-supreme",
@@ -6904,7 +6832,7 @@
       },
       {
         "episode_id": "chicken-piccata",
-        "name": "CHICKEN PICCATA",
+        "name": "Chicken Piccata",
         "published_date": "2022-02-18",
         "youtube_link": "https://www.youtube.com/watch?v=ZqEqtmMY1M0",
         "official_link": "https://www.babi.sh/recipes/chicken-piccata",
@@ -6983,20 +6911,20 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695844/babishImages/undefined-200135.png"
       },
       {
-        "episode_id": "cake-pops",
-        "name": "CAKE POPS",
-        "published_date": "2021-11-02",
-        "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
-        "official_link": "https://www.babi.sh/recipes/cake-pops",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
-      },
-      {
         "episode_id": "poke-bowls",
         "name": "POKE BOWLS",
         "published_date": "2021-10-26",
         "youtube_link": "https://www.youtube.com/watch?v=l7VRSINAEQo",
         "official_link": "https://www.babi.sh/recipes/poke-bowls",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695359/babishImages/undefined-263359.png"
+      },
+      {
+        "episode_id": "cake-pops",
+        "name": "Cake Pops",
+        "published_date": "2021-10-21",
+        "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
+        "official_link": "https://www.babi.sh/recipes/cake-pops",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
       },
       {
         "episode_id": "grits-breakfast-my-cousin-vinny",
@@ -7016,7 +6944,7 @@
       },
       {
         "episode_id": "calistyle-burrito",
-        "name": "CALI-STYLE BURRITO",
+        "name": "California Style Burritos",
         "published_date": "2021-09-13",
         "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
         "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
@@ -7032,7 +6960,7 @@
       },
       {
         "episode_id": "chiles-rellenos",
-        "name": "CHILES RELLENOS",
+        "name": "Chiles Rellenos",
         "published_date": "2021-08-26",
         "youtube_link": "https://www.youtube.com/watch?v=gAKW8RB6aeU",
         "official_link": "https://www.babi.sh/recipes/chiles-rellenos",
@@ -7192,7 +7120,7 @@
       },
       {
         "episode_id": "chicken-parmesan",
-        "name": "CHICKEN PARMESAN",
+        "name": "Chicken Parmesan",
         "published_date": "2020-12-10",
         "youtube_link": "https://www.youtube.com/watch?v=ZrR0VbqNdW8",
         "official_link": "https://www.babi.sh/recipes/chicken-parmesan",
@@ -7370,7 +7298,7 @@
         "episode_id": "beer-steamed-chili-dogs",
         "name": "Chili Dogs inspired by The Irishman",
         "published_date": "2019-12-17",
-        "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/c0A1bkF4mKM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM",
         "official_link": "https://www.babi.sh/recipes/beer-steamed-chili-dogs",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695792/babishImages/undefined-202970.png"
       },
@@ -7442,7 +7370,7 @@
         "episode_id": "bagelsandwiches",
         "name": "Bagel Sandwiches inspired by Steven Universe",
         "published_date": "2019-07-23",
-        "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
         "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png"
       },
@@ -7536,7 +7464,7 @@
       },
       {
         "episode_id": "cheesdips",
-        "name": "CHEESE DIPS",
+        "name": "Cheese Dips",
         "published_date": "2019-05-02",
         "youtube_link": "https://www.youtube.com/watch?v=9toK5UUGeok",
         "official_link": "https://www.babi.sh/recipes/cheesdips",
@@ -7560,7 +7488,7 @@
       },
       {
         "episode_id": "chickentikkamasala",
-        "name": "CHICKEN TIKKA MASALA",
+        "name": "Chicken Tikka Masala",
         "published_date": "2019-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=Bkd0LxBd2L8",
         "official_link": "https://www.babi.sh/recipes/chickentikkamasala",
@@ -7568,7 +7496,7 @@
       },
       {
         "episode_id": "blendersoups",
-        "name": "BLENDER SOUPS",
+        "name": "Blender Soups",
         "published_date": "2019-03-05",
         "youtube_link": "https://www.youtube.com/watch?v=S-gUFvpRQoU",
         "official_link": "https://www.babi.sh/recipes/blendersoups",
@@ -7584,7 +7512,7 @@
       },
       {
         "episode_id": "biggamesnacks",
-        "name": "BIG GAME SNACKS",
+        "name": "Big Game Snacks",
         "published_date": "2019-01-31",
         "youtube_link": "https://www.youtube.com/watch?v=8ckxhlDFNkg",
         "official_link": "https://www.babi.sh/recipes/biggamesnacks",
@@ -7642,7 +7570,7 @@
         "episode_id": "charliebrownthanksgiving",
         "name": "Charlie Brown Thanksgiving",
         "published_date": "2018-11-20",
-        "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5FyKxVJmsdE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE",
         "official_link": "https://www.babi.sh/recipes/charliebrownthanksgiving",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg"
       },
@@ -7674,7 +7602,7 @@
         "episode_id": "cinnamonrolls",
         "name": "Cinnamon Rolls inspired by Jim Gaffigan's Stand Up (sort of)",
         "published_date": "2018-10-23",
-        "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/jFYi2QRVFOc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc",
         "official_link": "https://www.babi.sh/recipes/cinnamonrolls",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679245506/gyb4qsztcyrv4kjnvwug.webp"
       },
@@ -7744,7 +7672,7 @@
       },
       {
         "episode_id": "barbecueporkchops",
-        "name": "BARBECUE PORK CHOPS",
+        "name": "Barbecue Pork Chops",
         "published_date": "2018-06-28",
         "youtube_link": "https://www.youtube.com/watch?v=YV9XuvfIudY",
         "official_link": "https://www.babi.sh/recipes/barbecueporkchops",
@@ -7768,7 +7696,7 @@
       },
       {
         "episode_id": "burgers",
-        "name": "BURGERS",
+        "name": "Burgers",
         "published_date": "2018-06-14",
         "youtube_link": "https://www.youtube.com/watch?v=nbCgfiqq-5c",
         "official_link": "https://www.babi.sh/recipes/burgers",
@@ -8184,7 +8112,7 @@
       {
         "episode_id": "churrons-broad-city",
         "name": "Churrons inspired by Broad City",
-        "published_date": "2022-08-17",
+        "published_date": "2022-08-03",
         "youtube_link": "https://www.youtube.com/watch?v=JiUsCTy8nEY",
         "official_link": "https://www.babi.sh/recipes/churrons-broad-city",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695905/babishImages/undefined-290140.png"
@@ -8216,7 +8144,7 @@
       {
         "episode_id": "chefs-choice-platter-monster-hunter-world",
         "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-        "published_date": "2021-03-31",
+        "published_date": "2021-03-30",
         "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
         "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png"
@@ -8264,8 +8192,8 @@
       {
         "episode_id": "crepessuzette",
         "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-        "published_date": "2019-10-24",
-        "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "published_date": "2019-10-22",
+        "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
         "official_link": "https://www.babi.sh/recipes/crepessuzette",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png"
       },
@@ -8310,7 +8238,7 @@
       },
       {
         "episode_id": "5-levels-of-spaghetti-or-with-babish",
-        "name": "5 Levels of Spaghetti | With Babish",
+        "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
         "published_date": "2026-01-30",
         "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
         "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
@@ -8326,8 +8254,8 @@
       },
       {
         "episode_id": "beef-wellington-or-with-babish",
-        "name": "Beef Wellington | With Babish",
-        "published_date": "2026-01-14",
+        "name": "$20 vs $200 Beef Wellington | With Babish",
+        "published_date": "2025-12-23",
         "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
         "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
@@ -8343,7 +8271,7 @@
       {
         "episode_id": "christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
         "name": "Christmas Turkey inspired by National Lampoon's Christmas Vacation",
-        "published_date": "2025-11-26",
+        "published_date": "2025-11-29",
         "youtube_link": "https://youtube.com/watch?v=w0pZ7MWajW8&si=r2TmnS9oJhDHIbp5",
         "official_link": "https://www.babi.sh/recipes/christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1764189007/giyklwlgdj7x3nwbi38c.webp"
@@ -8733,20 +8661,20 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695168/babishImages/undefined-41817.png"
       },
       {
-        "episode_id": "chocolate-croissants-its-complicated",
-        "name": "Chocolate Croissants inspired by It's Complicated",
-        "published_date": "2022-08-01",
-        "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
-        "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png"
-      },
-      {
         "episode_id": "lobster-scrambled-eggs-seinfeld",
         "name": "Lobster Scrambled Eggs inspired by Seinfeld (Copy)",
         "published_date": "2022-08-01",
         "youtube_link": "https://www.youtube.com/watch?v=71jrAWaRc3E",
         "official_link": "https://www.babi.sh/recipes/lobster-scrambled-eggs-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695727/babishImages/undefined-436056.png"
+      },
+      {
+        "episode_id": "chocolate-croissants-its-complicated",
+        "name": "Chocolate Croissants inspired by It's Complicated",
+        "published_date": "2022-07-13",
+        "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
+        "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png"
       },
       {
         "episode_id": "bobbys-cookies-king-of-the-hill",
@@ -8765,20 +8693,20 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695224/babishImages/undefined-943345.png"
       },
       {
-        "episode_id": "crab-bisque-seinfeld",
-        "name": "Crab Bisque inspired by Seinfeld",
-        "published_date": "2022-05-27",
-        "youtube_link": "https://www.youtube.com/watch?v=5kKMB890ABc",
-        "official_link": "https://www.babi.sh/recipes/crab-bisque-seinfeld",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695634/babishImages/undefined-585834.png"
-      },
-      {
         "episode_id": "lemon-meringue-pie",
         "name": "LEMON MERINGUE PIE",
         "published_date": "2022-05-27",
         "youtube_link": "https://www.youtube.com/watch?v=f0fmS1WEm3s",
         "official_link": "https://www.babi.sh/recipes/lemon-meringue-pie",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696099/babishImages/undefined-443317.png"
+      },
+      {
+        "episode_id": "crab-bisque-seinfeld",
+        "name": "Crab Bisque inspired by Seinfeld",
+        "published_date": "2022-05-24",
+        "youtube_link": "https://www.youtube.com/watch?v=5kKMB890ABc",
+        "official_link": "https://www.babi.sh/recipes/crab-bisque-seinfeld",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695634/babishImages/undefined-585834.png"
       },
       {
         "episode_id": "kelp-bar-spongebob",
@@ -8790,7 +8718,7 @@
       },
       {
         "episode_id": "corned-beef",
-        "name": "CORNED BEEF",
+        "name": "Corned Beef",
         "published_date": "2022-03-17",
         "youtube_link": "https://www.youtube.com/watch?v=IDkuwVvZpWM",
         "official_link": "https://www.babi.sh/recipes/corned-beef",
@@ -8830,7 +8758,7 @@
       },
       {
         "episode_id": "apple-cider-donuts",
-        "name": "APPLE CIDER DONUTS",
+        "name": "Apple Cider Donuts",
         "published_date": "2021-11-09",
         "youtube_link": "https://www.youtube.com/watch?v=baZoJYAQjfI",
         "official_link": "https://www.babi.sh/recipes/apple-cider-donuts",
@@ -8862,7 +8790,7 @@
       },
       {
         "episode_id": "biscotti",
-        "name": "BISCOTTI",
+        "name": "Biscotti",
         "published_date": "2021-09-24",
         "youtube_link": "https://www.youtube.com/watch?v=g4EkzEKlGOA",
         "official_link": "https://www.babi.sh/recipes/biscotti",
@@ -8998,7 +8926,7 @@
       },
       {
         "episode_id": "birria-tacos",
-        "name": "BIRRIA TACOS",
+        "name": "Birria Tacos",
         "published_date": "2021-03-11",
         "youtube_link": "https://www.youtube.com/watch?v=pQmSrlIbULk",
         "official_link": "https://www.babi.sh/recipes/birria-tacos",
@@ -9070,7 +8998,7 @@
       },
       {
         "episode_id": "andrewsohlathanksgiving",
-        "name": "ANDREW & SOHLA THANKSGIVING RECIPES",
+        "name": "Thanksgiving Recipe Livestream with Sohla El-Waylly",
         "published_date": "2020-11-20",
         "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
         "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
@@ -9182,7 +9110,7 @@
       },
       {
         "episode_id": "cheese-fondue",
-        "name": "CHEEESE FONDUE",
+        "name": "Cheese Fondue",
         "published_date": "2020-07-23",
         "youtube_link": "https://www.youtube.com/watch?v=_X-Mm8h1AHM",
         "official_link": "https://www.babi.sh/recipes/cheese-fondue",
@@ -9254,7 +9182,7 @@
       },
       {
         "episode_id": "ben-wyatt-calzones",
-        "name": "Calzones inspired by Parks & Rec",
+        "name": "Ben Wyatt's Calzones",
         "published_date": "2020-04-15",
         "youtube_link": "https://www.youtube.com/watch?v=PvgCEifW7Jo",
         "official_link": "https://www.babi.sh/recipes/ben-wyatt-calzones",
@@ -9424,7 +9352,7 @@
         "episode_id": "coffeejelly",
         "name": "Coffee Jelly inspired by The Disastrous Life of Saiki K.",
         "published_date": "2019-09-24",
-        "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YxEcd_wTf5c/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c",
         "official_link": "https://www.babi.sh/recipes/coffeejelly",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png"
       },
@@ -9448,7 +9376,7 @@
         "episode_id": "alwayssunny",
         "name": "It's Always Sunny in Philadelphia Special (Part II)",
         "published_date": "2019-06-12",
-        "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/_fnhy5xO9vQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ",
         "official_link": "https://www.babi.sh/recipes/alwayssunny",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696347/babishImages/undefined-129032.png"
       },
@@ -9464,7 +9392,7 @@
         "episode_id": "avengersicecream",
         "name": "Ice Cream Flavors inspired by Avengers: Infinity War",
         "published_date": "2019-04-30",
-        "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Ukjat70Iyt4/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4",
         "official_link": "https://www.babi.sh/recipes/avengersicecream",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695805/babishImages/undefined-987247.png"
       },
@@ -9480,7 +9408,7 @@
         "episode_id": "brocksdonuts",
         "name": "Brock's Donuts inspired by Pok\u00e9mon",
         "published_date": "2019-04-02",
-        "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/RentKWlhUXc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc",
         "official_link": "https://www.babi.sh/recipes/brocksdonuts",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695178/babishImages/undefined-56205.png"
       },
@@ -9504,7 +9432,7 @@
         "episode_id": "baobuns",
         "name": "Bao inspired by Pixar's Bao",
         "published_date": "2019-02-19",
-        "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M&amp;t=46s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/OFt3SThGi7M/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M",
         "official_link": "https://www.babi.sh/recipes/baobuns",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695380/babishImages/undefined-293013.png"
       },
@@ -9536,7 +9464,7 @@
         "episode_id": "aristocats",
         "name": "Cr\u00e8me de la Cr\u00e8me \u00e0 la Edgar inspired by The Aristocats",
         "published_date": "2019-01-23",
-        "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/zNY-qzp7pD0/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0",
         "official_link": "https://www.babi.sh/recipes/aristocats",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696317/babishImages/undefined-541474.png"
       },
@@ -9544,7 +9472,7 @@
         "episode_id": "coqauvin",
         "name": "Coq au Vin inspired by Donnie Brasco",
         "published_date": "2019-01-15",
-        "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/VP1uTgikarU/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU",
         "official_link": "https://www.babi.sh/recipes/coqauvin",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695986/babishImages/undefined-867897.png"
       },
@@ -9568,7 +9496,7 @@
         "episode_id": "chileanseabass",
         "name": "Chilean Sea Bass inspired by Jurassic Park",
         "published_date": "2018-11-27",
-        "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/p73kqpqGqqQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ",
         "official_link": "https://www.babi.sh/recipes/chileanseabass",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695721/babishImages/undefined-408439.png"
       },
@@ -9576,7 +9504,7 @@
         "episode_id": "bearstew",
         "name": "Bear Stew inspired by Red Dead Redemption 2",
         "published_date": "2018-11-06",
-        "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wMxKbkWrvDc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc",
         "official_link": "https://www.babi.sh/recipes/bearstew",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679263840/iyxpvkao4lwi6xqkcwd1.webp"
       },
@@ -9678,7 +9606,7 @@
       },
       {
         "episode_id": "burgers",
-        "name": "BURGERS",
+        "name": "Burgers",
         "published_date": "2018-06-14",
         "youtube_link": "https://www.youtube.com/watch?v=nbCgfiqq-5c",
         "official_link": "https://www.babi.sh/recipes/burgers",
@@ -9887,7 +9815,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -9943,7 +9871,7 @@
       {
         "episode_id": "babka-inspired-by-seinfeld",
         "name": "Babka inspired by Seinfeld",
-        "published_date": "2017-05-10",
+        "published_date": "2017-05-09",
         "youtube_link": "https://www.youtube.com/watch?v=pw2A03Z91FI",
         "official_link": "https://www.babi.sh/recipes/babka-inspired-by-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp"
@@ -9967,7 +9895,7 @@
       {
         "episode_id": "cubanos-inspired-by-chef",
         "name": "Cubanos inspired by Chef",
-        "published_date": "2017-03-29",
+        "published_date": "2017-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=hXYoduN0kWs",
         "official_link": "https://www.babi.sh/recipes/cubanos-inspired-by-chef",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992067/etfzgspqjiwp3janr32z.webp"
@@ -10043,14 +9971,6 @@
         "youtube_link": "https://www.youtube.com/watch?v=akO6D_tc0lo",
         "official_link": "https://www.babi.sh/recipes/reversesearsteak",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992080/orgwxidbhkpqwrhg9ogf.webp"
-      },
-      {
-        "episode_id": "croquemadame",
-        "name": "Croque Madame: The Ultimate Breakfast Sandwich",
-        "published_date": "2016-03-13",
-        "youtube_link": "https://www.youtube.com/watch?v=dVRl1aP28BI",
-        "official_link": "https://www.babi.sh/recipes/croquemadame",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991875/uhyqawcvmpjjitgohrse.webp"
       },
       {
         "episode_id": "parksandrecburger",
@@ -10188,20 +10108,20 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695667/babishImages/undefined-717015.png"
       },
       {
-        "episode_id": "chocolate-croissants-its-complicated",
-        "name": "Chocolate Croissants inspired by It's Complicated",
-        "published_date": "2022-08-01",
-        "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
-        "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png"
-      },
-      {
         "episode_id": "lobster-scrambled-eggs-seinfeld",
         "name": "Lobster Scrambled Eggs inspired by Seinfeld (Copy)",
         "published_date": "2022-08-01",
         "youtube_link": "https://www.youtube.com/watch?v=71jrAWaRc3E",
         "official_link": "https://www.babi.sh/recipes/lobster-scrambled-eggs-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695727/babishImages/undefined-436056.png"
+      },
+      {
+        "episode_id": "chocolate-croissants-its-complicated",
+        "name": "Chocolate Croissants inspired by It's Complicated",
+        "published_date": "2022-07-13",
+        "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
+        "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png"
       },
       {
         "episode_id": "grits-breakfast-my-cousin-vinny",
@@ -10213,7 +10133,7 @@
       },
       {
         "episode_id": "biscotti",
-        "name": "BISCOTTI",
+        "name": "Biscotti",
         "published_date": "2021-09-24",
         "youtube_link": "https://www.youtube.com/watch?v=g4EkzEKlGOA",
         "official_link": "https://www.babi.sh/recipes/biscotti",
@@ -10284,14 +10204,6 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695798/babishImages/undefined-854167.png"
       },
       {
-        "episode_id": "avatar-fire-flakes",
-        "name": "Fire Flakes inspired by Avatar the Last Airbender",
-        "published_date": "2020-08-04",
-        "youtube_link": "https://www.youtube.com/watch?v=RhUMA3bCvAY",
-        "official_link": "https://www.babi.sh/recipes/avatar-fire-flakes",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695535/babishImages/undefined-243692.png"
-      },
-      {
         "episode_id": "french-toast",
         "name": "FRENCH TOAST",
         "published_date": "2020-06-20",
@@ -10335,7 +10247,7 @@
         "episode_id": "coffeejelly",
         "name": "Coffee Jelly inspired by The Disastrous Life of Saiki K.",
         "published_date": "2019-09-24",
-        "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YxEcd_wTf5c/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c",
         "official_link": "https://www.babi.sh/recipes/coffeejelly",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png"
       },
@@ -10343,7 +10255,7 @@
         "episode_id": "bagelsandwiches",
         "name": "Bagel Sandwiches inspired by Steven Universe",
         "published_date": "2019-07-23",
-        "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
         "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png"
       },
@@ -10454,7 +10366,7 @@
       {
         "episode_id": "babka-inspired-by-seinfeld",
         "name": "Babka inspired by Seinfeld",
-        "published_date": "2017-05-10",
+        "published_date": "2017-05-09",
         "youtube_link": "https://www.youtube.com/watch?v=pw2A03Z91FI",
         "official_link": "https://www.babi.sh/recipes/babka-inspired-by-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp"
@@ -10532,7 +10444,7 @@
     "episodes": [
       {
         "episode_id": "10-levels-chicken-noodle-soup",
-        "name": "10 Levels Chicken Noodle Soup",
+        "name": "10 Levels of Chicken Noodle Soup",
         "published_date": "2026-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
         "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
@@ -10548,7 +10460,7 @@
       },
       {
         "episode_id": "5-levels-of-spaghetti-or-with-babish",
-        "name": "5 Levels of Spaghetti | With Babish",
+        "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
         "published_date": "2026-01-30",
         "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
         "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
@@ -10563,20 +10475,20 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768506428/gryanukvd2zeutfh9ibh.webp"
       },
       {
-        "episode_id": "beef-wellington-or-with-babish",
-        "name": "Beef Wellington | With Babish",
-        "published_date": "2026-01-14",
-        "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
-        "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
-      },
-      {
         "episode_id": "the-ultimate-marry-me-meals",
         "name": "The Ultimate Marry-Me Meals",
         "published_date": "2026-01-06",
         "youtube_link": "https://www.youtube.com/watch?v=TggSdedcLJo",
         "official_link": "https://www.babi.sh/recipes/the-ultimate-marry-me-meals",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1767735831/qh0bt5mllxrxbi4kvgsb.webp"
+      },
+      {
+        "episode_id": "beef-wellington-or-with-babish",
+        "name": "$20 vs $200 Beef Wellington | With Babish",
+        "published_date": "2025-12-23",
+        "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
+        "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
       },
       {
         "episode_id": "level-9:-babish's-pbandj",
@@ -10589,7 +10501,7 @@
       {
         "episode_id": "christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
         "name": "Christmas Turkey inspired by National Lampoon's Christmas Vacation",
-        "published_date": "2025-11-26",
+        "published_date": "2025-11-29",
         "youtube_link": "https://youtube.com/watch?v=w0pZ7MWajW8&si=r2TmnS9oJhDHIbp5",
         "official_link": "https://www.babi.sh/recipes/christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1764189007/giyklwlgdj7x3nwbi38c.webp"
@@ -10732,7 +10644,7 @@
       },
       {
         "episode_id": "classic-fettucine-alfredo",
-        "name": "Classic Fettucine Alfredo",
+        "name": "Classic Fettuccine Alfredo",
         "published_date": "2025-06-06",
         "youtube_link": "https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo",
         "official_link": "https://www.babi.sh/recipes/classic-fettucine-alfredo",
@@ -11059,20 +10971,20 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1676600503/v0ifeak5fzq4rrokacmc.webp"
       },
       {
-        "episode_id": "beer-can-chicken",
-        "name": "BEER CAN CHICKEN",
-        "published_date": "2022-12-19",
-        "youtube_link": "https://www.youtube.com/watch?v=Xo0v7ZuA9C0",
-        "official_link": "https://www.babi.sh/recipes/beer-can-chicken",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png"
-      },
-      {
         "episode_id": "meatballs-30rock",
         "name": "Meatballs inspired by 30 Rock",
         "published_date": "2022-12-19",
         "youtube_link": "https://www.youtube.com/watch?v=IMvffRnRO0E",
         "official_link": "https://www.babi.sh/recipes/meatballs-30rock",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695628/babishImages/undefined-273552.png"
+      },
+      {
+        "episode_id": "beer-can-chicken",
+        "name": "BEER CAN CHICKEN",
+        "published_date": "2022-12-18",
+        "youtube_link": "https://www.youtube.com/watch?v=Xo0v7ZuA9C0",
+        "official_link": "https://www.babi.sh/recipes/beer-can-chicken",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png"
       },
       {
         "episode_id": "sausages-ragnarok",
@@ -11165,7 +11077,7 @@
       {
         "episode_id": "crab-bisque-seinfeld",
         "name": "Crab Bisque inspired by Seinfeld",
-        "published_date": "2022-05-27",
+        "published_date": "2022-05-24",
         "youtube_link": "https://www.youtube.com/watch?v=5kKMB890ABc",
         "official_link": "https://www.babi.sh/recipes/crab-bisque-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695634/babishImages/undefined-585834.png"
@@ -11180,7 +11092,7 @@
       },
       {
         "episode_id": "corned-beef",
-        "name": "CORNED BEEF",
+        "name": "Corned Beef",
         "published_date": "2022-03-17",
         "youtube_link": "https://www.youtube.com/watch?v=IDkuwVvZpWM",
         "official_link": "https://www.babi.sh/recipes/corned-beef",
@@ -11204,7 +11116,7 @@
       },
       {
         "episode_id": "chicken-piccata",
-        "name": "CHICKEN PICCATA",
+        "name": "Chicken Piccata",
         "published_date": "2022-02-18",
         "youtube_link": "https://www.youtube.com/watch?v=ZqEqtmMY1M0",
         "official_link": "https://www.babi.sh/recipes/chicken-piccata",
@@ -11284,7 +11196,7 @@
       },
       {
         "episode_id": "calistyle-burrito",
-        "name": "CALI-STYLE BURRITO",
+        "name": "California Style Burritos",
         "published_date": "2021-09-13",
         "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
         "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
@@ -11292,7 +11204,7 @@
       },
       {
         "episode_id": "chiles-rellenos",
-        "name": "CHILES RELLENOS",
+        "name": "Chiles Rellenos",
         "published_date": "2021-08-26",
         "youtube_link": "https://www.youtube.com/watch?v=gAKW8RB6aeU",
         "official_link": "https://www.babi.sh/recipes/chiles-rellenos",
@@ -11468,7 +11380,7 @@
       },
       {
         "episode_id": "chicken-parmesan",
-        "name": "CHICKEN PARMESAN",
+        "name": "Chicken Parmesan",
         "published_date": "2020-12-10",
         "youtube_link": "https://www.youtube.com/watch?v=ZrR0VbqNdW8",
         "official_link": "https://www.babi.sh/recipes/chicken-parmesan",
@@ -11772,7 +11684,7 @@
       },
       {
         "episode_id": "chickentikkamasala",
-        "name": "CHICKEN TIKKA MASALA",
+        "name": "Chicken Tikka Masala",
         "published_date": "2019-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=Bkd0LxBd2L8",
         "official_link": "https://www.babi.sh/recipes/chickentikkamasala",
@@ -11788,7 +11700,7 @@
       },
       {
         "episode_id": "blendersoups",
-        "name": "BLENDER SOUPS",
+        "name": "Blender Soups",
         "published_date": "2019-03-05",
         "youtube_link": "https://www.youtube.com/watch?v=S-gUFvpRQoU",
         "official_link": "https://www.babi.sh/recipes/blendersoups",
@@ -11822,7 +11734,7 @@
         "episode_id": "coqauvin",
         "name": "Coq au Vin inspired by Donnie Brasco",
         "published_date": "2019-01-15",
-        "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/VP1uTgikarU/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU",
         "official_link": "https://www.babi.sh/recipes/coqauvin",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695986/babishImages/undefined-867897.png"
       },
@@ -11854,7 +11766,7 @@
         "episode_id": "chileanseabass",
         "name": "Chilean Sea Bass inspired by Jurassic Park",
         "published_date": "2018-11-27",
-        "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/p73kqpqGqqQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ",
         "official_link": "https://www.babi.sh/recipes/chileanseabass",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695721/babishImages/undefined-408439.png"
       },
@@ -11870,7 +11782,7 @@
         "episode_id": "bearstew",
         "name": "Bear Stew inspired by Red Dead Redemption 2",
         "published_date": "2018-11-06",
-        "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wMxKbkWrvDc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc",
         "official_link": "https://www.babi.sh/recipes/bearstew",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679263840/iyxpvkao4lwi6xqkcwd1.webp"
       },
@@ -11948,7 +11860,7 @@
       },
       {
         "episode_id": "barbecueporkchops",
-        "name": "BARBECUE PORK CHOPS",
+        "name": "Barbecue Pork Chops",
         "published_date": "2018-06-28",
         "youtube_link": "https://www.youtube.com/watch?v=YV9XuvfIudY",
         "official_link": "https://www.babi.sh/recipes/barbecueporkchops",
@@ -11972,7 +11884,7 @@
       },
       {
         "episode_id": "burgers",
-        "name": "BURGERS",
+        "name": "Burgers",
         "published_date": "2018-06-14",
         "youtube_link": "https://www.youtube.com/watch?v=nbCgfiqq-5c",
         "official_link": "https://www.babi.sh/recipes/burgers",
@@ -12221,7 +12133,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -12475,7 +12387,7 @@
     "episodes": [
       {
         "episode_id": "10-levels-chicken-noodle-soup",
-        "name": "10 Levels Chicken Noodle Soup",
+        "name": "10 Levels of Chicken Noodle Soup",
         "published_date": "2026-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
         "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
@@ -12483,7 +12395,7 @@
       },
       {
         "episode_id": "5-levels-of-spaghetti-or-with-babish",
-        "name": "5 Levels of Spaghetti | With Babish",
+        "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
         "published_date": "2026-01-30",
         "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
         "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
@@ -13003,7 +12915,7 @@
       },
       {
         "episode_id": "corned-beef",
-        "name": "CORNED BEEF",
+        "name": "Corned Beef",
         "published_date": "2022-03-17",
         "youtube_link": "https://www.youtube.com/watch?v=IDkuwVvZpWM",
         "official_link": "https://www.babi.sh/recipes/corned-beef",
@@ -13019,7 +12931,7 @@
       },
       {
         "episode_id": "chicken-piccata",
-        "name": "CHICKEN PICCATA",
+        "name": "Chicken Piccata",
         "published_date": "2022-02-18",
         "youtube_link": "https://www.youtube.com/watch?v=ZqEqtmMY1M0",
         "official_link": "https://www.babi.sh/recipes/chicken-piccata",
@@ -13091,7 +13003,7 @@
       },
       {
         "episode_id": "calistyle-burrito",
-        "name": "CALI-STYLE BURRITO",
+        "name": "California Style Burritos",
         "published_date": "2021-09-13",
         "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
         "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
@@ -13099,7 +13011,7 @@
       },
       {
         "episode_id": "chiles-rellenos",
-        "name": "CHILES RELLENOS",
+        "name": "Chiles Rellenos",
         "published_date": "2021-08-26",
         "youtube_link": "https://www.youtube.com/watch?v=gAKW8RB6aeU",
         "official_link": "https://www.babi.sh/recipes/chiles-rellenos",
@@ -13187,7 +13099,7 @@
       },
       {
         "episode_id": "birria-tacos",
-        "name": "BIRRIA TACOS",
+        "name": "Birria Tacos",
         "published_date": "2021-03-11",
         "youtube_link": "https://www.youtube.com/watch?v=pQmSrlIbULk",
         "official_link": "https://www.babi.sh/recipes/birria-tacos",
@@ -13227,7 +13139,7 @@
       },
       {
         "episode_id": "chicken-parmesan",
-        "name": "CHICKEN PARMESAN",
+        "name": "Chicken Parmesan",
         "published_date": "2020-12-10",
         "youtube_link": "https://www.youtube.com/watch?v=ZrR0VbqNdW8",
         "official_link": "https://www.babi.sh/recipes/chicken-parmesan",
@@ -13373,7 +13285,7 @@
         "episode_id": "beer-steamed-chili-dogs",
         "name": "Chili Dogs inspired by The Irishman",
         "published_date": "2019-12-17",
-        "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/c0A1bkF4mKM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM",
         "official_link": "https://www.babi.sh/recipes/beer-steamed-chili-dogs",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695792/babishImages/undefined-202970.png"
       },
@@ -13459,7 +13371,7 @@
       },
       {
         "episode_id": "chickentikkamasala",
-        "name": "CHICKEN TIKKA MASALA",
+        "name": "Chicken Tikka Masala",
         "published_date": "2019-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=Bkd0LxBd2L8",
         "official_link": "https://www.babi.sh/recipes/chickentikkamasala",
@@ -13475,7 +13387,7 @@
       },
       {
         "episode_id": "blendersoups",
-        "name": "BLENDER SOUPS",
+        "name": "Blender Soups",
         "published_date": "2019-03-05",
         "youtube_link": "https://www.youtube.com/watch?v=S-gUFvpRQoU",
         "official_link": "https://www.babi.sh/recipes/blendersoups",
@@ -13579,7 +13491,7 @@
       },
       {
         "episode_id": "barbecueporkchops",
-        "name": "BARBECUE PORK CHOPS",
+        "name": "Barbecue Pork Chops",
         "published_date": "2018-06-28",
         "youtube_link": "https://www.youtube.com/watch?v=YV9XuvfIudY",
         "official_link": "https://www.babi.sh/recipes/barbecueporkchops",
@@ -13603,7 +13515,7 @@
       },
       {
         "episode_id": "burgers",
-        "name": "BURGERS",
+        "name": "Burgers",
         "published_date": "2018-06-14",
         "youtube_link": "https://www.youtube.com/watch?v=nbCgfiqq-5c",
         "official_link": "https://www.babi.sh/recipes/burgers",
@@ -13828,7 +13740,7 @@
       {
         "episode_id": "babka-inspired-by-seinfeld",
         "name": "Babka inspired by Seinfeld",
-        "published_date": "2017-05-10",
+        "published_date": "2017-05-09",
         "youtube_link": "https://www.youtube.com/watch?v=pw2A03Z91FI",
         "official_link": "https://www.babi.sh/recipes/babka-inspired-by-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp"
@@ -13876,7 +13788,7 @@
       {
         "episode_id": "cubanos-inspired-by-chef",
         "name": "Cubanos inspired by Chef",
-        "published_date": "2017-03-29",
+        "published_date": "2017-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=hXYoduN0kWs",
         "official_link": "https://www.babi.sh/recipes/cubanos-inspired-by-chef",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992067/etfzgspqjiwp3janr32z.webp"
@@ -14305,7 +14217,7 @@
       },
       {
         "episode_id": "classic-fettucine-alfredo",
-        "name": "Classic Fettucine Alfredo",
+        "name": "Classic Fettuccine Alfredo",
         "published_date": "2025-06-06",
         "youtube_link": "https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo",
         "official_link": "https://www.babi.sh/recipes/classic-fettucine-alfredo",
@@ -14542,20 +14454,20 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690352611/ymqv7knnlfkyzfjyrgnt.webp"
       },
       {
-        "episode_id": "carnitas",
-        "name": "CARNITAS",
-        "published_date": "2023-05-12",
-        "youtube_link": "https://www.youtube.com/watch?v=FEZioC-qMd4",
-        "official_link": "https://www.babi.sh/recipes/carnitas",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690352698/ldnpp7ukrrvaiormf4ux.webp"
-      },
-      {
         "episode_id": "barbacoa-de-res",
-        "name": "BARBACOA DE RES CON CONSOM\u00c9",
+        "name": "Barbacoa Tacos and Gringas de Barbacoa with Consom\u00e9 | Pru\u00e9balo with Rick Martinez",
         "published_date": "2023-05-05",
         "youtube_link": "https://www.youtube.com/watch?v=Ya5u2uC3d2U",
         "official_link": "https://www.babi.sh/recipes/barbacoa-de-res",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690352793/xdxptaqk0rq7blwpqbre.webp"
+      },
+      {
+        "episode_id": "carnitas",
+        "name": "Easy Carnitas",
+        "published_date": "2023-05-02",
+        "youtube_link": "https://www.youtube.com/watch?v=FEZioC-qMd4",
+        "official_link": "https://www.babi.sh/recipes/carnitas",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690352698/ldnpp7ukrrvaiormf4ux.webp"
       },
       {
         "episode_id": "ultimate-cookie",
@@ -14584,7 +14496,7 @@
       {
         "episode_id": "beer-can-chicken",
         "name": "BEER CAN CHICKEN",
-        "published_date": "2022-12-19",
+        "published_date": "2022-12-18",
         "youtube_link": "https://www.youtube.com/watch?v=Xo0v7ZuA9C0",
         "official_link": "https://www.babi.sh/recipes/beer-can-chicken",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png"
@@ -14687,7 +14599,7 @@
       },
       {
         "episode_id": "corned-beef",
-        "name": "CORNED BEEF",
+        "name": "Corned Beef",
         "published_date": "2022-03-17",
         "youtube_link": "https://www.youtube.com/watch?v=IDkuwVvZpWM",
         "official_link": "https://www.babi.sh/recipes/corned-beef",
@@ -14695,7 +14607,7 @@
       },
       {
         "episode_id": "chicken-piccata",
-        "name": "CHICKEN PICCATA",
+        "name": "Chicken Piccata",
         "published_date": "2022-02-18",
         "youtube_link": "https://www.youtube.com/watch?v=ZqEqtmMY1M0",
         "official_link": "https://www.babi.sh/recipes/chicken-piccata",
@@ -14767,19 +14679,11 @@
       },
       {
         "episode_id": "apple-cider-donuts",
-        "name": "APPLE CIDER DONUTS",
+        "name": "Apple Cider Donuts",
         "published_date": "2021-11-09",
         "youtube_link": "https://www.youtube.com/watch?v=baZoJYAQjfI",
         "official_link": "https://www.babi.sh/recipes/apple-cider-donuts",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695695/babishImages/undefined-628666.png"
-      },
-      {
-        "episode_id": "cake-pops",
-        "name": "CAKE POPS",
-        "published_date": "2021-11-02",
-        "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
-        "official_link": "https://www.babi.sh/recipes/cake-pops",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
       },
       {
         "episode_id": "poke-bowls",
@@ -14788,6 +14692,14 @@
         "youtube_link": "https://www.youtube.com/watch?v=l7VRSINAEQo",
         "official_link": "https://www.babi.sh/recipes/poke-bowls",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695359/babishImages/undefined-263359.png"
+      },
+      {
+        "episode_id": "cake-pops",
+        "name": "Cake Pops",
+        "published_date": "2021-10-21",
+        "youtube_link": "https://www.youtube.com/watch?v=C_hz9wzeBbY",
+        "official_link": "https://www.babi.sh/recipes/cake-pops",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png"
       },
       {
         "episode_id": "swedish-meatballs",
@@ -14807,7 +14719,7 @@
       },
       {
         "episode_id": "biscotti",
-        "name": "BISCOTTI",
+        "name": "Biscotti",
         "published_date": "2021-09-24",
         "youtube_link": "https://www.youtube.com/watch?v=g4EkzEKlGOA",
         "official_link": "https://www.babi.sh/recipes/biscotti",
@@ -14815,7 +14727,7 @@
       },
       {
         "episode_id": "calistyle-burrito",
-        "name": "CALI-STYLE BURRITO",
+        "name": "California Style Burritos",
         "published_date": "2021-09-13",
         "youtube_link": "https://www.youtube.com/watch?v=55YUKZK7BXg",
         "official_link": "https://www.babi.sh/recipes/calistyle-burrito",
@@ -14831,7 +14743,7 @@
       },
       {
         "episode_id": "chiles-rellenos",
-        "name": "CHILES RELLENOS",
+        "name": "Chiles Rellenos",
         "published_date": "2021-08-26",
         "youtube_link": "https://www.youtube.com/watch?v=gAKW8RB6aeU",
         "official_link": "https://www.babi.sh/recipes/chiles-rellenos",
@@ -14919,7 +14831,7 @@
       },
       {
         "episode_id": "corn-dogs",
-        "name": "CORN DOGS",
+        "name": "Corn Dogs",
         "published_date": "2021-05-27",
         "youtube_link": "https://www.youtube.com/watch?v=zGT45vVJNso",
         "official_link": "https://www.babi.sh/recipes/corn-dogs",
@@ -14951,7 +14863,7 @@
       },
       {
         "episode_id": "bacon",
-        "name": "HOMEMADE BACON",
+        "name": "Homemade Bacon",
         "published_date": "2021-04-30",
         "youtube_link": "https://www.youtube.com/watch?v=TUh4Z2li1UM",
         "official_link": "https://www.babi.sh/recipes/bacon",
@@ -14967,7 +14879,7 @@
       },
       {
         "episode_id": "creme-caramel",
-        "name": "CR\u00c8ME CARAMEL",
+        "name": "Cr\u00e8me Caramel",
         "published_date": "2021-04-08",
         "youtube_link": "https://www.youtube.com/watch?v=ihS8__strtM",
         "official_link": "https://www.babi.sh/recipes/creme-caramel",
@@ -14999,7 +14911,7 @@
       },
       {
         "episode_id": "birria-tacos",
-        "name": "BIRRIA TACOS",
+        "name": "Birria Tacos",
         "published_date": "2021-03-11",
         "youtube_link": "https://www.youtube.com/watch?v=pQmSrlIbULk",
         "official_link": "https://www.babi.sh/recipes/birria-tacos",
@@ -15007,7 +14919,7 @@
       },
       {
         "episode_id": "biscuits-and-gravy",
-        "name": "BISCUITS AND GRAVY",
+        "name": "Biscuits & Gravy",
         "published_date": "2021-02-25",
         "youtube_link": "https://www.youtube.com/watch?v=NMbMT9tY8-Q",
         "official_link": "https://www.babi.sh/recipes/biscuits-and-gravy",
@@ -15015,7 +14927,7 @@
       },
       {
         "episode_id": "advanced-grilled-cheese",
-        "name": "ADVANCED GRILLED CHEESE",
+        "name": "Advanced Grilled Cheese",
         "published_date": "2021-02-19",
         "youtube_link": "https://www.youtube.com/watch?v=Zo7sRijXG00",
         "official_link": "https://www.babi.sh/recipes/advanced-grilled-cheese",
@@ -15079,7 +14991,7 @@
       },
       {
         "episode_id": "chicken-parmesan",
-        "name": "CHICKEN PARMESAN",
+        "name": "Chicken Parmesan",
         "published_date": "2020-12-10",
         "youtube_link": "https://www.youtube.com/watch?v=ZrR0VbqNdW8",
         "official_link": "https://www.babi.sh/recipes/chicken-parmesan",
@@ -15103,7 +15015,7 @@
       },
       {
         "episode_id": "andrewsohlathanksgiving",
-        "name": "ANDREW & SOHLA THANKSGIVING RECIPES",
+        "name": "Thanksgiving Recipe Livestream with Sohla El-Waylly",
         "published_date": "2020-11-20",
         "youtube_link": "https://www.youtube.com/watch?v=tXNuz8nXYGk",
         "official_link": "https://www.babi.sh/recipes/andrewsohlathanksgiving",
@@ -15191,7 +15103,7 @@
       },
       {
         "episode_id": "cheese-fondue",
-        "name": "CHEEESE FONDUE",
+        "name": "Cheese Fondue",
         "published_date": "2020-07-23",
         "youtube_link": "https://www.youtube.com/watch?v=_X-Mm8h1AHM",
         "official_link": "https://www.babi.sh/recipes/cheese-fondue",
@@ -15271,7 +15183,7 @@
       },
       {
         "episode_id": "chimichangas",
-        "name": "CHIMICHANGAS",
+        "name": "Deadpool's Chimichangas",
         "published_date": "2020-04-28",
         "youtube_link": "https://www.youtube.com/watch?v=szFLA4_pwew",
         "official_link": "https://www.babi.sh/recipes/chimichangas",
@@ -15415,7 +15327,7 @@
       },
       {
         "episode_id": "cajunfood",
-        "name": "CAJUN FOOD",
+        "name": "Cajun Food",
         "published_date": "2019-09-13",
         "youtube_link": "https://www.youtube.com/watch?v=nORg_aXMsmA",
         "official_link": "https://www.babi.sh/recipes/cajunfood",
@@ -15487,7 +15399,7 @@
       },
       {
         "episode_id": "cheesdips",
-        "name": "CHEESE DIPS",
+        "name": "Cheese Dips",
         "published_date": "2019-05-02",
         "youtube_link": "https://www.youtube.com/watch?v=9toK5UUGeok",
         "official_link": "https://www.babi.sh/recipes/cheesdips",
@@ -15503,7 +15415,7 @@
       },
       {
         "episode_id": "chickentikkamasala",
-        "name": "CHICKEN TIKKA MASALA",
+        "name": "Chicken Tikka Masala",
         "published_date": "2019-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=Bkd0LxBd2L8",
         "official_link": "https://www.babi.sh/recipes/chickentikkamasala",
@@ -15511,7 +15423,7 @@
       },
       {
         "episode_id": "blendersoups",
-        "name": "BLENDER SOUPS",
+        "name": "Blender Soups",
         "published_date": "2019-03-05",
         "youtube_link": "https://www.youtube.com/watch?v=S-gUFvpRQoU",
         "official_link": "https://www.babi.sh/recipes/blendersoups",
@@ -15527,7 +15439,7 @@
       },
       {
         "episode_id": "biggamesnacks",
-        "name": "BIG GAME SNACKS",
+        "name": "Big Game Snacks",
         "published_date": "2019-01-31",
         "youtube_link": "https://www.youtube.com/watch?v=8ckxhlDFNkg",
         "official_link": "https://www.babi.sh/recipes/biggamesnacks",
@@ -15535,7 +15447,7 @@
       },
       {
         "episode_id": "bagels",
-        "name": "BAGELS",
+        "name": "Bagels",
         "published_date": "2019-01-24",
         "youtube_link": "https://www.youtube.com/watch?v=ZrJtpCTZk38",
         "official_link": "https://www.babi.sh/recipes/bagels",
@@ -15663,7 +15575,7 @@
       },
       {
         "episode_id": "barbecueporkchops",
-        "name": "BARBECUE PORK CHOPS",
+        "name": "Barbecue Pork Chops",
         "published_date": "2018-06-28",
         "youtube_link": "https://www.youtube.com/watch?v=YV9XuvfIudY",
         "official_link": "https://www.babi.sh/recipes/barbecueporkchops",
@@ -15671,7 +15583,7 @@
       },
       {
         "episode_id": "burgers",
-        "name": "BURGERS",
+        "name": "Burgers",
         "published_date": "2018-06-14",
         "youtube_link": "https://www.youtube.com/watch?v=nbCgfiqq-5c",
         "official_link": "https://www.babi.sh/recipes/burgers",
@@ -15713,15 +15625,15 @@
         "episode_id": "baressentials-7xwwz",
         "name": "CHOCOLATE CHIP COOKIES",
         "published_date": "2018-03-29",
-        "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/ylxzfecackM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM",
         "official_link": "https://www.babi.sh/recipes/baressentials-7xwwz",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690485488/p72d0navvupz8bsaur3g.webp"
       },
       {
         "episode_id": "baressentials",
-        "name": "BAR ESSENTIALS",
+        "name": "Bar Essentials",
         "published_date": "2018-03-15",
-        "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/iZUfPIKbgUM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=iZUfPIKbgUM",
         "official_link": "https://www.babi.sh/recipes/baressentials",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690416607/jlnnbuig1g2nrqafs58x.webp"
       },
@@ -16295,18 +16207,10 @@
       {
         "episode_id": "churrons-broad-city",
         "name": "Churrons inspired by Broad City",
-        "published_date": "2022-08-17",
+        "published_date": "2022-08-03",
         "youtube_link": "https://www.youtube.com/watch?v=JiUsCTy8nEY",
         "official_link": "https://www.babi.sh/recipes/churrons-broad-city",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695905/babishImages/undefined-290140.png"
-      },
-      {
-        "episode_id": "chocolate-croissants-its-complicated",
-        "name": "Chocolate Croissants inspired by It's Complicated",
-        "published_date": "2022-08-01",
-        "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
-        "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png"
       },
       {
         "episode_id": "lobster-scrambled-eggs-seinfeld",
@@ -16315,6 +16219,14 @@
         "youtube_link": "https://www.youtube.com/watch?v=71jrAWaRc3E",
         "official_link": "https://www.babi.sh/recipes/lobster-scrambled-eggs-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695727/babishImages/undefined-436056.png"
+      },
+      {
+        "episode_id": "chocolate-croissants-its-complicated",
+        "name": "Chocolate Croissants inspired by It's Complicated",
+        "published_date": "2022-07-13",
+        "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
+        "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png"
       },
       {
         "episode_id": "bobbys-cookies-king-of-the-hill",
@@ -16343,7 +16255,7 @@
       {
         "episode_id": "crab-bisque-seinfeld",
         "name": "Crab Bisque inspired by Seinfeld",
-        "published_date": "2022-05-27",
+        "published_date": "2022-05-24",
         "youtube_link": "https://www.youtube.com/watch?v=5kKMB890ABc",
         "official_link": "https://www.babi.sh/recipes/crab-bisque-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695634/babishImages/undefined-585834.png"
@@ -16687,7 +16599,7 @@
       {
         "episode_id": "chefs-choice-platter-monster-hunter-world",
         "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-        "published_date": "2021-03-31",
+        "published_date": "2021-03-30",
         "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
         "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png"
@@ -17054,7 +16966,7 @@
       },
       {
         "episode_id": "ben-wyatt-calzones",
-        "name": "Calzones inspired by Parks & Rec",
+        "name": "Ben Wyatt's Calzones",
         "published_date": "2020-04-15",
         "youtube_link": "https://www.youtube.com/watch?v=PvgCEifW7Jo",
         "official_link": "https://www.babi.sh/recipes/ben-wyatt-calzones",
@@ -17184,7 +17096,7 @@
         "episode_id": "beer-steamed-chili-dogs",
         "name": "Chili Dogs inspired by The Irishman",
         "published_date": "2019-12-17",
-        "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/c0A1bkF4mKM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM",
         "official_link": "https://www.babi.sh/recipes/beer-steamed-chili-dogs",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695792/babishImages/undefined-202970.png"
       },
@@ -17247,8 +17159,8 @@
       {
         "episode_id": "crepessuzette",
         "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-        "published_date": "2019-10-24",
-        "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "published_date": "2019-10-22",
+        "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
         "official_link": "https://www.babi.sh/recipes/crepessuzette",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png"
       },
@@ -17280,7 +17192,7 @@
         "episode_id": "coffeejelly",
         "name": "Coffee Jelly inspired by The Disastrous Life of Saiki K.",
         "published_date": "2019-09-24",
-        "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YxEcd_wTf5c/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c",
         "official_link": "https://www.babi.sh/recipes/coffeejelly",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png"
       },
@@ -17304,7 +17216,7 @@
         "episode_id": "applefritters",
         "name": "Double-Glazed Apple Fritters inspired by Regular Show",
         "published_date": "2019-08-27",
-        "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YYSP1D6GJ30/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30",
         "official_link": "https://www.babi.sh/recipes/applefritters",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695467/babishImages/undefined-689012.png"
       },
@@ -17352,7 +17264,7 @@
         "episode_id": "bagelsandwiches",
         "name": "Bagel Sandwiches inspired by Steven Universe",
         "published_date": "2019-07-23",
-        "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
         "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png"
       },
@@ -17392,7 +17304,7 @@
         "episode_id": "alwayssunny",
         "name": "It's Always Sunny in Philadelphia Special (Part II)",
         "published_date": "2019-06-12",
-        "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/_fnhy5xO9vQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ",
         "official_link": "https://www.babi.sh/recipes/alwayssunny",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696347/babishImages/undefined-129032.png"
       },
@@ -17440,7 +17352,7 @@
         "episode_id": "avengersicecream",
         "name": "Ice Cream Flavors inspired by Avengers: Infinity War",
         "published_date": "2019-04-30",
-        "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Ukjat70Iyt4/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4",
         "official_link": "https://www.babi.sh/recipes/avengersicecream",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695805/babishImages/undefined-987247.png"
       },
@@ -17448,7 +17360,7 @@
         "episode_id": "bubbashrimp2",
         "name": "Shrimp inspired by Forrest Gump Part II",
         "published_date": "2019-04-23",
-        "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/mF6JUfczaO8/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8",
         "official_link": "https://www.babi.sh/recipes/bubbashrimp2",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696055/babishImages/undefined-252668.png"
       },
@@ -17472,7 +17384,7 @@
         "episode_id": "brocksdonuts",
         "name": "Brock's Donuts inspired by Pok\u00e9mon",
         "published_date": "2019-04-02",
-        "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/RentKWlhUXc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc",
         "official_link": "https://www.babi.sh/recipes/brocksdonuts",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695178/babishImages/undefined-56205.png"
       },
@@ -17520,7 +17432,7 @@
         "episode_id": "baobuns",
         "name": "Bao inspired by Pixar's Bao",
         "published_date": "2019-02-19",
-        "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M&amp;t=46s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/OFt3SThGi7M/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M",
         "official_link": "https://www.babi.sh/recipes/baobuns",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695380/babishImages/undefined-293013.png"
       },
@@ -17552,7 +17464,7 @@
         "episode_id": "aristocats",
         "name": "Cr\u00e8me de la Cr\u00e8me \u00e0 la Edgar inspired by The Aristocats",
         "published_date": "2019-01-23",
-        "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/zNY-qzp7pD0/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0",
         "official_link": "https://www.babi.sh/recipes/aristocats",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696317/babishImages/undefined-541474.png"
       },
@@ -17560,7 +17472,7 @@
         "episode_id": "coqauvin",
         "name": "Coq au Vin inspired by Donnie Brasco",
         "published_date": "2019-01-15",
-        "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/VP1uTgikarU/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU",
         "official_link": "https://www.babi.sh/recipes/coqauvin",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695986/babishImages/undefined-867897.png"
       },
@@ -17616,7 +17528,7 @@
         "episode_id": "chileanseabass",
         "name": "Chilean Sea Bass inspired by Jurassic Park",
         "published_date": "2018-11-27",
-        "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/p73kqpqGqqQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ",
         "official_link": "https://www.babi.sh/recipes/chileanseabass",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695721/babishImages/undefined-408439.png"
       },
@@ -17624,7 +17536,7 @@
         "episode_id": "charliebrownthanksgiving",
         "name": "Charlie Brown Thanksgiving",
         "published_date": "2018-11-20",
-        "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5FyKxVJmsdE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE",
         "official_link": "https://www.babi.sh/recipes/charliebrownthanksgiving",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg"
       },
@@ -17640,7 +17552,7 @@
         "episode_id": "bearstew",
         "name": "Bear Stew inspired by Red Dead Redemption 2",
         "published_date": "2018-11-06",
-        "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wMxKbkWrvDc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc",
         "official_link": "https://www.babi.sh/recipes/bearstew",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679263840/iyxpvkao4lwi6xqkcwd1.webp"
       },
@@ -17656,7 +17568,7 @@
         "episode_id": "cinnamonrolls",
         "name": "Cinnamon Rolls inspired by Jim Gaffigan's Stand Up (sort of)",
         "published_date": "2018-10-23",
-        "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/jFYi2QRVFOc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc",
         "official_link": "https://www.babi.sh/recipes/cinnamonrolls",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679245506/gyb4qsztcyrv4kjnvwug.webp"
       },
@@ -17899,14 +17811,6 @@
         "youtube_link": "https://www.youtube.com/watch?v=dn_aaxZIA2o",
         "official_link": "https://www.babi.sh/recipes/cremebrule",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681715756/babishImages/undefined-451881.png"
-      },
-      {
-        "episode_id": "baressentials-7xwwz",
-        "name": "CHOCOLATE CHIP COOKIES",
-        "published_date": "2018-03-29",
-        "youtube_link": "https://www.youtube.com/watch?v=ylxzfecackM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/ylxzfecackM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
-        "official_link": "https://www.babi.sh/recipes/baressentials-7xwwz",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1690485488/p72d0navvupz8bsaur3g.webp"
       },
       {
         "episode_id": "lasagna",
@@ -18223,7 +18127,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -18287,7 +18191,7 @@
       {
         "episode_id": "babka-inspired-by-seinfeld",
         "name": "Babka inspired by Seinfeld",
-        "published_date": "2017-05-10",
+        "published_date": "2017-05-09",
         "youtube_link": "https://www.youtube.com/watch?v=pw2A03Z91FI",
         "official_link": "https://www.babi.sh/recipes/babka-inspired-by-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp"
@@ -18343,7 +18247,7 @@
       {
         "episode_id": "cubanos-inspired-by-chef",
         "name": "Cubanos inspired by Chef",
-        "published_date": "2017-03-29",
+        "published_date": "2017-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=hXYoduN0kWs",
         "official_link": "https://www.babi.sh/recipes/cubanos-inspired-by-chef",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992067/etfzgspqjiwp3janr32z.webp"
@@ -18659,7 +18563,7 @@
     "episodes": [
       {
         "episode_id": "10-levels-of-cheesesteak",
-        "name": "10 Levels of Cheesesteak",
+        "name": "10 Levels of Philly Cheesesteak",
         "published_date": "2026-04-30",
         "youtube_link": "https://www.youtube.com/watch?v=jNan4FWeQEE",
         "official_link": "https://www.babi.sh/recipes/10-levels-of-cheesesteak",
@@ -18667,7 +18571,7 @@
       },
       {
         "episode_id": "10-levels-chicken-noodle-soup",
-        "name": "10 Levels Chicken Noodle Soup",
+        "name": "10 Levels of Chicken Noodle Soup",
         "published_date": "2026-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s",
         "official_link": "https://www.babi.sh/recipes/10-levels-chicken-noodle-soup",
@@ -18683,7 +18587,7 @@
       },
       {
         "episode_id": "5-levels-of-spaghetti-or-with-babish",
-        "name": "5 Levels of Spaghetti | With Babish",
+        "name": "$1 to $100 Spaghetti (5 Levels) | With Babish",
         "published_date": "2026-01-30",
         "youtube_link": "https://www.youtube.com/watch?v=FeWVA2tp9YI",
         "official_link": "https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish",
@@ -18706,20 +18610,20 @@
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768506428/gryanukvd2zeutfh9ibh.webp"
       },
       {
-        "episode_id": "beef-wellington-or-with-babish",
-        "name": "Beef Wellington | With Babish",
-        "published_date": "2026-01-14",
-        "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
-        "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
-      },
-      {
         "episode_id": "the-ultimate-marry-me-meals",
         "name": "The Ultimate Marry-Me Meals",
         "published_date": "2026-01-06",
         "youtube_link": "https://www.youtube.com/watch?v=TggSdedcLJo",
         "official_link": "https://www.babi.sh/recipes/the-ultimate-marry-me-meals",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1767735831/qh0bt5mllxrxbi4kvgsb.webp"
+      },
+      {
+        "episode_id": "beef-wellington-or-with-babish",
+        "name": "$20 vs $200 Beef Wellington | With Babish",
+        "published_date": "2025-12-23",
+        "youtube_link": "https://www.youtube.com/watch?v=A-Qb0ExQc-I",
+        "official_link": "https://www.babi.sh/recipes/beef-wellington-or-with-babish",
+        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp"
       },
       {
         "episode_id": "level-9:-babish's-pbandj",
@@ -18732,7 +18636,7 @@
       {
         "episode_id": "christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
         "name": "Christmas Turkey inspired by National Lampoon's Christmas Vacation",
-        "published_date": "2025-11-26",
+        "published_date": "2025-11-29",
         "youtube_link": "https://youtube.com/watch?v=w0pZ7MWajW8&si=r2TmnS9oJhDHIbp5",
         "official_link": "https://www.babi.sh/recipes/christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1764189007/giyklwlgdj7x3nwbi38c.webp"
@@ -19084,7 +18988,7 @@
         "episode_id": "coffeejelly",
         "name": "Coffee Jelly inspired by The Disastrous Life of Saiki K.",
         "published_date": "2019-09-24",
-        "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YxEcd_wTf5c/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=YxEcd_wTf5c",
         "official_link": "https://www.babi.sh/recipes/coffeejelly",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png"
       },
@@ -19130,7 +19034,7 @@
       {
         "episode_id": "christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
         "name": "Christmas Turkey inspired by National Lampoon's Christmas Vacation",
-        "published_date": "2025-11-26",
+        "published_date": "2025-11-29",
         "youtube_link": "https://youtube.com/watch?v=w0pZ7MWajW8&si=r2TmnS9oJhDHIbp5",
         "official_link": "https://www.babi.sh/recipes/christmas-turkey-inspired-by-national-lampoon's-christmas-vacation",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1764189007/giyklwlgdj7x3nwbi38c.webp"
@@ -19547,7 +19451,7 @@
         "episode_id": "beer-steamed-chili-dogs",
         "name": "Chili Dogs inspired by The Irishman",
         "published_date": "2019-12-17",
-        "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/c0A1bkF4mKM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=c0A1bkF4mKM",
         "official_link": "https://www.babi.sh/recipes/beer-steamed-chili-dogs",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695792/babishImages/undefined-202970.png"
       },
@@ -19562,8 +19466,8 @@
       {
         "episode_id": "crepessuzette",
         "name": "Cr\u00eapes Suzette inspired by Talladega Nights",
-        "published_date": "2019-10-24",
-        "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "published_date": "2019-10-22",
+        "youtube_link": "https://www.youtube.com/watch?v=Z1kR6SIr1XA",
         "official_link": "https://www.babi.sh/recipes/crepessuzette",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png"
       },
@@ -19627,7 +19531,7 @@
         "episode_id": "avengersicecream",
         "name": "Ice Cream Flavors inspired by Avengers: Infinity War",
         "published_date": "2019-04-30",
-        "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Ukjat70Iyt4/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=Ukjat70Iyt4",
         "official_link": "https://www.babi.sh/recipes/avengersicecream",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695805/babishImages/undefined-987247.png"
       },
@@ -19635,7 +19539,7 @@
         "episode_id": "bubbashrimp2",
         "name": "Shrimp inspired by Forrest Gump Part II",
         "published_date": "2019-04-23",
-        "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/mF6JUfczaO8/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=mF6JUfczaO8",
         "official_link": "https://www.babi.sh/recipes/bubbashrimp2",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696055/babishImages/undefined-252668.png"
       },
@@ -19643,7 +19547,7 @@
         "episode_id": "baobuns",
         "name": "Bao inspired by Pixar's Bao",
         "published_date": "2019-02-19",
-        "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M&amp;t=46s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/OFt3SThGi7M/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=OFt3SThGi7M",
         "official_link": "https://www.babi.sh/recipes/baobuns",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695380/babishImages/undefined-293013.png"
       },
@@ -19651,7 +19555,7 @@
         "episode_id": "aristocats",
         "name": "Cr\u00e8me de la Cr\u00e8me \u00e0 la Edgar inspired by The Aristocats",
         "published_date": "2019-01-23",
-        "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/zNY-qzp7pD0/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=zNY-qzp7pD0",
         "official_link": "https://www.babi.sh/recipes/aristocats",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696317/babishImages/undefined-541474.png"
       },
@@ -19659,7 +19563,7 @@
         "episode_id": "coqauvin",
         "name": "Coq au Vin inspired by Donnie Brasco",
         "published_date": "2019-01-15",
-        "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/VP1uTgikarU/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=VP1uTgikarU",
         "official_link": "https://www.babi.sh/recipes/coqauvin",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695986/babishImages/undefined-867897.png"
       },
@@ -19683,7 +19587,7 @@
         "episode_id": "chileanseabass",
         "name": "Chilean Sea Bass inspired by Jurassic Park",
         "published_date": "2018-11-27",
-        "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/p73kqpqGqqQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=p73kqpqGqqQ",
         "official_link": "https://www.babi.sh/recipes/chileanseabass",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695721/babishImages/undefined-408439.png"
       },
@@ -19890,7 +19794,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -19914,7 +19818,7 @@
       {
         "episode_id": "cubanos-inspired-by-chef",
         "name": "Cubanos inspired by Chef",
-        "published_date": "2017-03-29",
+        "published_date": "2017-03-28",
         "youtube_link": "https://www.youtube.com/watch?v=hXYoduN0kWs",
         "official_link": "https://www.babi.sh/recipes/cubanos-inspired-by-chef",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689992067/etfzgspqjiwp3janr32z.webp"
@@ -20329,18 +20233,10 @@
       {
         "episode_id": "churrons-broad-city",
         "name": "Churrons inspired by Broad City",
-        "published_date": "2022-08-17",
+        "published_date": "2022-08-03",
         "youtube_link": "https://www.youtube.com/watch?v=JiUsCTy8nEY",
         "official_link": "https://www.babi.sh/recipes/churrons-broad-city",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695905/babishImages/undefined-290140.png"
-      },
-      {
-        "episode_id": "chocolate-croissants-its-complicated",
-        "name": "Chocolate Croissants inspired by It's Complicated",
-        "published_date": "2022-08-01",
-        "youtube_link": "https://www.youtube.com/watch?v=qvNXPn4ptJM",
-        "official_link": "https://www.babi.sh/recipes/chocolate-croissants-its-complicated",
-        "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png"
       },
       {
         "episode_id": "lobster-scrambled-eggs-seinfeld",
@@ -20369,7 +20265,7 @@
       {
         "episode_id": "crab-bisque-seinfeld",
         "name": "Crab Bisque inspired by Seinfeld",
-        "published_date": "2022-05-27",
+        "published_date": "2022-05-24",
         "youtube_link": "https://www.youtube.com/watch?v=5kKMB890ABc",
         "official_link": "https://www.babi.sh/recipes/crab-bisque-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695634/babishImages/undefined-585834.png"
@@ -20832,7 +20728,7 @@
       },
       {
         "episode_id": "ben-wyatt-calzones",
-        "name": "Calzones inspired by Parks & Rec",
+        "name": "Ben Wyatt's Calzones",
         "published_date": "2020-04-15",
         "youtube_link": "https://www.youtube.com/watch?v=PvgCEifW7Jo",
         "official_link": "https://www.babi.sh/recipes/ben-wyatt-calzones",
@@ -20978,7 +20874,7 @@
         "episode_id": "applefritters",
         "name": "Double-Glazed Apple Fritters inspired by Regular Show",
         "published_date": "2019-08-27",
-        "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YYSP1D6GJ30/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=YYSP1D6GJ30",
         "official_link": "https://www.babi.sh/recipes/applefritters",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695467/babishImages/undefined-689012.png"
       },
@@ -20994,7 +20890,7 @@
         "episode_id": "bagelsandwiches",
         "name": "Bagel Sandwiches inspired by Steven Universe",
         "published_date": "2019-07-23",
-        "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=wv43IN_cnyw",
         "official_link": "https://www.babi.sh/recipes/bagelsandwiches",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png"
       },
@@ -21026,7 +20922,7 @@
         "episode_id": "alwayssunny",
         "name": "It's Always Sunny in Philadelphia Special (Part II)",
         "published_date": "2019-06-12",
-        "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/_fnhy5xO9vQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=_fnhy5xO9vQ",
         "official_link": "https://www.babi.sh/recipes/alwayssunny",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696347/babishImages/undefined-129032.png"
       },
@@ -21074,7 +20970,7 @@
         "episode_id": "brocksdonuts",
         "name": "Brock's Donuts inspired by Pok\u00e9mon",
         "published_date": "2019-04-02",
-        "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/RentKWlhUXc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=RentKWlhUXc",
         "official_link": "https://www.babi.sh/recipes/brocksdonuts",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681695178/babishImages/undefined-56205.png"
       },
@@ -21170,7 +21066,7 @@
         "episode_id": "charliebrownthanksgiving",
         "name": "Charlie Brown Thanksgiving",
         "published_date": "2018-11-20",
-        "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5FyKxVJmsdE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=5FyKxVJmsdE",
         "official_link": "https://www.babi.sh/recipes/charliebrownthanksgiving",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg"
       },
@@ -21194,7 +21090,7 @@
         "episode_id": "cinnamonrolls",
         "name": "Cinnamon Rolls inspired by Jim Gaffigan's Stand Up (sort of)",
         "published_date": "2018-10-23",
-        "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/jFYi2QRVFOc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=jFYi2QRVFOc",
         "official_link": "https://www.babi.sh/recipes/cinnamonrolls",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679245506/gyb4qsztcyrv4kjnvwug.webp"
       },
@@ -21497,7 +21393,7 @@
       {
         "episode_id": "cocktail-special",
         "name": "Cocktail Special",
-        "published_date": "2017-06-28",
+        "published_date": "2017-06-27",
         "youtube_link": "https://www.youtube.com/watch?v=v5tJBLfeurU",
         "official_link": "https://www.babi.sh/recipes/cocktail-special",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp"
@@ -21561,7 +21457,7 @@
       {
         "episode_id": "babka-inspired-by-seinfeld",
         "name": "Babka inspired by Seinfeld",
-        "published_date": "2017-05-10",
+        "published_date": "2017-05-09",
         "youtube_link": "https://www.youtube.com/watch?v=pw2A03Z91FI",
         "official_link": "https://www.babi.sh/recipes/babka-inspired-by-seinfeld",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp"
@@ -21800,7 +21696,7 @@
       {
         "episode_id": "chefs-choice-platter-monster-hunter-world",
         "name": "The Chef's Choice Platter inspired by Monster Hunter: World",
-        "published_date": "2021-03-31",
+        "published_date": "2021-03-30",
         "youtube_link": "https://www.youtube.com/watch?v=__qtH1ly2Sg",
         "official_link": "https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png"
@@ -21849,7 +21745,7 @@
         "episode_id": "bearstew",
         "name": "Bear Stew inspired by Red Dead Redemption 2",
         "published_date": "2018-11-06",
-        "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wMxKbkWrvDc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;",
+        "youtube_link": "https://www.youtube.com/watch?v=wMxKbkWrvDc",
         "official_link": "https://www.babi.sh/recipes/bearstew",
         "image_link": "https://res.cloudinary.com/dd27yihoo/image/upload/v1679263840/iyxpvkao4lwi6xqkcwd1.webp"
       },

--- a/ibdb/db_dump.sql
+++ b/ibdb/db_dump.sql
@@ -298,8 +298,8 @@ COPY public.alembic_version (version_num) FROM stdin;
 --
 
 COPY public.episode (id, name, slug, youtube_link, official_link, image_link, published_date, time_to_cook, yield_qty, yield_unit) FROM stdin;
-10-levels-chicken-noodle-soup	10 Levels Chicken Noodle Soup	10-levels-chicken-noodle-soup	https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s	https://www.babi.sh/recipes/10-levels-chicken-noodle-soup	https://res.cloudinary.com/dd27yihoo/image/upload/v1774738409/btugut1heyus4wsry467.webp	2026-03-28	2700	\N	\N
-10-levels-of-cheesesteak	10 Levels of Cheesesteak	10-levels-of-cheesesteak	https://www.youtube.com/watch?v=jNan4FWeQEE	https://www.babi.sh/recipes/10-levels-of-cheesesteak	https://res.cloudinary.com/dd27yihoo/image/upload/v1777507861/icg9k8c02j1h9nfo5qb7.webp	2026-04-30	5400	2	servings
+10-levels-chicken-noodle-soup	10 Levels of Chicken Noodle Soup	10-levels-chicken-noodle-soup	https://www.youtube.com/watch?v=EM_ptn24MUs&t=83s	https://www.babi.sh/recipes/10-levels-chicken-noodle-soup	https://res.cloudinary.com/dd27yihoo/image/upload/v1774738409/btugut1heyus4wsry467.webp	2026-03-28	2700	\N	\N
+10-levels-of-cheesesteak	10 Levels of Philly Cheesesteak	10-levels-of-cheesesteak	https://www.youtube.com/watch?v=jNan4FWeQEE	https://www.babi.sh/recipes/10-levels-of-cheesesteak	https://res.cloudinary.com/dd27yihoo/image/upload/v1777507861/icg9k8c02j1h9nfo5qb7.webp	2026-04-30	5400	2	servings
 10-levels-of-chocolate-chip-cookies-or-with-babish	10 Levels of Chocolate Chip Cookies | With Babish	10-levels-of-chocolate-chip-cookies-or-with-babish	https://www.youtube.com/watch?v=dzw6JO-yz34&pp=ygUTYmluZ2luZyB3aXRoIGJhYmlzaA%3D%3D	https://www.babi.sh/recipes/10-levels-of-chocolate-chip-cookies-or-with-babish	https://res.cloudinary.com/dd27yihoo/image/upload/v1761497423/go8m6uokvxy6qiayhnst.webp	2025-10-25	172800	\N	\N
 10-levels-of-mac-and-cheese	10 Levels of Mac and Cheese	10-levels-of-mac-and-cheese	https://youtube.com/watch?v=XpL2ZyyF55U&si=Ji3keCq-hmDoiCDS	https://www.babi.sh/recipes/10-levels-of-mac-and-cheese	https://res.cloudinary.com/dd27yihoo/image/upload/v1758370413/qtua6ccyjtklttjssedd.webp	2025-09-20	2700	5	servings
 18-pound-giant-fried-chicken-bowl	18 Pound Giant Fried Chicken Bowl	18-pound-giant-fried-chicken-bowl	https://www.youtube.com/watch?v=WM2d4JGynXc	https://www.babi.sh/recipes/18-pound-giant-fried-chicken-bowl	https://res.cloudinary.com/dd27yihoo/image/upload/v1754941912/nm2jss7wgfnfnv7bs3oo.webp	2025-08-11	5400	\N	\N
@@ -309,76 +309,76 @@ COPY public.episode (id, name, slug, youtube_link, official_link, image_link, pu
 324-layer-croissant-inspired-by-yakitate!!-japan	324 Layer Croissant inspired by Yakitate!! Japan	324-layer-croissant-inspired-by-yakitate!!-japan	https://www.youtube.com/watch?v=Ni8BsXyln_Q	https://www.babi.sh/recipes/324-layer-croissant-inspired-by-yakitate!!-japan	https://res.cloudinary.com/dd27yihoo/image/upload/v1725483449/qdfiijvciz0hlmgz6qrs.webp	2024-09-04	\N	1	servings
 3daypotatosalad	3-Day Potato Salad inspired by SpongeBob SquarePants	3daypotatosalad	https://www.youtube.com/watch?v=5Ugrgl9tB2s&amp;t=138s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5Ugrgl9tB2s/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/3daypotatosalad	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695320/babishImages/undefined-635034.png	2018-12-04	8400	4	servings
 4-cheese-lasagna-inspired-by-one-piece	4-Cheese Lasagna inspired by One Piece	4-cheese-lasagna-inspired-by-one-piece	https://www.youtube.com/watch?v=5LNNcu-t5kE	https://www.babi.sh/recipes/4-cheese-lasagna-inspired-by-one-piece	https://res.cloudinary.com/dd27yihoo/image/upload/v1755010442/kum7nnwdyimfrjrzeslp.webp	2025-08-12	10500	8	servings
-5-levels-of-spaghetti-or-with-babish	5 Levels of Spaghetti | With Babish	5-levels-of-spaghetti-or-with-babish	https://www.youtube.com/watch?v=FeWVA2tp9YI	https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish	https://res.cloudinary.com/dd27yihoo/image/upload/v1769797846/qlt7lmqzvuonokq8elpd.webp	2026-01-30	\N	6	servings
+5-levels-of-spaghetti-or-with-babish	$1 to $100 Spaghetti (5 Levels) | With Babish	5-levels-of-spaghetti-or-with-babish	https://www.youtube.com/watch?v=FeWVA2tp9YI	https://www.babi.sh/recipes/5-levels-of-spaghetti-or-with-babish	https://res.cloudinary.com/dd27yihoo/image/upload/v1769797846/qlt7lmqzvuonokq8elpd.webp	2026-01-30	\N	6	servings
 5-weeknight-recipes-for-pork-tenderloin	5 Weeknight Recipes for Pork Tenderloin	5-weeknight-recipes-for-pork-tenderloin	https://www.youtube.com/watch?v=VEAmtpkxXXQ&t=21s	https://www.babi.sh/recipes/5-weeknight-recipes-for-pork-tenderloin	https://res.cloudinary.com/dd27yihoo/image/upload/v1744118544/yh4iqwlo6kyfxad3flzw.webp	2025-04-08	2700	2	servings
 5mill-special	5 Million Subscriber Special: Recreating Homer Simpson's NOLA Food Tour	5mill-special	https://www.youtube.com/watch?v=oM8c31ru92A	https://www.youtube.com/watch?v=oM8c31ru92A	https://img.youtube.com/vi/oM8c31ru92A/mqdefault.jpg	2019-09-10	\N	\N	\N
 a5-wagyu-roti-don-inspired-by-food-wars!	A5 Wagyu Roti Don inspired by Food Wars!	a5-wagyu-roti-don-inspired-by-food-wars!	https://www.youtube.com/watch?v=VzPJE4LUxC4	https://www.babi.sh/recipes/a5-wagyu-roti-don-inspired-by-food-wars!	https://res.cloudinary.com/dd27yihoo/image/upload/v1726150996/cqreovarq8cekj22lfnt.webp	2024-09-12	\N	4	servings
-advanced-grilled-cheese	ADVANCED GRILLED CHEESE	advanced-grilled-cheese	https://www.youtube.com/watch?v=Zo7sRijXG00	https://www.babi.sh/recipes/advanced-grilled-cheese	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695856/babishImages/undefined-814327.png	2021-02-19	1200	4	servings
+advanced-grilled-cheese	Advanced Grilled Cheese	advanced-grilled-cheese	https://www.youtube.com/watch?v=Zo7sRijXG00	https://www.babi.sh/recipes/advanced-grilled-cheese	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695856/babishImages/undefined-814327.png	2021-02-19	1200	4	servings
 adventure-time-sandwich	Jake's Perfect Sandwich inspired by Adventure Time	adventure-time-sandwich	https://www.youtube.com/watch?v=HsxBw6ls7Z0	https://www.babi.sh/recipes/adventure-time-sandwich	https://res.cloudinary.com/dd27yihoo/image/upload/v1689992084/uhxjz80nkxch8j3kezjh.webp	2017-03-18	\N	\N	\N
 adventuretimespecial	Adventure Time Special	adventuretimespecial	https://www.youtube.com/watch?v=SjeS6gtPq8E	https://www.babi.sh/recipes/adventuretimespecial	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715699/babishImages/undefined-467797.png	2018-09-11	\N	\N	\N
 aglioeolio	Pasta Aglio e Olio inspired by Chef	aglioeolio	https://www.youtube.com/watch?v=bJUiWdM__Qw	https://www.babi.sh/recipes/aglioeolio	https://res.cloudinary.com/dd27yihoo/image/upload/v1689991767/akppdskvenkgmu1djweh.webp	2016-03-26	\N	\N	\N
 agua-de-jamaica-granita	Agua de Jamaica Granita	agua-de-jamaica-granita	https://www.youtube.com/shorts/NYPxT4K-jEw	https://www.babi.sh/recipes/agua-de-jamaica-granita	https://res.cloudinary.com/dd27yihoo/image/upload/v1745960432/nlcsou9whnpdevviupw4.webp	2025-04-29	14400	7	servings
-alwayssunny	It's Always Sunny in Philadelphia Special (Part II)	alwayssunny	https://www.youtube.com/watch?v=_fnhy5xO9vQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/_fnhy5xO9vQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/alwayssunny	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696347/babishImages/undefined-129032.png	2019-06-12	6000	4	servings
+alwayssunny	It's Always Sunny in Philadelphia Special (Part II)	alwayssunny	https://www.youtube.com/watch?v=_fnhy5xO9vQ	https://www.babi.sh/recipes/alwayssunny	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696347/babishImages/undefined-129032.png	2019-06-12	6000	4	servings
 amatriciana-eat-pray-love	Spaghetti all'Amatriciana inspired by Eat Pray Love	amatriciana-eat-pray-love	https://www.youtube.com/watch?v=EZUnAQtF17I&feature=youtu.be	https://www.babi.sh/recipes/amatriciana-eat-pray-love	https://res.cloudinary.com/dd27yihoo/image/upload/v1680588204/n4ann1i8022pvhi7rx3k.webp	2023-03-03	\N	4	servings
-andrewsohlathanksgiving	ANDREW & SOHLA THANKSGIVING RECIPES	andrewsohlathanksgiving	https://www.youtube.com/watch?v=tXNuz8nXYGk	https://www.babi.sh/recipes/andrewsohlathanksgiving	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715526/babishImages/undefined-665559.jpg	2020-11-20	7200	8	servings
+andrewsohlathanksgiving	Thanksgiving Recipe Livestream with Sohla El-Waylly	andrewsohlathanksgiving	https://www.youtube.com/watch?v=tXNuz8nXYGk	https://www.babi.sh/recipes/andrewsohlathanksgiving	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715526/babishImages/undefined-665559.jpg	2020-11-20	7200	8	servings
 angel-food-cake-groundhog-day	Angel Food Cake inspired by Groundhog Day	angel-food-cake-groundhog-day	https://www.youtube.com/watch?v=2d6VmncdK-E	https://www.babi.sh/recipes/angel-food-cake-groundhog-day	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696190/babishImages/undefined-22599.png	2021-02-03	3600	7	servings
 apple-and-brie-galette	Apple and Brie Galette	apple-and-brie-galette	https://www.instagram.com/reel/DDxGLEJuMPd/?utm_source=ig_web_copy_link	https://www.babi.sh/recipes/apple-and-brie-galette	https://res.cloudinary.com/dd27yihoo/image/upload/v1734127645/lqkxpmzhdc9fruj6rwpf.webp	2024-12-13	3600	4	servings
-apple-cider-donuts	APPLE CIDER DONUTS	apple-cider-donuts	https://www.youtube.com/watch?v=baZoJYAQjfI	https://www.babi.sh/recipes/apple-cider-donuts	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695695/babishImages/undefined-628666.png	2021-11-09	8400	8	servings
+apple-cider-donuts	Apple Cider Donuts	apple-cider-donuts	https://www.youtube.com/watch?v=baZoJYAQjfI	https://www.babi.sh/recipes/apple-cider-donuts	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695695/babishImages/undefined-628666.png	2021-11-09	8400	8	servings
 apple-snaps-mrfox	Nutmeg Ginger Apple Snaps inspired by Fantastic Mr. Fox	apple-snaps-mrfox	https://www.youtube.com/watch?v=PGxk4oVcKQE	https://www.babi.sh/recipes/apple-snaps-mrfox	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695673/babishImages/undefined-436418.png	2022-10-28	3600	24	cookies
-applefritters	Double-Glazed Apple Fritters inspired by Regular Show	applefritters	https://www.youtube.com/watch?v=YYSP1D6GJ30&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YYSP1D6GJ30/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/applefritters	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695467/babishImages/undefined-689012.png	2019-08-27	8400	4	servings
+applefritters	Double-Glazed Apple Fritters inspired by Regular Show	applefritters	https://www.youtube.com/watch?v=YYSP1D6GJ30	https://www.babi.sh/recipes/applefritters	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695467/babishImages/undefined-689012.png	2019-08-27	8400	4	servings
 applepie	How To Make Apple Pie	applepie	https://www.youtube.com/watch?v=-Vy12e0LjX4	https://www.babi.sh/recipes/applepie	https://res.cloudinary.com/dd27yihoo/image/upload/v1689991798/w3xv26lktz0rhousz1aq.webp	2016-09-23	\N	\N	\N
 applepiesmoothie	Apple Pie Smoothie	applepiesmoothie	https://www.youtube.com/watch?v=mv1z2p3to0U	https://www.babi.sh/recipes/applepiesmoothie	https://res.cloudinary.com/dd27yihoo/image/upload/v1689991771/oz6gen69krvy3tfzijvm.webp	2016-03-13	\N	\N	\N
 arancini	ARANCINI	arancini	https://www.youtube.com/watch?v=VChpbmhH9kk	https://www.babi.sh/recipes/arancini	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696032/babishImages/undefined-461034.png	2022-12-02	2700	4	servings
 arc-raiders	ARC Raiders	arc-raiders	https://youtube.com/watch?v=kII9xxDdQeM&si=jO5AyfwVip1cv24e	https://www.babi.sh/recipes/arc-raiders	https://res.cloudinary.com/dd27yihoo/image/upload/v1771616573/olepmhmsubpyhh3trl0h.webp	2026-02-20	2100	4	servings
 archer-margarita	Margaritas inspired by Archer	archer-margarita	https://www.youtube.com/watch?v=hsPXh3yna1U	https://www.babi.sh/recipes/archer-margarita	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695554/babishImages/undefined-521982.png	2020-05-05	7200	4	servings
 arepas-con-queso-encanto	Arepas con Queso inspired by Encanto	arepas-con-queso-encanto	https://www.youtube.com/watch?v=aRWUMlLMF1c	https://www.babi.sh/recipes/arepas-con-queso-encanto	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695249/babishImages/undefined-386675.png	2022-01-11	1200	4	servings
-aristocats	Crème de la Crème à la Edgar inspired by The Aristocats	aristocats	https://www.youtube.com/watch?v=zNY-qzp7pD0&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/zNY-qzp7pD0/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/aristocats	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696317/babishImages/undefined-541474.png	2019-01-23	7200	4	servings
+aristocats	Crème de la Crème à la Edgar inspired by The Aristocats	aristocats	https://www.youtube.com/watch?v=zNY-qzp7pD0	https://www.babi.sh/recipes/aristocats	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696317/babishImages/undefined-541474.png	2019-01-23	7200	4	servings
 arresteddevelopmentspecial	Arrested Development Special (feat. Sean Evans)	arresteddevelopmentspecial	https://www.youtube.com/watch?v=2U_0OlCizx0	https://www.babi.sh/recipes/arresteddevelopmentspecial	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715504/babishImages/undefined-955688.png	2018-05-29	\N	\N	\N
 arroz-con-pollo-spiderman-spiderverse	Arroz con Pollo inspired by Spider-Man: Into the Spiderverse	arroz-con-pollo-spiderman-spiderverse	https://www.youtube.com/watch?v=CFkVS9vhIQY	https://www.babi.sh/recipes/arroz-con-pollo-spiderman-spiderverse	https://res.cloudinary.com/dd27yihoo/image/upload/v1687966614/sgzjuqlbuzd8tzonz7pz.webp	2023-06-08	\N	\N	\N
 aunt-petunias-pudding-harry-potter	Aunt Petunia's Pudding Inspired by Harry Potter	aunt-petunias-pudding-harry-potter	https://www.youtube.com/watch?v=AxM17SyPdCk	https://www.babi.sh/recipes/aunt-petunias-pudding-harry-potter	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696008/babishImages/undefined-784864.png	2022-11-04	4800	8	servings
 avatar-fire-flakes	Fire Flakes inspired by Avatar the Last Airbender	avatar-fire-flakes	https://www.youtube.com/watch?v=RhUMA3bCvAY	https://www.babi.sh/recipes/avatar-fire-flakes	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695535/babishImages/undefined-243692.png	2020-08-04	2400	4	servings
-avengersicecream	Ice Cream Flavors inspired by Avengers: Infinity War	avengersicecream	https://www.youtube.com/watch?v=Ukjat70Iyt4&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Ukjat70Iyt4/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/avengersicecream	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695805/babishImages/undefined-987247.png	2019-04-30	6000	4	servings
+avengersicecream	Ice Cream Flavors inspired by Avengers: Infinity War	avengersicecream	https://www.youtube.com/watch?v=Ukjat70Iyt4	https://www.babi.sh/recipes/avengersicecream	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695805/babishImages/undefined-987247.png	2019-04-30	6000	4	servings
 babish's-ultimate-chicken-parm	Babish's Ultimate Chicken Parm	babish's-ultimate-chicken-parm		https://www.babi.sh/recipes/babish's-ultimate-chicken-parm	https://res.cloudinary.com/dd27yihoo/image/upload/v1713808776/fig1ofuidrluzdmve8gs.webp	2024-04-22	\N	2	servings
 babish's-ultimate-fried-chicken	Babish’s Ultimate Fried Chicken	babish's-ultimate-fried-chicken	https://www.youtube.com/watch?v=yvKf6aDxBLk	https://www.babi.sh/recipes/babish's-ultimate-fried-chicken	https://res.cloudinary.com/dd27yihoo/image/upload/v1761246372/oljov21inpdw2zrpqypy.webp	2025-10-23	6000	10	chicken pieces
 babishpaniniwinner	#BabishPanini Winning Recipe - Car Panini inspired by Family Guy	babishpaniniwinner	https://www.youtube.com/watch?v=4Rz8BPRFeiA	https://www.babi.sh/recipes/babishpaniniwinner	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715515/babishImages/undefined-702398.png	2018-08-21	\N	\N	\N
-babka-inspired-by-seinfeld	Babka inspired by Seinfeld	babka-inspired-by-seinfeld	https://www.youtube.com/watch?v=pw2A03Z91FI	https://www.babi.sh/recipes/babka-inspired-by-seinfeld	https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp	2017-05-10	\N	\N	\N
+babka-inspired-by-seinfeld	Babka inspired by Seinfeld	babka-inspired-by-seinfeld	https://www.youtube.com/watch?v=pw2A03Z91FI	https://www.babi.sh/recipes/babka-inspired-by-seinfeld	https://res.cloudinary.com/dd27yihoo/image/upload/v1689991794/caokjjp73hvi3tpco5ld.webp	2017-05-09	\N	\N	\N
 bachelor-chow-futurama	Bachelor Chow inspired by Futurama	bachelor-chow-futurama	https://www.youtube.com/watch?v=nowFI0WRpO0	https://www.babi.sh/recipes/bachelor-chow-futurama	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696129/babishImages/undefined-898773.png	2021-01-26	2400	4	servings
 back-to-school-sandwich	Hors D'oeuvres Sandwich inspired by Back to School	back-to-school-sandwich	https://www.youtube.com/watch?v=A7afwIxo5lE	https://www.babi.sh/recipes/back-to-school-sandwich	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715748/babishImages/undefined-681777.png	2017-09-05	\N	\N	\N
-bacon	HOMEMADE BACON	bacon	https://www.youtube.com/watch?v=TUh4Z2li1UM	https://www.babi.sh/recipes/bacon	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715746/babishImages/undefined-294937.png	2021-04-30	\N	5	serves
-bagels	BAGELS	bagels	https://www.youtube.com/watch?v=ZrJtpCTZk38	https://www.babi.sh/recipes/bagels	https://res.cloudinary.com/dd27yihoo/image/upload/v1686008218/li4kbj7e5pcj5xvhujqo.webp	2019-01-24	5400	8	servings
-bagelsandwiches	Bagel Sandwiches inspired by Steven Universe	bagelsandwiches	https://www.youtube.com/watch?v=wv43IN_cnyw&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wv43IN_cnyw/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/bagelsandwiches	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png	2019-07-23	4800	4	servings
+bacon	Homemade Bacon	bacon	https://www.youtube.com/watch?v=TUh4Z2li1UM	https://www.babi.sh/recipes/bacon	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715746/babishImages/undefined-294937.png	2021-04-30	\N	5	serves
+bagels	Bagels	bagels	https://www.youtube.com/watch?v=ZrJtpCTZk38	https://www.babi.sh/recipes/bagels	https://res.cloudinary.com/dd27yihoo/image/upload/v1686008218/li4kbj7e5pcj5xvhujqo.webp	2019-01-24	5400	8	servings
+bagelsandwiches	Bagel Sandwiches inspired by Steven Universe	bagelsandwiches	https://www.youtube.com/watch?v=wv43IN_cnyw	https://www.babi.sh/recipes/bagelsandwiches	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695325/babishImages/undefined-259410.png	2019-07-23	4800	4	servings
 bagelwithlox	Everything Bagel with Lox Inspired By Mr. & Mrs. Smith	bagelwithlox	https://youtu.be/ZOZ2qkcfWe0	https://www.babi.sh/recipes/bagelwithlox	https://res.cloudinary.com/dd27yihoo/image/upload/v1711553048/yyeo9skkrkvuloahw7lm.webp	2024-03-27	18000	4	servings
 baklava	BAKLAVA	baklava	https://www.youtube.com/watch?v=OkzpwHodaAs	https://www.babi.sh/recipes/baklava	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715500/babishImages/undefined-703057.png	2020-10-15	2700	8	servings
 bananapuddingpizza	Banana Pudding Pizza inspired by Doug	bananapuddingpizza	https://www.youtube.com/watch?v=wcJS3nQjhqM	https://www.babi.sh/recipes/bananapuddingpizza	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715456/babishImages/undefined-622310.png	2018-09-18	\N	\N	\N
 banoffeepie	Banoffee Pie inspired by Love, Actually	banoffeepie	https://www.youtube.com/watch?v=TNTKRj2lS1g	https://www.babi.sh/recipes/banoffeepie	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695262/babishImages/undefined-536957.png	2019-12-27	7200	4	servings
-baobuns	Bao inspired by Pixar's Bao	baobuns	https://www.youtube.com/watch?v=OFt3SThGi7M&amp;t=46s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/OFt3SThGi7M/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/baobuns	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695380/babishImages/undefined-293013.png	2019-02-19	4800	4	servings
-barbacoa-de-res	BARBACOA DE RES CON CONSOMÉ	barbacoa-de-res	https://www.youtube.com/watch?v=Ya5u2uC3d2U	https://www.babi.sh/recipes/barbacoa-de-res	https://res.cloudinary.com/dd27yihoo/image/upload/v1690352793/xdxptaqk0rq7blwpqbre.webp	2023-05-05	\N	\N	\N
-barbecueporkchops	BARBECUE PORK CHOPS	barbecueporkchops	https://www.youtube.com/watch?v=YV9XuvfIudY	https://www.babi.sh/recipes/barbecueporkchops	https://res.cloudinary.com/dd27yihoo/image/upload/v1686072562/oedhsfjnim7duljy7y19.webp	2018-06-28	2700	4	servings
-baressentials	BAR ESSENTIALS	baressentials	https://www.youtube.com/watch?v=iZUfPIKbgUM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/iZUfPIKbgUM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/baressentials	https://res.cloudinary.com/dd27yihoo/image/upload/v1690416607/jlnnbuig1g2nrqafs58x.webp	2018-03-15	\N	\N	\N
-baressentials-7xwwz	CHOCOLATE CHIP COOKIES	baressentials-7xwwz	https://www.youtube.com/watch?v=ylxzfecackM&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/ylxzfecackM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/baressentials-7xwwz	https://res.cloudinary.com/dd27yihoo/image/upload/v1690485488/p72d0navvupz8bsaur3g.webp	2018-03-29	0	36	servings
-bearstew	Bear Stew inspired by Red Dead Redemption 2	bearstew	https://www.youtube.com/watch?v=wMxKbkWrvDc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/wMxKbkWrvDc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/bearstew	https://res.cloudinary.com/dd27yihoo/image/upload/v1679263840/iyxpvkao4lwi6xqkcwd1.webp	2018-11-06	6000	4	servings
-beef-wellington-or-with-babish	Beef Wellington | With Babish	beef-wellington-or-with-babish	https://www.youtube.com/watch?v=A-Qb0ExQc-I	https://www.babi.sh/recipes/beef-wellington-or-with-babish	https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp	2026-01-14	259200	\N	\N
-beer-can-chicken	BEER CAN CHICKEN	beer-can-chicken	https://www.youtube.com/watch?v=Xo0v7ZuA9C0	https://www.babi.sh/recipes/beer-can-chicken	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png	2022-12-19	3600	8	servings
-beer-steamed-chili-dogs	Chili Dogs inspired by The Irishman	beer-steamed-chili-dogs	https://www.youtube.com/watch?v=c0A1bkF4mKM&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/c0A1bkF4mKM/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/beer-steamed-chili-dogs	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695792/babishImages/undefined-202970.png	2019-12-17	6000	4	servings
+baobuns	Bao inspired by Pixar's Bao	baobuns	https://www.youtube.com/watch?v=OFt3SThGi7M	https://www.babi.sh/recipes/baobuns	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695380/babishImages/undefined-293013.png	2019-02-19	4800	4	servings
+barbacoa-de-res	Barbacoa Tacos and Gringas de Barbacoa with Consomé | Pruébalo with Rick Martinez	barbacoa-de-res	https://www.youtube.com/watch?v=Ya5u2uC3d2U	https://www.babi.sh/recipes/barbacoa-de-res	https://res.cloudinary.com/dd27yihoo/image/upload/v1690352793/xdxptaqk0rq7blwpqbre.webp	2023-05-05	\N	\N	\N
+barbecueporkchops	Barbecue Pork Chops	barbecueporkchops	https://www.youtube.com/watch?v=YV9XuvfIudY	https://www.babi.sh/recipes/barbecueporkchops	https://res.cloudinary.com/dd27yihoo/image/upload/v1686072562/oedhsfjnim7duljy7y19.webp	2018-06-28	2700	4	servings
+baressentials	Bar Essentials	baressentials	https://www.youtube.com/watch?v=iZUfPIKbgUM	https://www.babi.sh/recipes/baressentials	https://res.cloudinary.com/dd27yihoo/image/upload/v1690416607/jlnnbuig1g2nrqafs58x.webp	2018-03-15	\N	\N	\N
+baressentials-7xwwz	CHOCOLATE CHIP COOKIES	baressentials-7xwwz	https://www.youtube.com/watch?v=ylxzfecackM	https://www.babi.sh/recipes/baressentials-7xwwz	https://res.cloudinary.com/dd27yihoo/image/upload/v1690485488/p72d0navvupz8bsaur3g.webp	2018-03-29	0	36	servings
+bearstew	Bear Stew inspired by Red Dead Redemption 2	bearstew	https://www.youtube.com/watch?v=wMxKbkWrvDc	https://www.babi.sh/recipes/bearstew	https://res.cloudinary.com/dd27yihoo/image/upload/v1679263840/iyxpvkao4lwi6xqkcwd1.webp	2018-11-06	6000	4	servings
+beef-wellington-or-with-babish	$20 vs $200 Beef Wellington | With Babish	beef-wellington-or-with-babish	https://www.youtube.com/watch?v=A-Qb0ExQc-I	https://www.babi.sh/recipes/beef-wellington-or-with-babish	https://res.cloudinary.com/dd27yihoo/image/upload/v1768353563/az6m41jbqphdkgosvot0.webp	2025-12-23	259200	\N	\N
+beer-can-chicken	BEER CAN CHICKEN	beer-can-chicken	https://www.youtube.com/watch?v=Xo0v7ZuA9C0	https://www.babi.sh/recipes/beer-can-chicken	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696392/babishImages/undefined-504592.png	2022-12-18	3600	8	servings
+beer-steamed-chili-dogs	Chili Dogs inspired by The Irishman	beer-steamed-chili-dogs	https://www.youtube.com/watch?v=c0A1bkF4mKM	https://www.babi.sh/recipes/beer-steamed-chili-dogs	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695792/babishImages/undefined-202970.png	2019-12-17	6000	4	servings
 beetandacorncookies	Carol's Beet & Acorn Cookies (feat. Ashwin Enjoys Nature)	beetandacorncookies	https://www.youtube.com/watch?v=6PTuUMJ2Uh8	https://www.babi.sh/recipes/beetandacorncookies	https://res.cloudinary.com/dd27yihoo/image/upload/v1689991765/h4mfwyugmu5erlh5yc8e.webp	2017-05-23	\N	\N	\N
 beignetsfromchef	Beignets inspired by Chef (and Princess and the Frog)	beignetsfromchef	https://www.youtube.com/watch?v=DnuHzHHwqAw&amp;t=142s	https://www.babi.sh/recipes/beignetsfromchef	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715498/babishImages/undefined-178544.png	2018-08-07	\N	\N	\N
 being-with-babish-1	Giving Back to a Fan in Need	being-with-babish-1	https://www.youtube.com/watch?v=YUDogDKMJbE	https://www.youtube.com/watch?v=YUDogDKMJbE	https://img.youtube.com/vi/YUDogDKMJbE/mqdefault.jpg	2019-03-22	\N	\N	\N
 being-with-babish-2	Surprising a Fan with a Vegas Hotel Suite	being-with-babish-2	https://www.youtube.com/watch?v=QphHaVaAeG4	https://www.youtube.com/watch?v=QphHaVaAeG4	https://img.youtube.com/vi/QphHaVaAeG4/mqdefault.jpg	2019-04-05	\N	\N	\N
 being-with-babish-3	Surprising Rashid	being-with-babish-3	https://www.youtube.com/watch?v=DApDGZ1AkFw	https://www.youtube.com/watch?v=DApDGZ1AkFw	https://img.youtube.com/vi/DApDGZ1AkFw/mqdefault.jpg	2019-04-26	\N	\N	\N
-being-with-babish-4	Training like Kratos for 30 Days | Body by Babish	being-with-babish-4	https://www.youtube.com/watch?v=n_aq5TVb0HA	https://www.youtube.com/watch?v=n_aq5TVb0HA	https://img.youtube.com/vi/n_aq5TVb0HA/mqdefault.jpg	2019-06-07	\N	\N	\N
+being-with-babish-4	Training like Kratos for 30 Days | Being with Babish	being-with-babish-4	https://www.youtube.com/watch?v=n_aq5TVb0HA	https://www.youtube.com/watch?v=n_aq5TVb0HA	https://img.youtube.com/vi/n_aq5TVb0HA/mqdefault.jpg	2019-06-07	\N	\N	\N
 being-with-babish-5	Whiskey Basics | Being with Babish Double Feature	being-with-babish-5	https://www.youtube.com/watch?v=32Qlof81vcM	https://www.youtube.com/watch?v=32Qlof81vcM	https://img.youtube.com/vi/32Qlof81vcM/mqdefault.jpg	2019-07-12	\N	\N	\N
 being-with-babish-6	I Surprised My Brother with a Tesla	being-with-babish-6	https://www.youtube.com/watch?v=N44XgSRE-gY	https://www.youtube.com/watch?v=N44XgSRE-gY	https://img.youtube.com/vi/N44XgSRE-gY/mqdefault.jpg	2019-10-26	\N	\N	\N
 bell-peppers-and-beef-inspired-by-cowboy-bebop	Bell Peppers and Beef inspired by Cowboy Bebop	bell-peppers-and-beef-inspired-by-cowboy-bebop	https://www.youtube.com/watch?v=2cAUXitY1Wg	https://www.babi.sh/recipes/bell-peppers-and-beef-inspired-by-cowboy-bebop	https://res.cloudinary.com/dd27yihoo/image/upload/v1724877351/hawouiv2bqsgxzhglqox.webp	2024-08-20	\N	4	servings
-ben-wyatt-calzones	Calzones inspired by Parks & Rec	ben-wyatt-calzones	https://www.youtube.com/watch?v=PvgCEifW7Jo	https://www.babi.sh/recipes/ben-wyatt-calzones	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695309/babishImages/undefined-56906.png	2020-04-15	7200	4	servings
+ben-wyatt-calzones	Ben Wyatt's Calzones	ben-wyatt-calzones	https://www.youtube.com/watch?v=PvgCEifW7Jo	https://www.babi.sh/recipes/ben-wyatt-calzones	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695309/babishImages/undefined-56906.png	2020-04-15	7200	4	servings
 big-bang-burger-inspired-by-persona-5	Big Bang Burger inspired by Persona 5	big-bang-burger-inspired-by-persona-5	https://www.youtube.com/watch?v=dUxzbnKKzf8&pp=ygUVYmlnIGJhbmcgYnVyZ2VyIGFsdmlu	https://www.babi.sh/recipes/big-bang-burger-inspired-by-persona-5	https://res.cloudinary.com/dd27yihoo/image/upload/v1728311555/laq2mbbfwx2xlzw3ucrw.webp	2024-10-07	\N	8	servings
-biggamesnacks	BIG GAME SNACKS	biggamesnacks	https://www.youtube.com/watch?v=8ckxhlDFNkg	https://www.babi.sh/recipes/biggamesnacks	https://res.cloudinary.com/dd27yihoo/image/upload/v1686007959/eyt2lwmqnjme9flte5ai.webp	2019-01-31	3600	4	servings
+biggamesnacks	Big Game Snacks	biggamesnacks	https://www.youtube.com/watch?v=8ckxhlDFNkg	https://www.babi.sh/recipes/biggamesnacks	https://res.cloudinary.com/dd27yihoo/image/upload/v1686007959/eyt2lwmqnjme9flte5ai.webp	2019-01-31	3600	4	servings
 bigkahunaburger	Big Kahuna Burger inspired by Pulp Fiction	bigkahunaburger	https://www.youtube.com/watch?v=OmwE0aJqkdA	https://www.babi.sh/recipes/bigkahunaburger	https://res.cloudinary.com/dd27yihoo/image/upload/v1689992063/svmbfnvcgcixlk4husak.webp	2017-01-03	\N	\N	\N
-birria-tacos	BIRRIA TACOS	birria-tacos	https://www.youtube.com/watch?v=pQmSrlIbULk	https://www.babi.sh/recipes/birria-tacos	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695549/babishImages/undefined-359574.png	2021-03-11	3600	4	servings
-biscotti	BISCOTTI	biscotti	https://www.youtube.com/watch?v=g4EkzEKlGOA	https://www.babi.sh/recipes/biscotti	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695295/babishImages/undefined-256401.png	2021-09-24	3600	\N	\N
-biscuits-and-gravy	BISCUITS AND GRAVY	biscuits-and-gravy	https://www.youtube.com/watch?v=NMbMT9tY8-Q	https://www.babi.sh/recipes/biscuits-and-gravy	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695440/babishImages/undefined-307049.png	2021-02-25	3600	6	servings
+birria-tacos	Birria Tacos	birria-tacos	https://www.youtube.com/watch?v=pQmSrlIbULk	https://www.babi.sh/recipes/birria-tacos	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695549/babishImages/undefined-359574.png	2021-03-11	3600	4	servings
+biscotti	Biscotti	biscotti	https://www.youtube.com/watch?v=g4EkzEKlGOA	https://www.babi.sh/recipes/biscotti	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695295/babishImages/undefined-256401.png	2021-09-24	3600	\N	\N
+biscuits-and-gravy	Biscuits & Gravy	biscuits-and-gravy	https://www.youtube.com/watch?v=NMbMT9tY8-Q	https://www.babi.sh/recipes/biscuits-and-gravy	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695440/babishImages/undefined-307049.png	2021-02-25	3600	6	servings
 biscuits-ted-lasso	Biscuits inspired by Ted Lasso	biscuits-ted-lasso	https://www.youtube.com/watch?v=r_yBqWHtWMo	https://www.babi.sh/recipes/biscuits-ted-lasso	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695315/babishImages/undefined-343517.png	2021-03-16	7200	4	servings
 black-and-white-cookies-seinfeld	Black and White Cookies inspired by Seinfeld	black-and-white-cookies-seinfeld	https://www.youtube.com/watch?v=9Z7s35n3a5I	https://www.babi.sh/recipes/black-and-white-cookies-seinfeld	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695369/babishImages/undefined-373274.png	2021-09-01	6000	\N	\N
-blendersoups	BLENDER SOUPS	blendersoups	https://www.youtube.com/watch?v=S-gUFvpRQoU	https://www.babi.sh/recipes/blendersoups	https://res.cloudinary.com/dd27yihoo/image/upload/v1686007069/ibhjyui89v1zkxbgpjgd.webp	2019-03-05	2100	2	servings
+blendersoups	Blender Soups	blendersoups	https://www.youtube.com/watch?v=S-gUFvpRQoU	https://www.babi.sh/recipes/blendersoups	https://res.cloudinary.com/dd27yihoo/image/upload/v1686007069/ibhjyui89v1zkxbgpjgd.webp	2019-03-05	2100	2	servings
 blood-pie-inspired-by-game-of-thrones	Blood Pie inspired by Game of Thrones	blood-pie-inspired-by-game-of-thrones	https://www.youtube.com/watch?v=Y_hc07rAQlc	https://www.babi.sh/recipes/blood-pie-inspired-by-game-of-thrones	https://res.cloudinary.com/dd27yihoo/image/upload/v1689991789/mgtmjmq4qkfmrt4f405n.webp	2017-07-11	\N	\N	\N
 blooming-fish-inspired-by-cinderella-chef	Blooming Fish inspired by Cinderella Chef	blooming-fish-inspired-by-cinderella-chef	https://www.youtube.com/watch?v=DAwamRa8m9Y	https://www.babi.sh/recipes/blooming-fish-inspired-by-cinderella-chef	https://res.cloudinary.com/dd27yihoo/image/upload/v1727902497/v0e6pzds2idrfzg2dqbj.webp	2024-10-02	5400	2	servings
 blue-noodles-andor	Blue Noodles inspired by Andor	blue-noodles-andor	https://www.youtube.com/watch?v=tpz4S18l5LM	https://www.babi.sh/recipes/blue-noodles-andor	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696246/babishImages/undefined-786955.png	2022-11-04	4800	4	servings
@@ -395,76 +395,76 @@ bread	BREAD	bread	https://www.youtube.com/watch?v=Jizr6LR83Kk	https://www.babi.s
 breakfast-uncrustable	Breakfast Uncrustable	breakfast-uncrustable		https://www.babi.sh/recipes/breakfast-uncrustable	https://res.cloudinary.com/dd27yihoo/image/upload/v1726165637/jmgh94llro228evbeodw.webp	2024-09-12	\N	6	servings
 breakingbadspecial	Breaking Bad Special	breakingbadspecial	https://www.youtube.com/watch?v=ZY63ZSUdywY	https://www.babi.sh/recipes/breakingbadspecial	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715452/babishImages/undefined-411961.png	2018-02-06	\N	\N	\N
 brie-butter-baguette-twin-peaks	Brie & Butter Baguette inspired by Twin Peaks	brie-butter-baguette-twin-peaks	https://www.youtube.com/watch?v=vWdjqdmFHxw	https://www.babi.sh/recipes/brie-butter-baguette-twin-peaks	https://res.cloudinary.com/dd27yihoo/image/upload/v1679419541/mjnsfwsylba6umemgi38.webp	2020-11-03	7200	4	servings
-brocksdonuts	Brock's Donuts inspired by Pokémon	brocksdonuts	https://www.youtube.com/watch?v=RentKWlhUXc&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/RentKWlhUXc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/brocksdonuts	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695178/babishImages/undefined-56205.png	2019-04-02	3600	4	servings
+brocksdonuts	Brock's Donuts inspired by Pokémon	brocksdonuts	https://www.youtube.com/watch?v=RentKWlhUXc	https://www.babi.sh/recipes/brocksdonuts	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695178/babishImages/undefined-56205.png	2019-04-02	3600	4	servings
 brocksonigiri	Brock's Onigiri inspired by Pokémon	brocksonigiri	https://www.youtube.com/watch?v=gW4PCfLzTYA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/gW4PCfLzTYA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/brocksonigiri	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696152/babishImages/undefined-105913.png	2019-04-02	6000	4	servings
 broodwich-aqua-teen-hunger-force	The Broodwich inspired by Aqua Teen Hunger Force	broodwich-aqua-teen-hunger-force	https://www.youtube.com/watch?v=0vZvPtI5Uk8	https://www.babi.sh/recipes/broodwich-aqua-teen-hunger-force	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695861/babishImages/undefined-804479.png	2020-10-27	6000	4	servings
 browned-butter-hojicha-rice-krispies-treats	Browned Butter Hojicha Rice Krispies Treats	browned-butter-hojicha-rice-krispies-treats	https://www.instagram.com/reel/C0t0TBPrEah/	https://www.babi.sh/recipes/browned-butter-hojicha-rice-krispies-treats	https://res.cloudinary.com/dd27yihoo/image/upload/v1702313696/qkcaee5tnamr2aq8q1ag.webp	2023-12-11	\N	6	servings
 brownies	BROWNIES	brownies	https://www.youtube.com/watch?v=kDdUdvNQndo	https://www.babi.sh/recipes/brownies	https://res.cloudinary.com/dd27yihoo/image/upload/v1685911967/gx79ngetgymhmlrzqa0h.webp	2019-06-27	4500	6	servings
-bubbashrimp2	Shrimp inspired by Forrest Gump Part II	bubbashrimp2	https://www.youtube.com/watch?v=mF6JUfczaO8&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/mF6JUfczaO8/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/bubbashrimp2	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696055/babishImages/undefined-252668.png	2019-04-23	4800	4	servings
+bubbashrimp2	Shrimp inspired by Forrest Gump Part II	bubbashrimp2	https://www.youtube.com/watch?v=mF6JUfczaO8	https://www.babi.sh/recipes/bubbashrimp2	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696055/babishImages/undefined-252668.png	2019-04-23	4800	4	servings
 bubblebass	Bubble Bass' Order inspired by Spongebob Squarepants	bubblebass	https://www.youtube.com/watch?v=Y8hi6A5MPVY	https://www.babi.sh/recipes/bubblebass	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715461/babishImages/undefined-746523.png	2018-05-22	\N	\N	\N
 bunnicorn-pizza	Bunnicorn Pizza inspired by Star Trek: Picard	bunnicorn-pizza	https://www.youtube.com/watch?v=2a8Uz3pYTh4	https://www.babi.sh/recipes/bunnicorn-pizza	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696254/babishImages/undefined-826177.png	2020-03-17	4800	4	servings
-burgers	BURGERS	burgers	https://www.youtube.com/watch?v=nbCgfiqq-5c	https://www.babi.sh/recipes/burgers	https://res.cloudinary.com/dd27yihoo/image/upload/v1686072856/hopwyczgnd5layejyvpe.webp	2018-06-14	3600	2	servings
+burgers	Burgers	burgers	https://www.youtube.com/watch?v=nbCgfiqq-5c	https://www.babi.sh/recipes/burgers	https://res.cloudinary.com/dd27yihoo/image/upload/v1686072856/hopwyczgnd5layejyvpe.webp	2018-06-14	3600	2	servings
 butterednoodles-community	Buttered Noodles inspired by Community	butterednoodles-community	https://www.youtube.com/watch?v=xGHTj4y_bd8	https://www.babi.sh/recipes/butterednoodles-community	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695894/babishImages/undefined-831336.png	2020-05-26	6000	4	servings
 buttermilk-pancakes-inspired-by-twin-peaks	Buttermilk Pancakes inspired by Twin Peaks	buttermilk-pancakes-inspired-by-twin-peaks	https://www.youtube.com/watch?v=nEoSBL25RO4	https://www.babi.sh/recipes/buttermilk-pancakes-inspired-by-twin-peaks	https://res.cloudinary.com/dd27yihoo/image/upload/v1689992075/k6lh85gi9qv44sgwuezx.webp	2017-05-18	\N	5	servings
 caillesensarchophage	Cailles en Sarchophage inspired by Babette's Feast	caillesensarchophage	https://www.youtube.com/watch?v=Bz1IXK6ahu0	https://www.youtube.com/watch?v=Bz1IXK6ahu0	https://img.youtube.com/vi/Bz1IXK6ahu0/mqdefault.jpg	2017-10-03	\N	\N	\N
-cajunfood	CAJUN FOOD	cajunfood	https://www.youtube.com/watch?v=nORg_aXMsmA	https://www.babi.sh/recipes/cajunfood	https://res.cloudinary.com/dd27yihoo/image/upload/v1685738278/bdfgvfer8ydjozwjsvmf.webp	2019-09-13	5400	4	servings
-cake-pops	CAKE POPS	cake-pops	https://www.youtube.com/watch?v=C_hz9wzeBbY	https://www.babi.sh/recipes/cake-pops	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png	2021-11-02	7200	10	servings
-calistyle-burrito	CALI-STYLE BURRITO	calistyle-burrito	https://www.youtube.com/watch?v=55YUKZK7BXg	https://www.babi.sh/recipes/calistyle-burrito	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695451/babishImages/undefined-566187.png	2021-09-13	4800	\N	\N
+cajunfood	Cajun Food	cajunfood	https://www.youtube.com/watch?v=nORg_aXMsmA	https://www.babi.sh/recipes/cajunfood	https://res.cloudinary.com/dd27yihoo/image/upload/v1685738278/bdfgvfer8ydjozwjsvmf.webp	2019-09-13	5400	4	servings
+cake-pops	Cake Pops	cake-pops	https://www.youtube.com/watch?v=C_hz9wzeBbY	https://www.babi.sh/recipes/cake-pops	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695195/babishImages/undefined-881481.png	2021-10-21	7200	10	servings
+calistyle-burrito	California Style Burritos	calistyle-burrito	https://www.youtube.com/watch?v=55YUKZK7BXg	https://www.babi.sh/recipes/calistyle-burrito	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695451/babishImages/undefined-566187.png	2021-09-13	4800	\N	\N
 carbonara	CARBONARA	carbonara	https://www.youtube.com/watch?v=qoHnwOHLiMk	https://www.babi.sh/recipes/carbonara	https://res.cloudinary.com/dd27yihoo/image/upload/v1685823362/wfj3v6zecpgzotkpwpow.webp	2019-08-15	1500	4	servings
 carbonara-anything	CARBONARA ANYTHING	carbonara-anything	https://www.youtube.com/watch?v=wrweyL0YS8Y	https://www.babi.sh/recipes/carbonara-anything	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695332/babishImages/undefined-714411.png	2022-09-19	\N	4	servings
-carnitas	CARNITAS	carnitas	https://www.youtube.com/watch?v=FEZioC-qMd4	https://www.babi.sh/recipes/carnitas	https://res.cloudinary.com/dd27yihoo/image/upload/v1690352698/ldnpp7ukrrvaiormf4ux.webp	2023-05-12	\N	\N	\N
+carnitas	Easy Carnitas	carnitas	https://www.youtube.com/watch?v=FEZioC-qMd4	https://www.babi.sh/recipes/carnitas	https://res.cloudinary.com/dd27yihoo/image/upload/v1690352698/ldnpp7ukrrvaiormf4ux.webp	2023-05-02	\N	\N	\N
 carpanini	Car Panini inspired by Family Guy	carpanini	https://www.youtube.com/watch?v=4Rz8BPRFeiA	https://www.babi.sh/recipes/carpanini	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715473/babishImages/undefined-402999.png	2018-07-10	\N	\N	\N
 ccourtesan-au-chocolat	Courtesan au Chocolat inspired by Grand Budapest Hotel	ccourtesan-au-chocolat	https://www.youtube.com/watch?v=GO5P3fLTwA0	https://www.babi.sh/recipes/ccourtesan-au-chocolat	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715490/babishImages/undefined-759763.jpg	2017-08-15	\N	12	servings
 challah	CHALLAH	challah	https://www.youtube.com/watch?v=M558453kb9g	https://www.babi.sh/recipes/challah	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695737/babishImages/undefined-872033.png	2021-12-07	8400	1	loaf
 charcuterieandcheeseboards	CHARCUTERIE & CHEESE BOARDS	charcuterieandcheeseboards	https://www.youtube.com/watch?v=VnrScNQDcEQ	https://www.babi.sh/recipes/charcuterieandcheeseboards	https://res.cloudinary.com/dd27yihoo/image/upload/v1686009296/mwxfpmkv2kqhubhm4xqu.webp	2018-12-06	\N	\N	\N
-charliebrownthanksgiving	Charlie Brown Thanksgiving	charliebrownthanksgiving	https://www.youtube.com/watch?v=5FyKxVJmsdE&amp;t=1s&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/5FyKxVJmsdE/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/charliebrownthanksgiving	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg	2018-11-20	4800	4	servings
+charliebrownthanksgiving	Charlie Brown Thanksgiving	charliebrownthanksgiving	https://www.youtube.com/watch?v=5FyKxVJmsdE	https://www.babi.sh/recipes/charliebrownthanksgiving	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696206/babishImages/undefined-812990.jpg	2018-11-20	4800	4	servings
 chateaubriandsteak	Chateaubriand Steak inspired by The Matrix	chateaubriandsteak	https://www.youtube.com/watch?v=eA6uLMsl9w0	https://www.babi.sh/recipes/chateaubriandsteak	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715539/babishImages/undefined-131890.png	2018-04-17	\N	\N	\N
-cheesdips	CHEESE DIPS	cheesdips	https://www.youtube.com/watch?v=9toK5UUGeok	https://www.babi.sh/recipes/cheesdips	https://res.cloudinary.com/dd27yihoo/image/upload/v1686005952/sgzpqqlxhdnjser57r5j.webp	2019-05-02	2700	6	servings
-cheese-fondue	CHEEESE FONDUE	cheese-fondue	https://www.youtube.com/watch?v=_X-Mm8h1AHM	https://www.babi.sh/recipes/cheese-fondue	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715730/babishImages/undefined-469596.png	2020-07-23	1800	6	servings
+cheesdips	Cheese Dips	cheesdips	https://www.youtube.com/watch?v=9toK5UUGeok	https://www.babi.sh/recipes/cheesdips	https://res.cloudinary.com/dd27yihoo/image/upload/v1686005952/sgzpqqlxhdnjser57r5j.webp	2019-05-02	2700	6	servings
+cheese-fondue	Cheese Fondue	cheese-fondue	https://www.youtube.com/watch?v=_X-Mm8h1AHM	https://www.babi.sh/recipes/cheese-fondue	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715730/babishImages/undefined-469596.png	2020-07-23	1800	6	servings
 cheeseburger-the-menu	Cheeseburger inspired by The Menu	cheeseburger-the-menu	https://www.youtube.com/watch?v=ep6k3Ofcf2s	https://www.babi.sh/recipes/cheeseburger-the-menu	https://res.cloudinary.com/dd27yihoo/image/upload/v1677044221/nldmt4l5dra69ov0dof0.webp	2023-02-22	7200	6	burgers
 cheesecake-inspired-by-junior's-cheesecakes	Cheesecake inspired by Junior's Cheesecakes	cheesecake-inspired-by-junior's-cheesecakes	https://www.youtube.com/watch?v=gQeY_wx9bsI&t=26s&ab_channel=BabishCulinaryUniverse	https://www.babi.sh/recipes/cheesecake-inspired-by-junior's-cheesecakes	https://res.cloudinary.com/dd27yihoo/image/upload/v1741657095/qjrimy3opynb08w9zudl.webp	2025-03-11	27900	\N	\N
 cheesesteak	Philly Cheesesteaks inspired by Creed	cheesesteak	https://www.youtube.com/watch?v=Zru1yk--rGQ	https://www.babi.sh/recipes/cheesesteak	https://res.cloudinary.com/dd27yihoo/image/upload/v1689992082/xlhovdhhw4afkquqaobt.webp	2016-08-21	\N	\N	\N
 cheesyblasters	Cheesy Blasters inspired by 30 Rock	cheesyblasters	https://www.youtube.com/watch?v=atLL2Yzi3bg	https://www.babi.sh/recipes/cheesyblasters	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715459/babishImages/undefined-717173.png	2018-05-15	\N	\N	\N
-chefs-choice-platter-monster-hunter-world	The Chef's Choice Platter inspired by Monster Hunter: World	chefs-choice-platter-monster-hunter-world	https://www.youtube.com/watch?v=__qtH1ly2Sg	https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png	2021-03-31	7200	9	servings
+chefs-choice-platter-monster-hunter-world	The Chef's Choice Platter inspired by Monster Hunter: World	chefs-choice-platter-monster-hunter-world	https://www.youtube.com/watch?v=__qtH1ly2Sg	https://www.babi.sh/recipes/chefs-choice-platter-monster-hunter-world	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696043/babishImages/undefined-419307.png	2021-03-30	7200	9	servings
 chicago-deep-dish-the-bear	Chicago Deep Dish Pizza inspired by The Bear	chicago-deep-dish-the-bear	https://www.youtube.com/watch?v=Ris0udk2C84	https://www.babi.sh/recipes/chicago-deep-dish-the-bear	https://res.cloudinary.com/dd27yihoo/image/upload/v1690249416/oxrjvgjzaljdvfvtinpj.webp	2023-07-21	\N	\N	\N
 chicago-style-italian-beef-inspired-by-the-bear	Chicago-Style Italian Beef inspired by The Bear	chicago-style-italian-beef-inspired-by-the-bear	https://www.youtube.com/watch?v=xrXDdlrcuKs	https://www.babi.sh/recipes/chicago-style-italian-beef-inspired-by-the-bear	https://res.cloudinary.com/dd27yihoo/image/upload/v1720451211/caje3wf74d8gwuq8hbjn.webp	2024-07-08	\N	5	servings
 chicken-fingers-community	Chicken Fingers inspired by Community	chicken-fingers-community	https://www.youtube.com/watch?v=MJoSs4BGaHI	https://www.babi.sh/recipes/chicken-fingers-community	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695499/babishImages/undefined-134001.png	2021-04-02	3600	4	servings
 chicken-kiev-mad-men	Chicken Kiev inspired by Mad Men	chicken-kiev-mad-men	https://www.youtube.com/watch?v=kf8XzD-xVGc	https://www.babi.sh/recipes/chicken-kiev-mad-men	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695711/babishImages/undefined-516619.png	2021-03-02	2400	2	servings
 chicken-meatball-hotpot-inspired-by-jujutsu-kaisen	Chicken Meatball Hotpot inspired By Jujutsu Kaisen	chicken-meatball-hotpot-inspired-by-jujutsu-kaisen	https://www.youtube.com/watch?v=GymqadVYSXk&t=34s	https://www.babi.sh/recipes/chicken-meatball-hotpot-inspired-by-jujutsu-kaisen	https://res.cloudinary.com/dd27yihoo/image/upload/v1727887830/cnkxewktxghxefrnq6xa.webp	2024-10-02	\N	3	servings
-chicken-parmesan	CHICKEN PARMESAN	chicken-parmesan	https://www.youtube.com/watch?v=ZrR0VbqNdW8	https://www.babi.sh/recipes/chicken-parmesan	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715495/babishImages/undefined-30590.png	2020-12-10	3600	4	servings
-chicken-piccata	CHICKEN PICCATA	chicken-piccata	https://www.youtube.com/watch?v=ZqEqtmMY1M0	https://www.babi.sh/recipes/chicken-piccata	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695515/babishImages/undefined-561520.png	2022-02-18	\N	4	servings
+chicken-parmesan	Chicken Parmesan	chicken-parmesan	https://www.youtube.com/watch?v=ZrR0VbqNdW8	https://www.babi.sh/recipes/chicken-parmesan	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715495/babishImages/undefined-30590.png	2020-12-10	3600	4	servings
+chicken-piccata	Chicken Piccata	chicken-piccata	https://www.youtube.com/watch?v=ZqEqtmMY1M0	https://www.babi.sh/recipes/chicken-piccata	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695515/babishImages/undefined-561520.png	2022-02-18	\N	4	servings
 chicken-pot-pie	CHICKEN POT PIE	chicken-pot-pie	https://www.youtube.com/watch?v=Sv7NP9LMU4Q	https://www.babi.sh/recipes/chicken-pot-pie	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715703/babishImages/undefined-597597.png	2020-11-13	\N	5	servings
 chicken-schnitzel-with-kohlrabi-slaw	Chicken Schnitzel with Kohlrabi Slaw	chicken-schnitzel-with-kohlrabi-slaw		https://www.babi.sh/recipes/chicken-schnitzel-with-kohlrabi-slaw	https://res.cloudinary.com/dd27yihoo/image/upload/v1712164085/zevoznd2i1yfyqnxouis.webp	2024-04-03	\N	\N	\N
 chickenpaprikash	Chicken Paprikash inspired by Captain America: Civil War	chickenpaprikash	https://www.youtube.com/watch?v=baG767jr8c8	https://www.babi.sh/recipes/chickenpaprikash	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715753/babishImages/undefined-326225.png	2018-04-24	\N	\N	\N
-chickentikkamasala	CHICKEN TIKKA MASALA	chickentikkamasala	https://www.youtube.com/watch?v=Bkd0LxBd2L8	https://www.babi.sh/recipes/chickentikkamasala	https://res.cloudinary.com/dd27yihoo/image/upload/v1686006735/dk1zntqnkdzyf26vol0o.webp	2019-03-28	2700	4	servings
+chickentikkamasala	Chicken Tikka Masala	chickentikkamasala	https://www.youtube.com/watch?v=Bkd0LxBd2L8	https://www.babi.sh/recipes/chickentikkamasala	https://res.cloudinary.com/dd27yihoo/image/upload/v1686006735/dk1zntqnkdzyf26vol0o.webp	2019-03-28	2700	4	servings
 chickpeas	CHICKPEAS (HUMMUS, CHANA MASALA, MERINGUES, COOKIES)	chickpeas	https://www.youtube.com/watch?v=LfzKfD_WuDM	https://www.babi.sh/recipes/chickpeas	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715488/babishImages/undefined-317396.png	2020-03-19	3600	4	servings
 chilaquiles-divorciados-(con-todo)	Chilaquiles Divorciados (Con Todo)	chilaquiles-divorciados-(con-todo)		https://www.babi.sh/recipes/chilaquiles-divorciados-(con-todo)	https://res.cloudinary.com/dd27yihoo/image/upload/v1715004133/jasux88sbxvtoi3eawdi.webp	2024-05-06	\N	3	servings
-chileanseabass	Chilean Sea Bass inspired by Jurassic Park	chileanseabass	https://www.youtube.com/watch?v=p73kqpqGqqQ&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/p73kqpqGqqQ/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/chileanseabass	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695721/babishImages/undefined-408439.png	2018-11-27	1200	3	servings
-chiles-rellenos	CHILES RELLENOS	chiles-rellenos	https://www.youtube.com/watch?v=gAKW8RB6aeU	https://www.babi.sh/recipes/chiles-rellenos	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695355/babishImages/undefined-627603.png	2021-08-26	3600	\N	\N
+chileanseabass	Chilean Sea Bass inspired by Jurassic Park	chileanseabass	https://www.youtube.com/watch?v=p73kqpqGqqQ	https://www.babi.sh/recipes/chileanseabass	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695721/babishImages/undefined-408439.png	2018-11-27	1200	3	servings
+chiles-rellenos	Chiles Rellenos	chiles-rellenos	https://www.youtube.com/watch?v=gAKW8RB6aeU	https://www.babi.sh/recipes/chiles-rellenos	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695355/babishImages/undefined-627603.png	2021-08-26	3600	\N	\N
 chili-two-ways	CHILI (MEAT & VEGETARIAN)	chili-two-ways	https://www.youtube.com/watch?v=4BTm1Ezl6XE	https://www.babi.sh/recipes/chili-two-ways	https://images.squarespace-cdn.com/content/v1/59d40133017db2fd8a60b3fe/1580394251048-E9PK1EUOJW3TS4QI6DYT/BWB+Meatiest+Chili.jpg	2020-01-30	7200	4	servings
-chimichangas	CHIMICHANGAS	chimichangas	https://www.youtube.com/watch?v=szFLA4_pwew	https://www.babi.sh/recipes/chimichangas	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715751/babishImages/undefined-916823.png	2020-04-28	3600	6	servings
+chimichangas	Deadpool's Chimichangas	chimichangas	https://www.youtube.com/watch?v=szFLA4_pwew	https://www.babi.sh/recipes/chimichangas	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715751/babishImages/undefined-916823.png	2020-04-28	3600	6	servings
 chocolate-cake-inspired-by-matilda	Chocolate Cake inspired by Matilda	chocolate-cake-inspired-by-matilda	https://www.youtube.com/watch?v=exQ6oGefSiA	https://www.babi.sh/recipes/chocolate-cake-inspired-by-matilda	https://res.cloudinary.com/dd27yihoo/image/upload/v1689991787/cxpb3rjiwrvezbgpjfej.webp	2017-06-06	\N	\N	\N
 chocolate-cake-milkshake-inspired-by-portillo's	Chocolate Cake Milkshake inspired by Portillo's	chocolate-cake-milkshake-inspired-by-portillo's	https://www.youtube.com/watch?v=NqEqOQZSXOE&pp=ygUoY2hvY29sYXRlIGNha2Ugc2hha2UgYmluZ2luZyB3aXRoIGJhYmlzaA%3D%3D	https://www.babi.sh/recipes/chocolate-cake-milkshake-inspired-by-portillo's	https://res.cloudinary.com/dd27yihoo/image/upload/v1749064072/hstkkvyg9ja8s6vazkgi.webp	2025-06-04	\N	\N	\N
-chocolate-croissants-its-complicated	Chocolate Croissants inspired by It's Complicated	chocolate-croissants-its-complicated	https://www.youtube.com/watch?v=qvNXPn4ptJM	https://www.babi.sh/recipes/chocolate-croissants-its-complicated	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png	2022-08-01	4800	4	servings
+chocolate-croissants-its-complicated	Chocolate Croissants inspired by It's Complicated	chocolate-croissants-its-complicated	https://www.youtube.com/watch?v=qvNXPn4ptJM	https://www.babi.sh/recipes/chocolate-croissants-its-complicated	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696083/babishImages/undefined-824297.png	2022-07-13	4800	4	servings
 chocolate-pudding-rugrats	Chocolate Pudding (4 Ways) inspired by Rugrats	chocolate-pudding-rugrats	https://www.youtube.com/watch?v=1lPU4CwSnTc	https://www.babi.sh/recipes/chocolate-pudding-rugrats	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696061/babishImages/undefined-143561.png	2020-03-03	4800	4	servings
 chocolate-spongebob	Chocolate inspired by SpongeBob SquarePants	chocolate-spongebob	https://www.youtube.com/watch?v=KB0kltHtnBA	https://www.babi.sh/recipes/chocolate-spongebob	https://res.cloudinary.com/dd27yihoo/image/upload/v1677047143/hqv73vmgjwxyv5364bph.webp	2023-02-22	14400	4	servings
 chocolatelavacakes	Chocolate Lava Cakes inspired by Chef with Jon Favreau and Roy Choi	chocolatelavacakes	https://www.youtube.com/watch?v=qbMTukAJskQ	https://www.babi.sh/recipes/chocolatelavacakes	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715705/babishImages/undefined-478519.png	2018-02-20	\N	\N	\N
 chopped-cheese	CHOPPED CHEESE	chopped-cheese	https://www.youtube.com/watch?v=E1z55dYHv8c	https://www.babi.sh/recipes/chopped-cheese	https://res.cloudinary.com/dd27yihoo/image/upload/v1680343867/ersvctalsr97j0gpoa1p.webp	2021-07-13	8400	4	servings
 chorizo-clam-pasta	Chorizo Clam Pasta	chorizo-clam-pasta		https://www.babi.sh/recipes/chorizo-clam-pasta	https://res.cloudinary.com/dd27yihoo/image/upload/v1723131815/pp5vavgjuw3vbgrspxwe.webp	2024-08-08	\N	\N	\N
-christmas-turkey-inspired-by-national-lampoon's-christmas-vacation	Christmas Turkey inspired by National Lampoon's Christmas Vacation	christmas-turkey-inspired-by-national-lampoon's-christmas-vacation	https://youtube.com/watch?v=w0pZ7MWajW8&si=r2TmnS9oJhDHIbp5	https://www.babi.sh/recipes/christmas-turkey-inspired-by-national-lampoon's-christmas-vacation	https://res.cloudinary.com/dd27yihoo/image/upload/v1764189007/giyklwlgdj7x3nwbi38c.webp	2025-11-26	259200	\N	\N
-churrons-broad-city	Churrons inspired by Broad City	churrons-broad-city	https://www.youtube.com/watch?v=JiUsCTy8nEY	https://www.babi.sh/recipes/churrons-broad-city	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695905/babishImages/undefined-290140.png	2022-08-17	8400	4	servings
+christmas-turkey-inspired-by-national-lampoon's-christmas-vacation	Christmas Turkey inspired by National Lampoon's Christmas Vacation	christmas-turkey-inspired-by-national-lampoon's-christmas-vacation	https://youtube.com/watch?v=w0pZ7MWajW8&si=r2TmnS9oJhDHIbp5	https://www.babi.sh/recipes/christmas-turkey-inspired-by-national-lampoon's-christmas-vacation	https://res.cloudinary.com/dd27yihoo/image/upload/v1764189007/giyklwlgdj7x3nwbi38c.webp	2025-11-29	259200	\N	\N
+churrons-broad-city	Churrons inspired by Broad City	churrons-broad-city	https://www.youtube.com/watch?v=JiUsCTy8nEY	https://www.babi.sh/recipes/churrons-broad-city	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695905/babishImages/undefined-290140.png	2022-08-03	8400	4	servings
 cinnamon-rolls-3-ways-(pumpkin-spice-strawberry-nutella-classic)	Cinnamon Rolls 3-Ways (Pumpkin Spice, Strawberry Nutella, Classic)	cinnamon-rolls-3-ways-(pumpkin-spice-strawberry-nutella-classic)	https://www.youtube.com/watch?v=QsMNoGvPAJ4	https://www.babi.sh/recipes/cinnamon-rolls-3-ways-(pumpkin-spice-strawberry-nutella-classic)	https://res.cloudinary.com/dd27yihoo/image/upload/v1728682940/vwybjlgymmmndc3ghs9r.webp	2024-10-11	10800	12	servings
-cinnamonrolls	Cinnamon Rolls inspired by Jim Gaffigan's Stand Up (sort of)	cinnamonrolls	https://www.youtube.com/watch?v=jFYi2QRVFOc&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/jFYi2QRVFOc/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/cinnamonrolls	https://res.cloudinary.com/dd27yihoo/image/upload/v1679245506/gyb4qsztcyrv4kjnvwug.webp	2018-10-23	3600	4	servings
-classic-fettucine-alfredo	Classic Fettucine Alfredo	classic-fettucine-alfredo	https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo	https://www.babi.sh/recipes/classic-fettucine-alfredo	https://res.cloudinary.com/dd27yihoo/image/upload/v1749216590/llpz2sobgkra4ttgl9kx.webp	2025-06-06	1800	2	servings
+cinnamonrolls	Cinnamon Rolls inspired by Jim Gaffigan's Stand Up (sort of)	cinnamonrolls	https://www.youtube.com/watch?v=jFYi2QRVFOc	https://www.babi.sh/recipes/cinnamonrolls	https://res.cloudinary.com/dd27yihoo/image/upload/v1679245506/gyb4qsztcyrv4kjnvwug.webp	2018-10-23	3600	12	rolls
+classic-fettucine-alfredo	Classic Fettuccine Alfredo	classic-fettucine-alfredo	https://www.youtube.com/watch?v=2Xx1QY_WVs0&pp=ygUhY2xhc3NpYyBmZXR0dWNjaW5lIGFsZnJlZG8gYmFiaXNo	https://www.babi.sh/recipes/classic-fettucine-alfredo	https://res.cloudinary.com/dd27yihoo/image/upload/v1749216590/llpz2sobgkra4ttgl9kx.webp	2025-06-06	1800	2	servings
 classicpancakes	Classic Pancakes inspired by Uncle Buck	classicpancakes	https://www.youtube.com/watch?v=WMj7G-U3LW8	https://www.babi.sh/recipes/classicpancakes	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695456/babishImages/undefined-606334.png	2019-08-20	2400	4	servings
 clayroastedthigh	Clay-Roasted Thigh inspired by Hannibal	clayroastedthigh	https://www.youtube.com/watch?v=lnB7svFAZBs&amp;t=2s	https://www.babi.sh/recipes/clayroastedthigh	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715438/babishImages/undefined-943571.png	2017-10-31	\N	\N	\N
 clementinecake	Clementine Cake inspired by The Secret Life of Walter Mitty	clementinecake	https://www.youtube.com/watch?v=cr2wUlNSFg0	https://www.babi.sh/recipes/clementinecake	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715728/babishImages/undefined-306069.png	2018-03-06	11400	6	servings
-cocktail-special	Cocktail Special	cocktail-special	https://www.youtube.com/watch?v=v5tJBLfeurU	https://www.babi.sh/recipes/cocktail-special	https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp	2017-06-28	\N	\N	\N
+cocktail-special	Cocktail Special	cocktail-special	https://www.youtube.com/watch?v=v5tJBLfeurU	https://www.babi.sh/recipes/cocktail-special	https://res.cloudinary.com/dd27yihoo/image/upload/v1689991773/frvdqes62h3gdapclpxo.webp	2017-06-27	\N	\N	\N
 cocoa-krispies-oliver-and-company	Oeufs a la Jenny avec Cocoa Krispies inspired by Oliver & Company	cocoa-krispies-oliver-and-company	https://www.youtube.com/watch?v=YPsRQ6O1gjA	https://www.babi.sh/recipes/cocoa-krispies-oliver-and-company	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696134/babishImages/undefined-989706.png	2022-01-11	9000	6	servings
 coconut-tres-leches-cake-(inspired-by-uncle-boon'sthai-diner)	Coconut Tres Leches Cake (inspired by Uncle Boon's/Thai Diner)	coconut-tres-leches-cake-(inspired-by-uncle-boon'sthai-diner)		https://www.babi.sh/recipes/coconut-tres-leches-cake-(inspired-by-uncle-boon'sthai-diner)	https://res.cloudinary.com/dd27yihoo/image/upload/v1711376222/qzxptjovrunyeh6a7gxv.webp	2024-03-25	\N	\N	\N
 coffee	COFFEE	coffee	https://www.youtube.com/watch?v=6yItCQB4V9A	https://www.babi.sh/recipes/coffee	https://res.cloudinary.com/dd27yihoo/image/upload/v1685913686/jkj0usgdv3og2qcwbn95.webp	2019-05-31	600	\N	\N
 coffeecake	COFFEE CAKE	coffeecake	https://www.youtube.com/watch?v=ds0jskRIeRI	https://www.babi.sh/recipes/coffeecake	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715476/babishImages/undefined-63787.png	2020-05-14	5400	6	servings
-coffeejelly	Coffee Jelly inspired by The Disastrous Life of Saiki K.	coffeejelly	https://www.youtube.com/watch?v=YxEcd_wTf5c&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/YxEcd_wTf5c/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/coffeejelly	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png	2019-09-24	4800	4	servings
+coffeejelly	Coffee Jelly inspired by The Disastrous Life of Saiki K.	coffeejelly	https://www.youtube.com/watch?v=YxEcd_wTf5c	https://www.babi.sh/recipes/coffeejelly	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695184/babishImages/undefined-73008.png	2019-09-24	4800	4	servings
 cola-short-ribs-the-bear	Cola-Braised Short Ribs inspired by The Bear	cola-short-ribs-the-bear	https://www.youtube.com/watch?v=6GZDBmQsaw0	https://www.babi.sh/recipes/cola-short-ribs-the-bear	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695757/babishImages/undefined-202545.png	2022-10-28	7200	4	servings
 cold-cure	Cold Cure inspired by Kenan & Kel	cold-cure	https://www.youtube.com/watch?v=M-7t9FBecoU	https://www.babi.sh/recipes/cold-cure	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695640/babishImages/undefined-577796.png	2020-03-24	1200	4	servings
 cookie-cat-steven-universe	Cookie Cat inspired by Steven Universe	cookie-cat-steven-universe	https://www.youtube.com/watch?v=KbNRvWfndjA	https://www.babi.sh/recipes/cookie-cat-steven-universe	https://res.cloudinary.com/dd27yihoo/image/upload/v1681696201/babishImages/undefined-799954.png	2021-02-16	4800	4	servings
@@ -472,19 +472,19 @@ cookie-dough	COOKIE DOUGH	cookie-dough	https://www.youtube.com/watch?v=Il1Cy4tQC
 cookie-nachos-sweet-tooth	Cookie Nachos inspired by Sweet Tooth Goes Euro	cookie-nachos-sweet-tooth	https://www.youtube.com/watch?v=tVmhieZDmdA	https://www.babi.sh/recipes/cookie-nachos-sweet-tooth	https://res.cloudinary.com/dd27yihoo/image/upload/v1695140575/hp7xzdscoynuc2pdkbr8.webp	2023-08-09	\N	\N	\N
 copy-cat-spicy-vodka-rigatoni	Copy Cat Spicy Vodka Rigatoni	copy-cat-spicy-vodka-rigatoni	https://www.youtube.com/watch?v=KMUvINcrpzM	https://www.babi.sh/recipes/copy-cat-spicy-vodka-rigatoni	https://res.cloudinary.com/dd27yihoo/image/upload/v1749222937/h0akjerb4dvfjjofwtkj.webp	2025-06-06	3600	6	servings
 coq-au-vin	Coq au Vin	coq-au-vin	https://www.youtube.com/watch?v=cf1H6ylUFH4	https://www.babi.sh/recipes/coq-au-vin	https://res.cloudinary.com/dd27yihoo/image/upload/v1760217634/qggynlnkmhze8roieemn.webp	2025-10-11	7200	\N	\N
-coqauvin	Coq au Vin inspired by Donnie Brasco	coqauvin	https://www.youtube.com/watch?v=VP1uTgikarU&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/VP1uTgikarU/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/coqauvin	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695986/babishImages/undefined-867897.png	2019-01-15	3600	4	servings
-corn-dogs	CORN DOGS	corn-dogs	https://www.youtube.com/watch?v=zGT45vVJNso	https://www.babi.sh/recipes/corn-dogs	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695001/babishImages/undefined-765280.png	2021-05-27	\N	6	servings
+coqauvin	Coq au Vin inspired by Donnie Brasco	coqauvin	https://www.youtube.com/watch?v=VP1uTgikarU	https://www.babi.sh/recipes/coqauvin	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695986/babishImages/undefined-867897.png	2019-01-15	3600	4	servings
+corn-dogs	Corn Dogs	corn-dogs	https://www.youtube.com/watch?v=zGT45vVJNso	https://www.babi.sh/recipes/corn-dogs	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695001/babishImages/undefined-765280.png	2021-05-27	\N	6	servings
 cornbread	CORNBREAD	cornbread	https://www.youtube.com/watch?v=nAtCqHJofJk	https://www.babi.sh/recipes/cornbread	https://images.squarespace-cdn.com/content/v1/59d40133017db2fd8a60b3fe/1575566267341-AZ6STDKJCOS6J4VVLMCJ/Screen+Shot+2019-12-05+at+10.45.40+AM+%282%29.png	2019-12-12	2700	6	servings
-corned-beef	CORNED BEEF	corned-beef	https://www.youtube.com/watch?v=IDkuwVvZpWM	https://www.babi.sh/recipes/corned-beef	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695564/babishImages/undefined-160589.png	2022-03-17	\N	3	servings
-crab-bisque-seinfeld	Crab Bisque inspired by Seinfeld	crab-bisque-seinfeld	https://www.youtube.com/watch?v=5kKMB890ABc	https://www.babi.sh/recipes/crab-bisque-seinfeld	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695634/babishImages/undefined-585834.png	2022-05-27	2400	4	servings
-creme-caramel	CRÈME CARAMEL	creme-caramel	https://www.youtube.com/watch?v=ihS8__strtM	https://www.babi.sh/recipes/creme-caramel	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695974/babishImages/undefined-25052.png	2021-04-08	3600	4	servings
+corned-beef	Corned Beef	corned-beef	https://www.youtube.com/watch?v=IDkuwVvZpWM	https://www.babi.sh/recipes/corned-beef	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695564/babishImages/undefined-160589.png	2022-03-17	\N	3	servings
+crab-bisque-seinfeld	Crab Bisque inspired by Seinfeld	crab-bisque-seinfeld	https://www.youtube.com/watch?v=5kKMB890ABc	https://www.babi.sh/recipes/crab-bisque-seinfeld	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695634/babishImages/undefined-585834.png	2022-05-24	2400	4	servings
+creme-caramel	Crème Caramel	creme-caramel	https://www.youtube.com/watch?v=ihS8__strtM	https://www.babi.sh/recipes/creme-caramel	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695974/babishImages/undefined-25052.png	2021-04-08	3600	4	servings
 cremebrule	Crème Brûlée inspired by Amelie	cremebrule	https://www.youtube.com/watch?v=dn_aaxZIA2o	https://www.babi.sh/recipes/cremebrule	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715756/babishImages/undefined-451881.png	2018-04-03	\N	\N	\N
-crepessuzette	Crêpes Suzette inspired by Talladega Nights	crepessuzette	https://www.youtube.com/watch?v=Z1kR6SIr1XA&quot;,&quot;width&quot;:854,&quot;height&quot;:480,&quot;providerName&quot;:&quot;YouTube&quot;,&quot;thumbnailUrl&quot;:&quot;https://i.ytimg.com/vi/Z1kR6SIr1XA/hqdefault.jpg&quot;,&quot;resolvedBy&quot;:&quot;youtube&quot;&#125;	https://www.babi.sh/recipes/crepessuzette	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png	2019-10-24	4800	4	servings
+crepessuzette	Crêpes Suzette inspired by Talladega Nights	crepessuzette	https://www.youtube.com/watch?v=Z1kR6SIr1XA	https://www.babi.sh/recipes/crepessuzette	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695392/babishImages/undefined-957845.png	2019-10-22	4800	4	servings
 crispiest-sandwich-kidnapped-on-christmas	The Crispiest Sandwich inspired by They Kidnapped my Son on Christmas	crispiest-sandwich-kidnapped-on-christmas	https://www.youtube.com/watch?v=mhLM0FUlhJg	https://www.babi.sh/recipes/crispiest-sandwich-kidnapped-on-christmas	https://res.cloudinary.com/dd27yihoo/image/upload/v1695094920/vr0vqmqsilm4by7affx7.webp	2023-08-09	\N	1	sandwich
 croque-madame-kringle	Croque Madame Kringle	croque-madame-kringle	https://www.instagram.com/reel/C0UhkHDxwq8/?igshid=N2ViNmM2MDRjNw==	https://www.babi.sh/recipes/croque-madame-kringle	https://res.cloudinary.com/dd27yihoo/image/upload/v1701447710/snzltuylalzupksxlua9.webp	2023-12-01	\N	2	servings
 croque-monsieur-brooklyn-nine-nine	Croque Monsieur inspired by Brooklyn Nine-Nine	croque-monsieur-brooklyn-nine-nine	https://www.youtube.com/watch?v=q7JDYiLz9Mo	https://www.babi.sh/recipes/croque-monsieur-brooklyn-nine-nine	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695733/babishImages/undefined-944805.png	2020-07-21	3600	4	servings
 croquemadame	Croque Madame: The Ultimate Breakfast Sandwich	croquemadame	https://www.youtube.com/watch?v=dVRl1aP28BI	https://www.babi.sh/recipes/croquemadame	https://res.cloudinary.com/dd27yihoo/image/upload/v1689991875/uhyqawcvmpjjitgohrse.webp	2016-03-13	\N	\N	\N
-cubanos-inspired-by-chef	Cubanos inspired by Chef	cubanos-inspired-by-chef	https://www.youtube.com/watch?v=hXYoduN0kWs	https://www.babi.sh/recipes/cubanos-inspired-by-chef	https://res.cloudinary.com/dd27yihoo/image/upload/v1689992067/etfzgspqjiwp3janr32z.webp	2017-03-29	\N	\N	\N
+cubanos-inspired-by-chef	Cubanos inspired by Chef	cubanos-inspired-by-chef	https://www.youtube.com/watch?v=hXYoduN0kWs	https://www.babi.sh/recipes/cubanos-inspired-by-chef	https://res.cloudinary.com/dd27yihoo/image/upload/v1689992067/etfzgspqjiwp3janr32z.webp	2017-03-28	\N	\N	\N
 curbyourenthusiasm	Curb Your Enthusiasm Special	curbyourenthusiasm	https://www.youtube.com/watch?v=XIZxT7iI-QI	https://www.babi.sh/recipes/curbyourenthusiasm	https://res.cloudinary.com/dd27yihoo/image/upload/v1681715468/babishImages/undefined-615321.png	2017-10-10	\N	\N	\N
 curry-risotto-omurice-inspired-by-food-wars!	Curry Risotto Omurice inspired by Food Wars!	curry-risotto-omurice-inspired-by-food-wars!	https://www.youtube.com/watch?v=LPo8_trCP8M	https://www.babi.sh/recipes/curry-risotto-omurice-inspired-by-food-wars!	https://res.cloudinary.com/dd27yihoo/image/upload/v1725472664/o1xkl6c29o1zkbk7ckni.webp	2024-09-04	\N	4	servings
 dalgona-squid-games	Dalgona inspired by Squid Games	dalgona-squid-games	https://www.youtube.com/watch?v=s5SqsNPWYA4	https://www.babi.sh/recipes/dalgona-squid-games	https://res.cloudinary.com/dd27yihoo/image/upload/v1681695349/babishImages/undefined-152769.png	2021-10-13	1200	1	servings
@@ -943,6 +943,7 @@ ziti-lasagna	Baked Ziti and Lasagna inspired by The Sopranos	ziti-lasagna	https:
 --
 
 COPY public.episode_inspired_by (episode_id, reference_id) FROM stdin;
+2024oscarsspecial	642
 3-course-dinner-inspired-by-drop	574
 324-layer-croissant-inspired-by-yakitate!!-japan	593
 3daypotatosalad	21
@@ -960,7 +961,6 @@ applefritters	7
 applepie	96
 applepie	116
 applepie	117
-applepiesmoothie	115
 arc-raiders	636
 archer-margarita	23
 arepas-con-queso-encanto	627
@@ -975,6 +975,7 @@ babka-inspired-by-seinfeld	30
 bachelor-chow-futurama	535
 back-to-school-sandwich	536
 bagelsandwiches	6
+bagelwithlox	641
 bananapuddingpizza	41
 banoffeepie	284
 baobuns	22
@@ -994,8 +995,10 @@ black-and-white-cookies-seinfeld	30
 blood-pie-inspired-by-game-of-thrones	40
 blooming-fish-inspired-by-cinderella-chef	589
 blue-noodles-andor	620
+bluey-duck-cake	643
 bobbys-cookies-king-of-the-hill	37
 bobsburgers	14
+bobsburgers-potato-lasagna	14
 boeufbourguignon	98
 bone-broth	140
 bop-egg-sandwich	292
@@ -1026,10 +1029,11 @@ chicago-deep-dish-the-bear	602
 chicago-style-italian-beef-inspired-by-the-bear	602
 chicken-fingers-community	303
 chicken-kiev-mad-men	68
+chicken-meatball-hotpot-inspired-by-jujutsu-kaisen	596
 chickenpaprikash	60
 chileanseabass	31
+chimichangas	54
 chocolate-cake-inspired-by-matilda	93
-chocolate-cake-inspired-by-matilda	114
 chocolate-cake-milkshake-inspired-by-portillo's	572
 chocolate-croissants-its-complicated	623
 chocolate-pudding-rugrats	293
@@ -1038,9 +1042,9 @@ chocolatelavacakes	47
 christmas-turkey-inspired-by-national-lampoon's-christmas-vacation	558
 churrons-broad-city	546
 cinnamonrolls	42
+classic-fettucine-alfredo	649
 classicpancakes	76
 clayroastedthigh	79
-clayroastedthigh	113
 clementinecake	66
 cocktail-special	118
 cocktail-special	119
@@ -1111,6 +1115,7 @@ fried-bear-inspired-food-wars!	65
 fried-chicken-inspired-by-legend-of-zelda:-tears-of-the-kingdom	571
 fried-chicken-waffle-breakfast-lasagna-inspired-by-the-boondocks	90
 friedgreentomatoes	51
+futurama-shrimp-popplers	535
 garbageplate	74
 garlic-bread-scott-pilgrim	320
 giant-onigiri-inspired-by-cooking-from-valkyries	584
@@ -1142,6 +1147,8 @@ instant-mac-cheese	289
 isotope-dog-the-simpsons	15
 itsalwayssunnyspecial	10
 japanese-style-big-mac-inspired-by-weathering-with-you	575
+jell-o-cake-nuka-cola-and-cram-inspired-by-fallout	639
+jerk-meat-platter-inspired-by-futurama	535
 jiggly-souffle-omelette-inspired-by-food-wars!	65
 johnnycakes	44
 judys-hot-cocoa-santa-clause	330
@@ -1182,6 +1189,7 @@ maisel-brisket	298
 marmalade	287
 mayors-request-cloudy-with-a-chance-of-meatballs	630
 mc1035-archer	23
+mean-girls-toaster-strudel	644
 meat-pies-sweeny-todd	556
 meat-tornado-parks-and-rec	19
 meatballs-30rock	50
@@ -1205,6 +1213,7 @@ nipples-of-venus-amadeus	609
 nypizzatmnt	109
 okonomiyaki	52
 omelette-du-fromage-dexters-laboratory	326
+one-piece-tuna-saute	568
 orangemochafrapp	12
 orangemochafrapp-fpm9l	11
 ossobuco	80
@@ -1212,6 +1221,7 @@ parksandrecburger	19
 parmhero	21
 parmhero	44
 parmhero	78
+parmhero	648
 pasta-curry-inspired-by-pokemon-sword-and-shield	580
 pastaputtanesca	55
 pastrami	305
@@ -1251,6 +1261,7 @@ raspberry-danish-ant-man-and-the-wasp	319
 ratatouille	101
 regular-show-mississippi-queen	7
 remys-soup-ratatouille	101
+renaissance-wrap-inspired-by-shrek-2	640
 restaurant-wars-steven-universe	6
 ribwich	15
 rick-and-morty-every-burger	83
@@ -1373,7 +1384,6 @@ COPY public.episode_tags (episode_id, tag_id) FROM stdin;
 10-levels-of-cheesesteak	6
 10-levels-of-cheesesteak	20
 10-levels-of-cheesesteak	21
-10-levels-of-cheesesteak	31
 10-levels-of-chocolate-chip-cookies-or-with-babish	6
 10-levels-of-chocolate-chip-cookies-or-with-babish	16
 10-levels-of-chocolate-chip-cookies-or-with-babish	18
@@ -1464,7 +1474,6 @@ aglioeolio	30
 aglioeolio	31
 agua-de-jamaica-granita	7
 agua-de-jamaica-granita	18
-agua-de-jamaica-granita	19
 agua-de-jamaica-granita	31
 alwayssunny	4
 alwayssunny	12
@@ -1548,7 +1557,6 @@ aunt-petunias-pudding-harry-potter	18
 aunt-petunias-pudding-harry-potter	32
 avatar-fire-flakes	4
 avatar-fire-flakes	12
-avatar-fire-flakes	28
 avatar-fire-flakes	33
 avengersicecream	5
 avengersicecream	12
@@ -1560,11 +1568,9 @@ babish's-ultimate-chicken-parm	29
 babish's-ultimate-chicken-parm	30
 babish's-ultimate-chicken-parm	31
 babish's-ultimate-fried-chicken	6
-babish's-ultimate-fried-chicken	19
 babish's-ultimate-fried-chicken	21
 babish's-ultimate-fried-chicken	29
 babish's-ultimate-fried-chicken	30
-babish's-ultimate-fried-chicken	31
 babishpaniniwinner	4
 babishpaniniwinner	12
 babka-inspired-by-seinfeld	4
@@ -1591,7 +1597,6 @@ bagelsandwiches	28
 bagelsandwiches	31
 bagelwithlox	4
 bagelwithlox	12
-bagelwithlox	15
 bagelwithlox	16
 bagelwithlox	20
 bagelwithlox	23
@@ -1617,7 +1622,6 @@ banoffeepie	18
 banoffeepie	32
 baobuns	5
 baobuns	12
-baobuns	18
 baobuns	32
 barbacoa-de-res	13
 barbecueporkchops	13
@@ -1626,7 +1630,6 @@ barbecueporkchops	29
 barbecueporkchops	30
 barbecueporkchops	31
 baressentials	13
-baressentials-7xwwz	12
 baressentials-7xwwz	13
 baressentials-7xwwz	15
 baressentials-7xwwz	16
@@ -1774,7 +1777,6 @@ braciole	30
 braciole	32
 bread	13
 bread	16
-bread	18
 breakfast-uncrustable	1
 breakfast-uncrustable	2
 breakingbadspecial	4
@@ -1816,7 +1818,6 @@ bunnicorn-pizza	30
 bunnicorn-pizza	32
 burgers	13
 burgers	15
-burgers	18
 burgers	20
 burgers	29
 burgers	30
@@ -1986,7 +1987,6 @@ chocolate-cake-milkshake-inspired-by-portillo's	16
 chocolate-cake-milkshake-inspired-by-portillo's	17
 chocolate-cake-milkshake-inspired-by-portillo's	18
 chocolate-cake-milkshake-inspired-by-portillo's	31
-chocolate-croissants-its-complicated	4
 chocolate-croissants-its-complicated	12
 chocolate-croissants-its-complicated	16
 chocolate-croissants-its-complicated	18
@@ -2023,7 +2023,6 @@ christmas-turkey-inspired-by-national-lampoon's-christmas-vacation	30
 christmas-turkey-inspired-by-national-lampoon's-christmas-vacation	32
 churrons-broad-city	4
 churrons-broad-city	12
-churrons-broad-city	15
 churrons-broad-city	16
 churrons-broad-city	18
 churrons-broad-city	33
@@ -2147,7 +2146,6 @@ croquemadame	12
 croquemadame	20
 croquemadame	28
 croquemadame	31
-croquemadame	32
 cubanos-inspired-by-chef	5
 cubanos-inspired-by-chef	12
 cubanos-inspired-by-chef	20
@@ -4110,6 +4108,16 @@ COPY public.guest (id, name, image_link) FROM stdin;
 72	David (Brother)	\N
 73	Sarah and Stefan	\N
 74	The Rae Family	\N
+75	Brian Sa	\N
+76	Alvin Zhou	\N
+77	Kendall Beach	\N
+78	Sohla El-Waylly	\N
+79	Chris Parnell	\N
+80	H. Jon Benjamin	\N
+81	Jess	\N
+82	Olivia Tiedemann	\N
+83	You Suck at Cooking	\N
+84	Dominique Ansel	\N
 \.
 
 
@@ -4118,8 +4126,17 @@ COPY public.guest (id, name, image_link) FROM stdin;
 --
 
 COPY public.guest_appearances (episode_id, guest_id) FROM stdin;
+10-levels-of-cheesesteak	75
+18-pound-giant-fried-chicken-bowl	76
+28-layer-chocolate-cake	76
+324-layer-croissant-inspired-by-yakitate!!-japan	76
+324-layer-croissant-inspired-by-yakitate!!-japan	77
+4-cheese-lasagna-inspired-by-one-piece	76
 5mill-special	67
 5mill-special	68
+a5-wagyu-roti-don-inspired-by-food-wars!	76
+andrewsohlathanksgiving	78
+archer-margarita	80
 arresteddevelopmentspecial	50
 bagels	58
 beetandacorncookies	55
@@ -4134,18 +4151,27 @@ being-with-babish-3	67
 being-with-babish-3	68
 being-with-babish-3	69
 being-with-babish-3	71
-being-with-babish-4	68
 being-with-babish-4	73
+being-with-babish-4	79
 being-with-babish-5	63
 being-with-babish-6	68
 being-with-babish-6	72
 buttermilk-pancakes-inspired-by-twin-peaks	66
 cajunfood	64
+calistyle-burrito	81
+cheesecake-inspired-by-junior's-cheesecakes	76
+chicken-meatball-hotpot-inspired-by-jujutsu-kaisen	76
 chocolate-cake-inspired-by-matilda	57
+chocolate-cake-milkshake-inspired-by-portillo's	76
 chocolatelavacakes	52
 chocolatelavacakes	53
+christmas-turkey-inspired-by-national-lampoon's-christmas-vacation	82
+classic-fettucine-alfredo	76
 classicpancakes	58
+clayroastedthigh	83
 coffee	60
+copy-cat-spicy-vodka-rigatoni	76
+creme-caramel	84
 deathsandwich	65
 direwolfbread	49
 friedgreentomatoes	68
@@ -4283,7 +4309,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 124	Toasted Jalapeño Points	\N	8 ounces cream cheese, softened\n5-6 jalapeños, seeded and diced (with additional slices for garnish)\n6 ounces mozzarella, shredded\nStore bought puff pastry\n2 eggs	In a bowl combine 8 ounces of softened cream cheese with 5-6 seeded and diced jalapeños along with 6 ounces of mozzarella cheese. Stir to combine.\nRoll out your store bought pastry and cut into even squares. Beat 2 eggs in a bowl and brush egg wash along all 4 edges of puff pastry square. Place a dollop of your cream cheese mixture in the middle and fold it over on itself. Crimp the edges shut and then brush outside with an egg wash.\nSeason with salt and place a slice of jalapeño in the middle as a garnish.\nPlace in a 400°F oven for 10-15 minutes or until golden brown.\nLet cool then serve and enjoy!	sandyfryesappetizers
 125	Mozzarella Volcano	\N	Puff Pastry #1\nParmesan cheese, grated\nRomano cheese, grated\nMozzarella cheese, grated\nEgg\nWarm tomato sauce	Roll out your puff pastry and then cut into strips. Cover entire puff pastry with grated parmesan, romano, and mozzarella cheese.\nBeat one egg and brush the tops and bottoms of the puff pastry with the egg wash.\nRoll each strip from one end to the other forming a little volcano.\nAdd volcanos to a parchment lined baking sheet and bake at 400°F for 15-20 minutes.\nRemove and let cool.\nAdd some warm tomato sauce to the top so it looks more like a volcano.\nServe and enjoy.	sandyfryesappetizers
 126	Bagels	\N	1 cup plus 2 tablespoons ice water (9 ounces)\n2 tablespoons malt syrup\n2 ⅔ cups (14 2/3 ounces) bread flour\n4 teaspoons vital wheat gluten\n2 teaspoons instant or rapid-rise yeast\n2 teaspoons salt\n¼ cup (1 1/4 ounces) cornmeal\n¼ cup (1 3/4 ounces) sugar\n1 tablespoon baking soda	In a food processor add: 14.66 ounces of bread flour, 4 tsp of vital wheat gluten, and 2 tsp of instant yeast. Pulse to combine.\nNext combine 9 ounces of cold water and 2 Tbsp of malt syrup in a bowl. Whisk to mix. Turn food processor on low and add the cold water and malt syrup mixture. Mix for about 20 seconds, stop, and let it sit for 10 minutes. Once it has rested for 10 minutes, add 2 tsp of salt. Turn the food processor on medium to high for about 90 seconds.\nRemove dough from food processor and knead for about a minute. Next, divide dough into 3.5 ounce pieces. Roll the pieces into tight balls and cover with plastic wrap and let rest for 15 minutes. Once they have rested, decide which method you will use to turn your balls of dough into bagels. For the best tutorial, watch the episode to see the difference in the methods.\nOption 1 - Twist Method: Roll out a piece of dough with a rolling pin until it’s roughly 5 inches across. Next, start from one end of the circle and start rolling the dough onto itself. Once it is rolled into a tight roll that is 9-10 inches long, it’s time to twist the dough. Place one hand on each side of the dough roll and then roll the ends in opposite directions to create the “twist”. Wrap the dough around your hand and then pinch the ends together. With the ring of dough still wrapped around your hand, roll the dough on your work surface to seal together.\nOption 2 - Punch Method: Take a ball of dough and place it on your work surface. Stick one finger into the center and shake the dough around your finger until a round hole forms. Pick up the dough and shape it with two fingers, coaxing it into a bagel shape. This method is easier, but doesn’t yield as great of a bagel texture as the twist method.\nPlace the bagels on a baking sheet covered in cornmeal. Cover that with plastic wrap and let sit for an hour. Once they’ve sat for an hour, place them in the fridge overnight or for 24 hours.\nBring water in a pot to a boil and add ¼ cup of sugar and 1 Tbsp of baking soda. Add the bagels to the water and boil for about 20 seconds on each side.\nRemove and place them on a wire rimmed baking sheet, making sure the cornmeal side is down. If you’d like to add toppings, now is the time to do it.\nAdd ½ cup of boiling water to the bottom of the pan and then place in the oven at 450°F for 20 to 25 minutes flipping them halfway through.\nLet cool, serve, and enjoy!	bagels
-127	Big Cracker	\N	10 ounces all purpose flour\n3 tsp baking powder\n½ tsp kosher salt\n1 Tbsp granulated sugar\n6 Tbsp cold butter\n2 Tbsp vegetable oil\n⅔ cup ice water	In a food processor add 10 ounces of all purpose flour along with 3 tsp of baking powder, ½ tsp of kosher salt, and 1 Tbsp of granulated sugar. Pulse to combine.\nNext add 6 Tbsp of sliced cold butter along with 2 Tbsp of vegetable oil and mix to combine before drizzling ⅔ cup of ice cold water into the food processor while it’s processing. When a ball of dough forms, remove and immediately wrap in plastic wrap and place in the fridge for 10-15 minutes.\nRemove dough from the fridge and liberally flour your work surface. Roll out your dough as thin as possible. Using a fluted biscuit cutter, cut out cracker shapes and place them on a parchment lined baking sheet. Using a toothpick add the signature Ritz Cracker 7 holes and then brush all of them down with some melted butter. Place in a 400°F oven for 10-15 minutes.\nOnce they are golden brown in the oven, remove and brush with butter and immediately sprinkle with some salt.	aristocats
+127	Homemade Ritz Crackers	\N	10 ounces all purpose flour\n3 tsp baking powder\n½ tsp kosher salt\n1 Tbsp granulated sugar\n6 Tbsp cold butter\n2 Tbsp vegetable oil\n⅔ cup ice water	In a food processor add 10 ounces of all purpose flour along with 3 tsp of baking powder, ½ tsp of kosher salt, and 1 Tbsp of granulated sugar. Pulse to combine.\nNext add 6 Tbsp of sliced cold butter along with 2 Tbsp of vegetable oil and mix to combine before drizzling ⅔ cup of ice cold water into the food processor while it’s processing. When a ball of dough forms, remove and immediately wrap in plastic wrap and place in the fridge for 10-15 minutes.\nRemove dough from the fridge and liberally flour your work surface. Roll out your dough as thin as possible. Using a fluted biscuit cutter, cut out cracker shapes and place them on a parchment lined baking sheet. Using a toothpick add the signature Ritz Cracker 7 holes and then brush all of them down with some melted butter. Place in a 400°F oven for 10-15 minutes.\nOnce they are golden brown in the oven, remove and brush with butter and immediately sprinkle with some salt.	aristocats
 128	Crème de la Crème à la Edgar	\N	1 pint heavy cream\n1 pint whole milk\n1 vanilla bean\n⅓ cup sugar\n¼ tsp ground cinnamon\n¼ tsp ground nutmeg\nPinch of salt	In a pot add 1 pint of heavy cream and 1 pint of whole milk. Stir to combine.\nScrape one vanilla bean and then add the beans and the pod to the milk mixture along with ⅓ cup of sugar, ¼ tsp ground cinnamon, ¼ tsp ground nutmeg and a pinch of salt.\nJust bring to a boil and stir to combine.\nServe with crackers and enjoy!	aristocats
 129	Coq au Vin	\N	1 whole chicken, broken down into pieces\nFlour\n3 slices thick-cut bacon\n1 carrot, chopped\n1 stalk celery, chopped\n3 cloves garlic, chopped\n½ onion, chopped\n¼ cup water\nE&J brandy\n1 ¼ cups chicken broth\n½ bottle full bodied red wine\n1 can whole San Marzano tomatoes\n2 tsp thyme\n2 tsp rosemary\nEgg noodles\nButter\nParsley, chopped	Start by breaking down your chicken into 10 pieces (2 breasts, 2 wings, 2 back pieces, 2 legs, 2 thighs). Once it’s broken down into 10 pieces, dredge your chicken in flour.\nDice up 3 slices of thick cut bacon and start to cook it in a pan over medium high heat. While that is cooking, chop your carrot, celery, garlic, and onion. Set aside.\nOnce the bacon is cooked, remove from the pan, and then add your chicken, skin side down. Cook until golden brown and crisp, then flip to the other side.\nWhile cooking, drizzle chicken with some E&J brandy and then VERY CAREFULLY flambe the chicken and then put out the flame by covering with a lid.\nOnce fire is out, remove chicken and deglaze the pan with 1 ¼ cups of chicken broth and ½ a bottle of a dry full bodied red wine. Scrape up all the fond off of the bottom, bring to a simmer and add ½ a chopped onion, 1 chopped carrot, 1 chopped stalk of celery, and 3 chopped cloves of garlic.\nAdd 1 can of whole San Marzano tomatoes. Mix to combine before adding 2 tsp of thyme and 2 tsp of rosemary. Mix to combine and break up the tomatoes into bite sized pieces.\nAdd chicken back into pan leaving them half submerged in the braising liquid, along with your cooked chopped bacon. Mix to combine.\nAfter 30 minutes, turn the chicken pieces and then 30 minutes after that, turn again.\nAdd a punch of salt. (It’s really just a pinch).\nCook some egg noodles and toss with butter, salt, and pepper.\nIn a bowl add your egg noodles along with some chicken and broth and top with some freshly chopped parsley.\nServe and enjoy!	coqauvin
 130	Tortellini En Brodo	\N	Pre-made pasta dough\n1/3 lb grated mozzarella\n1/2 cup ricotta cheese\n1/2 cup grated parmesan cheese\n2 Tbsp finely chopped basil\nKosher salt\nFreshly ground black pepper\nFresh grated nutmeg\nBeef, chicken, or veal broth\nFresh grated parmesan to top	After you make your ball of dough, wrap it tightly in plastic wrap and let it sit for 30 minutes at room temperature.\nTo make the tortellini filling, grate ⅓ pound of mozzarella cheese and then combine with equal parts ricotta and parmesan cheese (about ½ cup each). Finely chop some basil and add that to the mixture along with salt, pepper, and a little freshly grated nutmeg. Mix to combine. Cover and refrigerate until ready to be used.\nRoll out your dough either by hand or by using a pasta-making KitchenAid attachment. It should be in one long thing strip (mine was on the second thinnest setting). Cut out small rounds from the sheet of dough. Reuse leftover dough for more rounds. Fill each round of dough with about a teaspoon of your cheese mixture. Use some water to wet the edges and then fold over and seal with the other side. Grab both corners and bring them together in the middle to make that tortellini shape. Do that for as many tortellini as you’d like to make.\nCook in boiling water for 3-5 minutes and then place a few tortellini in each bowl for serving.\nFill each bowl with either beef, chicken, or veal broth - just enough to cover the pasta. Top with grated parmesan cheese.\nServe and enjoy!	pasta2
@@ -4382,7 +4408,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 223	Rajas Con Crema	\N	3 poblano peppers\n¼ white onion, sliced\nDried oregano\n¼ cup heavy cream\n½ lime, juiced\nSalt and pepper	Remove the tops and seeds from 3 poblano peppers and cut in half. Place peppers on an open flame until they turn black on the outside. Once they’re black put them in foil 10 minutes to let them rest and soften up.\nRemove from foil and remove all the charred outside skin and slice them into strips or into bite sized pieces.\nIn a skillet add ½ white onion sliced with some olive oil and saute for about 1-2 minutes before adding your poblano peppers and some dried oregano. Let cook for a few minutes.\nNext add ¼ cup of heavy cream and the juice of ⅓ a lime and cook for about 5 minutes or until thickened. Salt and pepper to taste.\nRemove from skillet and place in a bowl. Set aside.	tacos
 224	Pickled Radishes	\N	4 radishes, thinly sliced\n2ish cups of apple cider vinegar\nMustard seeds, whole peppercorns, and dill (optional)	Scrub, wash, and thinly slice 4 radishes and place in a heat proof bowl.\nAdd about 2 cups of hot apple cider vinegar and let sit for about an hour or until cooled off.\nOptionally you can add mustard seeds, whole peppercorns, or dill if you’d like, but it’s not necessary.	tacos
 225	Other Taco Garnishes	\N	Half of one white onion, diced\nCilantro or parsley to taste\nOne lime, juiced\nCotija or feta cheese	Chop one onion and mix with cilantro (or parsley) along with the juice of one lime. Let sit for 15 minutes.	tacos
-226	Car Panini	\N	Mole Sauce\nPasilla dried chilis\nGuajillo dried chilis\nAncho dried chilis\n1 tsp whole cloves\n1 tsp peppercorn\n3 bay leaves, crumbled\n1 cinnamon stick\n1 corn tortilla\n1 slice of white bread\n⅓ cup peanuts\n⅓ cup pumpkin seeds\n⅓ cup almonds\n⅓ cup raisins\n¼ cup sesame seeds\n1 large tomato, quartered\n1 large onion\n4 cloves of garlic\n¼ tsp dried thyme\n¼ tsp marjoram\n¼ tsp aniseed\n4 cups chicken stock, hot\n4 ounces bittersweet chocolate, chopped\nSugar (if necessary)\nTomatillos (optional)\nCheddar Crisps\nShredded mild cheddar cheese\nGoat Cheese Cream\n5 ounces goat cheese\n1 Tbsp honey\n2 Tbsp heavy cream\nSandwich Stuff\n2 slices of white bread\nChorizo	Start by stemming and seeding some dried pasilla, guajillo, and ancho chilis. Save a few tablespoons of the seeds.\nHeat a cast iron skillet to a medium heat and add chilis. Dry roast them for about 2 minutes. Place about 12 chilis into a blender and set aside. Remove any extra chilis from skillet.\nIn the same skillet add 1 tsp whole cloves, 1 tsp peppercorns, 3 crumbled bay leaves, 1 cinnamon stick broken into a few pieces, and some of our reserved chili seeds. Dry roast for about 2 minutes or until the seeds darken. Remove from skillet and add to the blender.\nAdd one corn tortilla that has been torn into smaller pieces to the skillet cook with a little bit of oil until they turn brown. Add them to the blender.\nToast 1 piece of white bread and add that to the blender.\nAdd some vegetable oil to the pan along with ⅓ cup each of peanuts, pumpkin seeds, almonds and raisins. Roast for about one minute before adding ¼ cup of sesame seeds. Let it go for one more minute before placing all of it into the blender.\nAdd some oil to the skillet and turn to a medium high heat. Add 1 large quartered tomato, 1 large chopped onion, and 4 cloves of garlic (If you have tomatillos this is the time to add them). Let them sit undisturbed for about a minute, letting them get nice and brown. Add ¼ tsp each of dried thyme, marjoram, and aniseed. Cook for about a minute and then add to the blender.\nHeat up 4 cups of chicken stock and add that to the blender. Let everything sit in the blender for 10 minutes. Blend on medium for about 2 minutes or until smooth.\nAdd blended sauce to a large saucepan and cook on medium-low heat for about an hour.\nRun the sauce through a mesh sieve until you have a thick paste in the sieve and a smooth puree below.\nAdd the puree back to saucepan on a medium heat and add 4 ounces of chopped bittersweet chocolate. Taste and add sugar if necessary.\nPreheat oven to 425°F. Place a small handful of cheddar cheese in six piles on a cookie sheet lined with a silicon mat or parchment paper. Bake the cheese for about 10 minutes, checking constantly just until all cheese is melted and edges begin to brown. Remove from oven and let cool slightly. Transfer crisps to a wire rack to cool.\nIn a blender combine 5 ounces of goat cheese with 1 Tbsp of honey and 2 Tbsp of heavy cream. Blend on high speed until you have a thick spreadable cream.\nIn a skillet cook up one piece of chorizo until your preferred doneness. Cut into 4 pieces.\nButter both slices of bread on the outside. On one piece of bread, slather some mole, top with cooked chorizo sausages, cheese crisps, and goat cheese cream. Top with other piece of bread. Place into your panini press/George Foreman grill. Serve and enjoy!	babishpaniniwinner
+226	Winning #BabishPanini Car Panini	\N	Mole Sauce\nPasilla dried chilis\nGuajillo dried chilis\nAncho dried chilis\n1 tsp whole cloves\n1 tsp peppercorn\n3 bay leaves, crumbled\n1 cinnamon stick\n1 corn tortilla\n1 slice of white bread\n⅓ cup peanuts\n⅓ cup pumpkin seeds\n⅓ cup almonds\n⅓ cup raisins\n¼ cup sesame seeds\n1 large tomato, quartered\n1 large onion\n4 cloves of garlic\n¼ tsp dried thyme\n¼ tsp marjoram\n¼ tsp aniseed\n4 cups chicken stock, hot\n4 ounces bittersweet chocolate, chopped\nSugar (if necessary)\nTomatillos (optional)\nCheddar Crisps\nShredded mild cheddar cheese\nGoat Cheese Cream\n5 ounces goat cheese\n1 Tbsp honey\n2 Tbsp heavy cream\nSandwich Stuff\n2 slices of white bread\nChorizo	Start by stemming and seeding some dried pasilla, guajillo, and ancho chilis. Save a few tablespoons of the seeds.\nHeat a cast iron skillet to a medium heat and add chilis. Dry roast them for about 2 minutes. Place about 12 chilis into a blender and set aside. Remove any extra chilis from skillet.\nIn the same skillet add 1 tsp whole cloves, 1 tsp peppercorns, 3 crumbled bay leaves, 1 cinnamon stick broken into a few pieces, and some of our reserved chili seeds. Dry roast for about 2 minutes or until the seeds darken. Remove from skillet and add to the blender.\nAdd one corn tortilla that has been torn into smaller pieces to the skillet cook with a little bit of oil until they turn brown. Add them to the blender.\nToast 1 piece of white bread and add that to the blender.\nAdd some vegetable oil to the pan along with ⅓ cup each of peanuts, pumpkin seeds, almonds and raisins. Roast for about one minute before adding ¼ cup of sesame seeds. Let it go for one more minute before placing all of it into the blender.\nAdd some oil to the skillet and turn to a medium high heat. Add 1 large quartered tomato, 1 large chopped onion, and 4 cloves of garlic (If you have tomatillos this is the time to add them). Let them sit undisturbed for about a minute, letting them get nice and brown. Add ¼ tsp each of dried thyme, marjoram, and aniseed. Cook for about a minute and then add to the blender.\nHeat up 4 cups of chicken stock and add that to the blender. Let everything sit in the blender for 10 minutes. Blend on medium for about 2 minutes or until smooth.\nAdd blended sauce to a large saucepan and cook on medium-low heat for about an hour.\nRun the sauce through a mesh sieve until you have a thick paste in the sieve and a smooth puree below.\nAdd the puree back to saucepan on a medium heat and add 4 ounces of chopped bittersweet chocolate. Taste and add sugar if necessary.\nPreheat oven to 425°F. Place a small handful of cheddar cheese in six piles on a cookie sheet lined with a silicon mat or parchment paper. Bake the cheese for about 10 minutes, checking constantly just until all cheese is melted and edges begin to brown. Remove from oven and let cool slightly. Transfer crisps to a wire rack to cool.\nIn a blender combine 5 ounces of goat cheese with 1 Tbsp of honey and 2 Tbsp of heavy cream. Blend on high speed until you have a thick spreadable cream.\nIn a skillet cook up one piece of chorizo until your preferred doneness. Cut into 4 pieces.\nButter both slices of bread on the outside. On one piece of bread, slather some mole, top with cooked chorizo sausages, cheese crisps, and goat cheese cream. Top with other piece of bread. Place into your panini press/George Foreman grill. Serve and enjoy!	babishpaniniwinner
 227	Chili	\N	1 spanish onion, diced\n1 green pepper, diced\n4 cloves garlic, minced\n1 lb ground chuck\n2 Tbsp chili powder\n1 Tbsp white pepper\n1 Tbsp cumin\n1 14.5 ounce can crushed tomatoes\n14.5 ounces of water\n1 can of kidney beans\n1 can of chipotles in adobo, peppers removed (we’ll be using the sauce)\n1 tsp smoked paprika\n1 tsp oregano	Start by dicing 1 spanish onion and 1 green pepper along with mincing 4 cloves of garlic. In a large saucepan, add 1 pound of ground round chuck and cook until browned. Remove from pan and drain off all but a little of the beef fat, then add onion and pepper.\nOnce everything is nice and soft, add garlic, 2 Tbsp chili powder, 1 Tbsp white pepper, and 1 Tbsp cumin. Stir to combine for 1 minute.\nNext add one 14.5 ounce can of crushed tomatoes, 14.5 ounces of water, the browned beef, 1 can of kidney beans, the adobo sauce from the can of chipotle peppers, 1 tsp smoked paprika, and 1 tsp oregano. Stir to combine over a medium-low heat for about an hour.	eggscellentchallenge
 228	Omelette	\N	12 eggs\n1 red pepper\n1 green pepper\n16 ounces mushrooms\nSalt	Cut up 1 red pepper, 1 green pepper, and 16 ounces of mushrooms.\nIn a cast iron skillet melt 1-2 Tbsp of butter over medium heat. Add your mushrooms with a generous pinch of salt. Once the mushrooms have dried out a little bit, add your peppers and saute until everything is nice and soft. Place in a bowl and set aside.\nIn the same cast iron skillet add 1-2 Tbsp of butter along with a few tsp of olive oil. In a separate bowl combine 12 eggs and whisk to combine. Pour this mixture into the pan. Stir around with a fork until some curds form. Keep doing this until you can see the bottom of the pan when you move the fork. At this point let the eggs cook for about 2 minutes and let a sort of omelette crust form. Add your mushroom and pepper fillings and fold the omelette shut.\nUsing two spatulas, move to a large plate. Cover with 4 cups of chili, 2 cups of american cheese and add two biscuits. You have one hour to finish this omelette and 5 pounds of fruit. Enjoy!	eggscellentchallenge
 229	Fruit	\N	1 watermelon\n1 cantaloupe\n1 honeydew melon	Cut up 1 watermelon, 1 cantaloupe, and 1 honeydew melon into 1-inch cubes. Place in a bowl and mix to combine. The sum total should be 5 pounds.	eggscellentchallenge
@@ -4460,7 +4486,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 301	Dirty Martini	\N	2 oz Vodka\n1 oz Sweet vermouth\n1 oz Olive juice\n1 Olive, for garnish	Mix and pour into a chilled martini glass. Add an olive on a toothpick. Serve.	baressentials
 302	Dry Martini	\N	3 1/2 oz Vodka\n1/2 oz Sweet Vermouth	Shake and strain into a chilled martini glass. Serve neat.	baressentials
 303	The Old Fashioned	\N	2 oz Bourbon\nAngostura bitters\nOrange peel\nSimple syrup	Mix and serve.	baressentials
-304	Margaretta	\N	4 oz Tequila\n1 oz Triple Sec\nLime juice\nSalt	Salt the rim of a glass using lime juice.\nMix and serve.	baressentials
+304	Margarita	\N	4 oz Tequila\n1 oz Triple Sec\nLime juice\nSalt	Salt the rim of a glass using lime juice.\nMix and serve.	baressentials
 305	Mojito	\N	Sugar Cubes\nLimes\nMint\nIce\n2 oz White rum\nClub soda	Muddle sugar and limes in the bottom of a glass.\nAdd ice and rum and mix with a spoon.\nTop with ice and club soda.\nGarnish with a lime.\nMetal straw recommended.	baressentials
 306	Pineapple-Curry Fried Rice	\N	Dried Chinese chilis\n1 tsp coriander seeds\n1 tsp cardamom\n2 tsp cumin seed\n1 tsp mustard seeds\n1 tsp peppercorns\n1 crushed cinnamon stick\n1 Tbsp grated ginger\n1 Tbsp grated turmeric\n2 cups short grain rice\n1 Pineapple\n2 eggs\nVegetable oil\n1 red pepper\n1 carrot\n1 bird’s eye chili (optional)\n1 crushed clove of garlic\nKosher salt\n1 Tbsp rice wine vinegar\n1 Tbsp fish sauce\n1 Tbsp sesame oil\n1 Tbsp soy sauce\nGreen onions\nChopped cashews	First we are going to toast and grind our spice mixture. In a saucepan, combine a few chinese chilis, 1 tsp coriander seed, 1 tsp cardamom, 2 tsp cumin seed, 1 tsp mustard seeds, 1 crushed cinnamon stick, and 1 tsp peppercorns. Cook over high heat until fragrant and slightly smoking, and then add to spice grinder, grind, and set aside.\nNext add 2 cups of short grain rice and 4 cups of water to a pan that you’re going to cover tightly and place in a 325°F for 5 minutes longer than the specified boiling time. Once cooked, spread rice on a baking sheet to cool for an hour.\nPrep all of your accoutrements. Chop your red peppers, carrots, green onions, chopped cashews, and bird’s eye chili.\nSlice pineapple in half. Place a cut skin deep around the pineapple and score at 2 cm wide intervals, and scoop out into a bowl and set aside.\nIn a wok, heat 3 Tbsp of vegetable oil over maximum heat. Add 2 beaten eggs to the wok and cook until just barely set and then add your chopped red pepper, carrot, and bird’s eye chili. Add 1 Tbsp grated ginger, 1 Tbsp grated turmeric, and 1 crushed clove of garlic. Give it a good mix before adding all of the rice.\nNext add a little bit of our spice powder, some kosher salt, 1 Tbsp each of rice wine vinegar, fish sauce, sesame oil, and soy sauce.\nStir and continue to cook over a high heat before adding pineapple. Add some chopped green onions and some chopped cashews.\nMake sure that you slightly undercook the rice because we’re going to steam cook it a little bit more in our hollowed out pineapple.\nSalt both sides of your pineapple.\nFill one half of the pineapple with all of the rice, and form it into a mound. Cover with the other side of the pineapple and place in a 375°F oven for 30 minutes.\nGenerously butter a bowl.\nTake the pineapple out of the oven and scoop rice into buttered bowl. Place a plate upside down on top of the bowl, and while holding the bowl and plate, flip over so the plate is on the bottom and the bowl is on top. Lay the Pineapple stem at the top for aesthetics. Dig in and enjoy!	pineapplecurryfriedrice
 307	Clementine Cake	\N	Clementines\n3 cups of sugar\n450g of cake flour\n1 ½ tsp salt\n¾ tsp of baking powder\n¾ tsp baking soda\n1 ½ cup of butter\n487.5g of sugar\n6 large eggs\n3 tsp vanilla extract\n¾ cup clementine juice\nZest of 4 clementines\n1 ¼ cup buttermilk\nNonstick spray\nParchment paper	Start by slicing 3 clementines for candying. Make sure you slice them very thin.\nPoach the clementines in boiling water for 1 minute, and then shock them by transferring them to a bowl of ice water.\nCombine 3 cups of sugar and 1 ½ cups of water in a large saucepan. Add a little squeeze of clementine juice and bring to a sweet gentle simmer. Add clementines in a single layer and simmer for 90 minutes, flipping every 30 minutes.\nOnce soft and translucent, cool on a wire rack and pour clementine syrup into a measuring cup for later. Set aside.\nWeigh out 450g of cake flour to which you’re going to add 1 ½ tsp of salt, ¾ tsp of baking powder, and ¾ tsp of baking soda. Whisk to combine.\nIn the bowl of a stand mixer, mix 1 ½ cups of butter until creamy\nScrape down the sides of the bowl and add 487.5g of sugar and mix that as well.\nScrape down the sides again, and add 6 large eggs and 3 tsp of vanilla extract. Mix again.\nAdd ¾ cup of clementine juice and the zest of 4 clementines and mix to combine.\nFinally add the dry ingredients and 1 ¼ cups of buttermilk and mix just enough to combine.\nCoat a cake pan with nonstick spray and parchment paper. Add the cake batter and cook at 350°F for 45 minutes.\nUse a cake tester or a knife to make sure the cake is completely done.\nGenerously brush down the cake with clementine syrup.\nPour glaze over the top and add candied clementines.\nSlice yourself a piece and enjoy.	clementinecake
@@ -4826,8 +4852,8 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 676	Cream Filling	\N	1 ¼ cup heavy cream, plus an additional ¼ cup set aside\n1 package gelatin\n⅔ cup granulated sugar\n1 lb cream cheese\n½ large lemon (juiced and zested)\n½ tsp vanilla extract\n50 drops red food coloring\nKosher salt		imaginary-pie-hook
 677	Whipped Cream	\N	1 cup heavy cream\n1 Tbsp granulated sugar\n15 drops blue food coloring (in separate batch)\n15 drops green food coloring (in separate batch)		imaginary-pie-hook
 678	Brisket inspired by The Marvelous Mrs. Maisel	\N	First Cut (flat cut) of brisket\n4 medium carrots\n4 stalks celery\n4 medium onions\n4 cloves garlic\nSprigs of thyme\n¼ cup light brown sugar\n2 Tbsp tomato paste\n2 Tbsp flour (if you want to stay Kosher, substitute potato starch)\n1 ½ cups dry red wine\n1 ½ cup beef broth\n½ cup ketchup\n1 cup crushed tomatoes\n¼ cup white wine vinegar\n3-4 bay leaves\n1 Tbsp paprika\n1 tsp cayenne pepper (Optional)\n2 Tbsp honey\n2 Tbsp dijon mustard		maisel-brisket
-679	Crust	\N	300 grams all-purpose flour\n2 Tbsp sugar\n1 tsp kosher salt\n225 grams unsalted butter, cold & cubed\n6-8 Tbsp ice water		ben-wyatt-calzones
-680	Filling	\N	2lbs honey crisp apples, peeled and sliced\n1 lemon, juiced\n¾ cup sugar\n1 ½ Tbsp cornstarch\n¼ cup brown sugar\n2 tsp cinnamon\n½ tsp ground ginger\n½ tsp allspice\n¼ tsp ground clove\nZest of 1 lemon\n1 tsp kosher salt\n1 egg white\nDemerara sugar		ben-wyatt-calzones
+679	Pie Dough Crust	\N	300 grams all-purpose flour\n2 Tbsp sugar\n1 tsp kosher salt\n225 grams unsalted butter, cold & cubed\n6-8 Tbsp ice water		ben-wyatt-calzones
+680	Apple Pie Filling	\N	2lbs honey crisp apples, peeled and sliced\n1 lemon, juiced\n¾ cup sugar\n1 ½ Tbsp cornstarch\n¼ cup brown sugar\n2 tsp cinnamon\n½ tsp ground ginger\n½ tsp allspice\n¼ tsp ground clove\nZest of 1 lemon\n1 tsp kosher salt\n1 egg white\nDemerara sugar		ben-wyatt-calzones
 681	Tomato Sauce	\N	2 Tbsp olive oil\n½  small onion, minced\n2 cloves garlic, crushed\n2 Tbsp tomato paste\n28 oz can of san marzano tomatoes\nSprig of fresh basil\nKosher salt\nFreshly ground pepper		ben-wyatt-calzones
 682	Mozzarella	\N	1 tsp cheese salt (optional)\n1 ½ tsp citric acid\n¼ tsp animal or vegetable rennet\n1 gallon whole milk\n1 cup non-chlorinated water\n¼ cup non-chlorinated water		homemade-mozzarella
 683	Caprese Dressing	\N	1 whole anchovy, minced\n1 piece dried seaweed, finely chopped\n2 Tbsp white wine vinegar\n½ lemon, squeezed\n2 Tbsp olive oil\nKosher salt\nFreshly ground pepper\n2 splashes balsamic vinegar		homemade-mozzarella
@@ -4955,8 +4981,8 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 805	Pie Crust	\N	150 g of all-purpose flour\n1 tsp kosher salt\n1 stick (113 g) refrigerator cold butter\n50 g ice cold water		chicken-pot-pie
 806	Filling	\N	Chicken (white meat), cubed\n4 tbsp butter\n½ onion, chopped\nCelery , chopped\nCarrots, chopped\nParsnips, chopped\n1 Tbsp thyme, chopped\n4 tbsp all-purpose flour\n¼ cup white wine (or dried sherry)\n2 cups chicken stock\nKosher salt\nFreshly ground black pepper\n2 tbsp parsley, chopped\n½ cup frozen peas\n¼ cup heavy cream		chicken-pot-pie
 807	Frozen Filling	\N	Chicken (dark meat), cubed\nVegetable Oil\n½ onion, chopped\nCelery , chopped\nCarrots, chopped\nParsnips, chopped\n1 cup thyme, chopped\n2 cups chicken stock\nKosher salt\nFreshly ground black pepper\n2 tbsp parsley, chopped\n½ cup frozen peas\n2-3 tbsp cornstarch\n½ cup cold chicken stock		chicken-pot-pie
-808	Casserole Dish Prep	\N	2 tbsp mayonnaise\n¼ cup finely crumbled cotija cheese		andrewsohlathanksgiving
-809	The Casserole	\N	1 ⅔ cups fresh or frozen corn kernels		andrewsohlathanksgiving
+808	Elote Spoon Bread Pan Prep	\N	2 tbsp mayonnaise\n¼ cup finely crumbled cotija cheese		andrewsohlathanksgiving
+809	Elote Spoon Bread	\N	1 ⅔ cups fresh or frozen corn kernels		andrewsohlathanksgiving
 810	Optional Dry Brine	\N	1 tsp salt per pound of turkey		andrewsohlathanksgiving
 811	Southwestern Compound Butter	\N	12 tbsp unsalted butter, softened, divided\n2 tbsp garlic powder\n2 tsp cayenne\n1 tsp cumin\n2 tsp coriander\n1 tbsp kosher salt		andrewsohlathanksgiving
 812	The Turkey	\N	2 onions, quartered (optional)\n6 stalks celery, chopped into 4 inch pieces (optional)\n4 carrots,  chopped into 4 inch piece (optional)\n1 turkey, preferably 12-15 lbs.\nAs needed, kosher salt\nAs needed, pepper		andrewsohlathanksgiving
@@ -5078,7 +5104,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 933	For Serving	\N	White onion, diced\nJalapeno peppers, thinly sliced\nLimes, quartered\nCilantro		birria-tacos
 934	Easy Shortbread Biscuit	\N	8 oz unsalted butter, very soft + more for greasing\n½ tsp kosher salt\n3.5 oz granulated sugar\n12 oz all purpose-flour		biscuits-ted-lasso
 935	Improved Shortbread Biscuit	\N	5 oz unsalted butter, very soft + more for greasing\nAs needed demerara sugar\n2 oz browned butter, soft (see recipe below)\n¾ tsp kosher salt\n5 oz toasted sugar (see recipe below)\n9.5 oz all purpose flour\n2 oz cornstarch		biscuits-ted-lasso
-936	https://www.seriouseats.com/recipes/2016/05/dry-toasted-sugar-granulated-caramel-recipe.html	\N	4 cups white granulated sugar		biscuits-ted-lasso
+936	Toasted Sugar	\N	4 cups white granulated sugar		biscuits-ted-lasso
 937	Browned Butter	\N	1 stick unsalted butter		biscuits-ted-lasso
 938	Recipe Credit: https://cooking.nytimes.com/recipes/12884-basic-short-crust-pastry	\N	145 g all-purpose flour\n½ tsp kosher salt\n1 stick unsalted butter, cold + cubed\n3-4 Tbsp water, cold		quiche
 939	Recipe Credit: https://www.kingarthurbaking.com/recipes/all-butter-pie-crust-recipe	\N	300 g all-purpose flour\n1 tsp kosher salt\n2 sticks unsalted butter, cold + cubed\n60 g - 120 g water, cold		quiche
@@ -5138,7 +5164,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 993	Avocado Mayonnaise	\N	1 ripe avocado, peeled + pit removed\n½ tsp onion powder\n¼ tsp garlic powder\n1 Tbsp freshly squeezed lemon juice\n¼ tsp kosher salt\n2 Tbsp avocado oil\nOptional: hot sauce		bacon
 994	Classic BLT	\N	2 classic bacon slices\n2 tomato slices\nAs needed kosher salt\n1 Tbsp unsalted butter, soft\n2 slices hearty white bread\n1 Tbsp mayonnaise, preferably homemade\n2 iceberg lettuce leaves		bacon
 995	Fancy Boy BLT	\N	2 pastrami bacon slices\n2 slices tomato\nAs needed kosher salt\n2 slices sourdough or peasant bread\n1 Tbsp mayonnaise\n2 butter lettuce leaves		bacon
-996	Healthy-esque BLT ingredients	\N	2 classic bacon slices\n2 slices tomato\nAs needed kosher salt\n2 slices seeded whole wheat bread\n1 Tbsp unsalted butter\n1 Tbsp avocado mayonnaise\n¼ cup (loosely packed) alfalfa sprouts\nTo taste kosher salt\nTo taste freshly ground black pepper		bacon
+996	Healthy-esque BLT	\N	2 classic bacon slices\n2 slices tomato\nAs needed kosher salt\n2 slices seeded whole wheat bread\n1 Tbsp unsalted butter\n1 Tbsp avocado mayonnaise\n¼ cup (loosely packed) alfalfa sprouts\nTo taste kosher salt\nTo taste freshly ground black pepper		bacon
 997	Savory Custard	\N	125 g whole milk\n125 g heavy cream\n1 tsp kosher salt + more to taste\n1 Tbsp sugar\n3 egg yolks\n¼ tsp onion powder\n¼ tsp garlic powder\n2 Tbsp fresh dill, chopped\n1 small dill pickle, finely chopped\nJuice of 1 lemon\nTo taste freshly ground black pepper		fish-fingers-custard-doctor-who
 998	Battered Fish Fingers	\N	48 oz peanut oil\n1 ½ Cups + 2 Tbsp all purpose flour\n½ Cup cornstarch\n1 tsp kosher salt\n1 tsp baking powder\n½ tsp paprika\n¼ tsp cayenne\n4 cod fish fillets\n1 ½ - 2 Cups lager beer, very cold\nAs needed kosher salt\nSavory custard		fish-fingers-custard-doctor-who
 999	Breakfast Burrito	\N	3 Tbsp butter\n15 eggs\nTo taste kosher salt\nTo taste freshly ground black pepper\n1 Tbsp neutral oil\n1 onion, diced\n1 bunch Swiss chard, stems removed + leaves chopped\n4 chicken sausages (pre-cooked), chopped\n6 large flour tortilla\n12 oz gruyere or cheddar cheese, grated		freezer-meals
@@ -5274,7 +5300,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1129	French Fries	\N	3-4 large Yukon gold potatoes\n1 Tbsp white vinegar\nAs needed kosher salt\nAs needed fry oil		calistyle-burrito
 1130	California Burrito	\N	Large flour tortillas (~12” diameter)\nGuacamole\nSour cream\nFrench fries\nCarne asada\nMonterey jack cheese, shredded\nSalsa verde\nSalsa roja		calistyle-burrito
 1131	Original Almond Biscotti	\N	As needed nonstick spray\n250 g all-purpose flour\n1 tsp baking powder\n¼ tsp baking soda\n½ tsp kosher salt\n120 g whole almonds, roasted + skin-on\n3 large eggs\n175 g granulated sugar\n1 tsp almond extract\n½ tsp vanilla extract\n12 oz dark chocolate, melted		biscotti
-1132	Orange Chocolate Biscotti	\N	As needed nonstick spray\n200 g all purpose flour\n50 g cocoa powder\n1 tsp baking powder\n¼ tsp baking soda\n½ tsp kosher salt\n120 g dark chocolate\n3 large eggs\n175 g granulated sugar\nZest of 1 large orange\nOptional: ¼ tsp orange extract\n1 tsp vanilla extract\nOrange glaze (see recipe below)		biscotti
+1132	Double Chocolate Orange Biscotti	\N	As needed nonstick spray\n200 g all purpose flour\n50 g cocoa powder\n1 tsp baking powder\n¼ tsp baking soda\n½ tsp kosher salt\n120 g dark chocolate\n3 large eggs\n175 g granulated sugar\nZest of 1 large orange\nOptional: ¼ tsp orange extract\n1 tsp vanilla extract\nOrange glaze (see recipe below)		biscotti
 1133	Orange Glaze	\N	150 g  powdered sugar, sifted\nAs needed freshly squeezed orange juice\nOptional: orange food coloring		biscotti
 1134	Pistachio Cranberry Biscotti	\N	As needed nonstick spray\n250 g all-purpose flour\n1 tsp baking powder\n¼ tsp baking soda\n½ tsp kosher salt\n80 g pistachios, skin-off + roasted\n60 g dried cranberries\n3 large eggs\n175 g granulated sugar\n1 tsp vanilla extract\n12 oz white chocolate, melted		biscotti
 1135	Sous Vide Pork Belly	\N	1 ½ Cup water, divided\n1 dried ancho chile, stem and seeds removed\n⅓ Cup ice cubes\nJuice of 1 orange\nJuice of 2 limes\n5 cloves garlic, crushed\n3 dried bay leaves\n2 Mexican cinnamon sticks\n1 Tbsp Mexican oregano\n1 Tbsp black peppercorns\n1 Tbsp (packed)  brown sugar\n2 Tbsp soy sauce\n2 Tbsp mirin\n2 Tbsp kosher salt\n½ pork belly (about 4-5 lbs), skin removed\nGarlic Chili Sauce (see recipe below)\nCarrot Puree (see recipe below)\nSalsa Verde (see recipe below)\nPickled Radish (see recipe below)\nTo garnish: scallions, thinly sliced		feast-from-chef
@@ -5348,7 +5374,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1203	sauce	\N	chicken\nflour\nbuttermilk\nwhite rice flour		lava-chicken-inspired-by-a-minecraft-movie
 1204	assembly	\N	can san marzano tomatoes\ncalabrian chilis seeds removed\nflour		meatball-smashwich-with-babish
 1205	10 Levels of Chocolate Chip Cookies | With Babish	\N	flour\nbrown butter with\ndark brown sugar\nwhite sugar\nwhite chocolate caramelized\nchocolate fèves\neggs\nspelt\nice\ndark chocolate chips		10-levels-of-chocolate-chip-cookies-or-with-babish
-1206	batter dredge	\N	flour\nchicken broken down into ten pieces\nbuttermilk\nsalt\npotato starch\nwhite rice flour\nliquid egg whites		babish's-ultimate-fried-chicken
+1206	Babish's Ultimate Fried Chicken	\N	flour\nchicken broken down into ten pieces\nbuttermilk\nsalt\npotato starch\nwhite rice flour\nliquid egg whites		babish's-ultimate-fried-chicken
 1207	beans	\N	short grain rice\ndried black soybeans\nspinach\nsoy sauce\nanchovies\nsheets gim\nvegetable oil		kimbap-and-lunchbox-inspired-by-squid-game-season-2
 1208	beurre blanc	\N	unsalted danish creamery european style butter\nchicken patted completely dry\ndry white wine\nhigh quality white sturgeon caviar\nsalt\nwhite wine vinegar		turkey-and-caviar-inspired-by-star-trek:-the-next-generation
 1209	sausage	\N	fat back or pork belly cut into half inch cubes\nchicken stock more\nsalt\nblack pepper\nwild boar meat cut into one inch cubes\nhog casings\nmeat		sausage-inspired-by-god-of-war
@@ -5358,7 +5384,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1213	lentil sloppy joes	\N	baby bella mushrooms\nbacon\nspaghetti\nlentils		struggle-meals
 1214	Korean Garlic Fried Chicken inspired by Korean Street Food	\N	garlic cloves		korean-garlic-fried-chicken-inspired-by-korean-street-food
 1215	korean fried chicken powder mix	\N	flour\nsoy sauce\nbrown sugar\nhoney\nrice wine\ncorn starch		korean-garlic-fried-chicken-inspired-by-korean-street-food
-1216	assembly	\N	hot italian sausage casings removed\nsweet italian sausage casings removed\nmilk ricotta cheese\nno boil lasagna noodles for flat layers\nlow moisture mozzarella thinly\npecorino cheese\nparmesan		4-cheese-lasagna-inspired-by-one-piece
+1216	4-Cheese Lasagna	\N	hot italian sausage casings removed\nsweet italian sausage casings removed\nmilk ricotta cheese\nno boil lasagna noodles for flat layers\nlow moisture mozzarella thinly\npecorino cheese\nparmesan		4-cheese-lasagna-inspired-by-one-piece
 1217	Water Tribe Noodles inspired by The Legend of Korra	\N	spinach		water-tribe-noodles-inspired-by-the-legend-of-korra
 1218	spinach noodles	\N	flour\nshaoxing wine\ngreen onions cut into pieces		water-tribe-noodles-inspired-by-the-legend-of-korra
 1219	stir fry	\N	grain white rice\nthinly pork shoulder\npotato starch\nsoy sauce\ngarlic cloves microplaned\nsake\nsugar		18-pound-giant-fried-chicken-bowl
@@ -5377,14 +5403,14 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1232	chocolate ganache	\N	sugar\nmilk\nheavy cream\ncake flour\neggs		28-layer-chocolate-cake
 1233	pistachio pesto	\N	flour\nbasil		florentine-foccacia-sandwich-inspired-by
 1234	rigatoni	\N	mezzi rigatoni\nheavy cream\nvodka\nbutter\ngarlic cloves\na few basil\nsalt		copy-cat-spicy-vodka-rigatoni
-1235	fettucine alfredo	\N	eggs\ndouble zero flour\nsemolina flour\ntwenty four month aged parmigiano reggiano\nunsalted high quality butter		classic-fettucine-alfredo
+1235	fettuccine alfredo	\N	eggs\ndouble zero flour\nsemolina flour\ntwenty four month aged parmigiano reggiano\nunsalted high quality butter		classic-fettucine-alfredo
 1236	pastrami on rye	\N	ice\nsalt		katz's-corned-beef-and-pastrami
 1237	chocolate cake milkshake assembly	\N	cake flour\nunsweetened cocoa powder\ndutch processed cocoa powder\nmayonnaise		chocolate-cake-milkshake-inspired-by-portillo's
 1238	spaghetti all'assassina	\N	sauce\ngarlic cloves brown stem removed\nspaghettoni spaghetti, linguine\ngarlic oil\nolive oil\ncan passata preferably san marzano		spaghetti-all'assassina-inspired-by-claudia-romeo
 1239	assembly	\N	flour\npurple cabbage\npanko breadcrumbs\nmayonnaise\neggs\ngarlic		nopal-katsu-sando
 1240	assembly	\N	tomatillos husked\ncilantro\nblack beans\nblack beans drained\ngarlic		dobladitas-con-salsa-verde
 1241	serving	\N	sweet sherry\nheavy cream\nmilk\nbrown sugar\nsugar\npears peeled, halved, cored		panna-cotta-with-poached-pears
-1242	serving	\N	dried sorrel\ncinnamon orange peel, or a few cloves,\nheavy cream\nsweetened condensed milk		agua-de-jamaica-granita
+1242	Agua de Jamaica Granita	\N	dried sorrel\ncinnamon orange peel, or a few cloves,\nheavy cream\nsweetened condensed milk		agua-de-jamaica-granita
 1243	tom yum tomato cream pasta	\N	shrimp stock\ngarlic cloves\nshrimp shells\nsundried tomatoes\ngalangal root\nmakrut lime		tom-yum-tomato-cream-pasta
 1244	Spiced Rum Tarte Tatin	\N	sugar		spiced-rum-tarte-tatin
 1245	assembly	\N	heavy cream\ngranny smith apples & quartered		spiced-rum-tarte-tatin
@@ -5392,7 +5418,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1247	burgers	\N	flour		demon-burger-inspired-by-dragon-ball-daima
 1248	assembly	\N	milk\noaxaca\njalapenos\nbutter\nflour\nred tomatoes		super-stretchy-nachos
 1249	assembly	\N	3 flour\nflour\nfrozen danish creamery butter\nbrown sugar\npink lady apples cut into 1 or 4 inch thick slices\negg		apple-and-brie-galette
-1250	cinnamon sugar mixture	\N	flour\nsugar		cinnamon-rolls-3-ways-(pumpkin-spice-strawberry-nutella-classic)
+1250	classic cinnamon sugar filling	\N	flour\nsugar		cinnamon-rolls-3-ways-(pumpkin-spice-strawberry-nutella-classic)
 1251	Golden Fried Rice inspired by Kaguya-Sama: Love is War	\N	rice		golden-fried-rice-inspired-by-kaguya-sama:-love-is-war
 1252	golden fried rice with egg threads scallions	\N	eggs\neggs into yolks whites\nscallions		golden-fried-rice-inspired-by-kaguya-sama:-love-is-war
 1253	pasta	\N	japanese short grain rice\nbeef stock\nribeye steak thinly\npasta		pasta-curry-inspired-by-pokemon-sword-and-shield
@@ -5402,23 +5428,23 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1257	Giant Onigiri inspired by Cooking from Valkyries	\N	short grain rice		giant-onigiri-inspired-by-cooking-from-valkyries
 1258	assembly	\N	kewpie mayonnaise\n2 oz cans of tuna, drained\numeboshi\nsheets of nori\nsake\nsalt		giant-onigiri-inspired-by-cooking-from-valkyries
 1259	Big Bang Burger inspired by Persona 5	\N	flour		big-bang-burger-inspired-by-persona-5
-1260	condiments & toppings	\N	milk warm\nbeef\nbutter\nsugar\negg\ntomatoes thinly		big-bang-burger-inspired-by-persona-5
+1260	Burger Sauce	\N	milk warm\nbeef\nbutter\nsugar\negg\ntomatoes thinly		big-bang-burger-inspired-by-persona-5
 1261	Roast Beef inspired by Attack on Titan	\N	beef tallow\n~4 lb boneless dry aged ribeye roast\nsalt\npepper\nmirepoix\nbed of lettuce for garnish		roast-beef-inspired-by-attack-on-titan
 1262	assembly	\N	octopus\nfish stock or homemade seafood stock\nshrimp & deveined\narborio rice\nsquid tubes cut into rings\ndry white wine\nparsley stems		sanji's-seafood-risotto
 1263	assembly	\N	flour\ncake flour\nalmond flour\nmilk\nsugar\nbutter		underwear-bread-inspired-by-asteroid-in-love
-1264	garnish	\N	corn starch\npotato starch\nblack sea bass\nneutral oil\nshaoxing cooking wine\nsalt\n40g white vinegar		blooming-fish-inspired-by-cinderella-chef
-1265	ramen in hotpot broth	\N	rice\nchrysanthemum\neggs\nboneless skinless chicken thighs		chicken-meatball-hotpot-inspired-by-jujutsu-kaisen
+1264	Blooming Fish	\N	corn starch\npotato starch\nblack sea bass\nneutral oil\nshaoxing cooking wine\nsalt\n40g white vinegar		blooming-fish-inspired-by-cinderella-chef
+1265	chicken meatball hotpot	\N	rice\nchrysanthemum\neggs\nboneless skinless chicken thighs		chicken-meatball-hotpot-inspired-by-jujutsu-kaisen
 1266	Diablo Onigiri	\N	short grain rice\ngarlic\nchipotles in adobo with 1 of sauce\nshichimi togarashi\nbone in skin on chicken breasts\ncarrots\ncelery stalks\nroma tomatoes\nnori		diablo-onigiri
 1267	garnish	\N	azuki beans\nbrown sugar\nsugar\nblack sesame seeds toasted\nflour\nbutter		souffle-pancakes-inspired-by-food-wars!
 1268	Breakfast Uncrustable	\N	chicken\neggs\ncheese\ncottage cheese\nunsalted butter more for toasting		breakfast-uncrustable
 1269	A5 Wagyu Roti Don inspired by Food Wars!	\N	day old rice		a5-wagyu-roti-don-inspired-by-food-wars!
-1270	alvin's version	\N	garlic thinly\nparsley\nbeef tallow butter\nbutter\nsalt		a5-wagyu-roti-don-inspired-by-food-wars!
+1270	Garlic Fried Rice	\N	garlic thinly\nparsley\nbeef tallow butter\nbutter\nsalt		a5-wagyu-roti-don-inspired-by-food-wars!
 1271	assembly	\N	heavy cream\nstrawberries or as desired\neggs\nsugar\ncake flour\nbutter		strawberry-shortcake-inspired-by-death-note
 1272	shokupan crusts snack	\N	dashi\npanko or 2 cups dry panko\nshokupan crusts removed		pork-katsudon-inspired-by-yuri!!!-on-ice
 1273	Mega Beef Bowl inspired by Persona 4	\N	ribeye thinly		mega-beef-bowl-inspired-by-persona-4
 1274	assembly	\N	mirin\nsoy sauce		mega-beef-bowl-inspired-by-persona-4
 1275	Potsticker Pizza	\N	pizza dough\npork\nlow moisture mozzarella cheese\ncabbage\ngarlic\ndark soy sauce		potsticker-pizza
-1276	ham cheese croissants	\N	croissant dough scraps\ncroissant dough\nlayer croissant dough		324-layer-croissant-inspired-by-yakitate!!-japan
+1276	324 layer croissant	\N	croissant dough scraps\ncroissant dough\nlayer croissant dough		324-layer-croissant-inspired-by-yakitate!!-japan
 1277	mitarashi sauce	\N	silken tofu\njoshinko\nshiratamako\nmirin\nsoy sauce\nsugar\npotato starch		mitarashi-dango-inspired-by-demon-slayer
 1278	omelet	\N	eggs\nsugar\nbeef\narborio rice\nparmesan cheese		curry-risotto-omurice-inspired-by-food-wars!
 1279	Herring and Pumpkin Pot Pie inspired by Kiki's Delivery Service	\N	2 g unsalted butter blocks,		herring-and-pumpkin-pot-pie-inspired-by-kiki's-delivery-service
@@ -5436,7 +5462,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1291	Chorizo Clam Pasta	\N	littleneck clams could substitute part or with cockles if desired\ndried linguine\nspanish chorizo\nparsley\nwhite wine\ngarlic smashed		chorizo-clam-pasta
 1292	Lobster Salad Panzanella	\N	lobster tails\ncrusty sourdough bread cut into 1 inch thick slices\nbutter\nmayonnaise\nlemon juice\ncapers		lobster-salad-panzanella
 1293	halloumi sandwich ingredients:	\N	jarred roasted red peppers drained\nhalloumi cut into 1 or 2 inch\nunsalted almonds roasted\nsundried tomatoes drained\nparsley\nbasil\ngarlic\nsherry vinegar		halloumi-sandwich
-1294	beef	\N	top sirloin butt		chicago-style-italian-beef-inspired-by-the-bear
+1294	Italian beef (Al's-style top sirloin)	\N	top sirloin butt		chicago-style-italian-beef-inspired-by-the-bear
 1295	coleslaw	\N	chicken\nhomemade mayo\nketchup\nvegetable oil\negg		the-best-barbecue-chicken
 1296	cram ingredients:	\N	sugar\nprepared strawberry kool aid or fruit juice		jell-o-cake-nuka-cola-and-cram-inspired-by-fallout
 1297	assembly	\N	lard\neinkorn stone wheat flour\ngreen cabbage thinly\nsquab		renaissance-wrap-inspired-by-shrek-2
@@ -5448,15 +5474,15 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1303	jerk barbecue sauce ingredients:	\N	lean beef\nlong grain white rice\nflour\nlard		jerk-meat-platter-inspired-by-futurama
 1304	egg wash:	\N	flour\nricotta cheese\ngreek feta\negg\neggs\ncooking olive oil		spanakopita-galettes
 1305	slaw:	\N	chicken breast\nghee or clarified butter (or enough reach 1" high in pan\nbreadcrumbs\nflour\neggs\nred radishes\nmint\ntarragon		chicken-schnitzel-with-kohlrabi-slaw
-1306	everything bagel ingredients:	\N	milk\nflour\nsalt\nsugar\nwhite vinegar\nwhite sesame seeds		bagelwithlox
+1306	Everything Bagel	\N	milk\nflour\nsalt\nsugar\nwhite vinegar\nwhite sesame seeds		bagelwithlox
 1307	candied cinnamon peanuts:	\N	sugar\ncream of coconut\nevaporated coconut milk\ncoconut milk\nheavy cream\nflour		coconut-tres-leches-cake-(inspired-by-uncle-boon'sthai-diner)
 1308	calabrian chili pasta	\N	pasta\nricotta\ngarlic\ncalabrian chili\na few thinly sheets of parmesan\ncherry tomatoes		tomato-confit-(ricotta-toast-simple-salad-pasta-with-calabrian-chili)
-1309	short cut pastéis de nata ingredients:	\N	milk\nsweet cherries\nsugar\nflour\negg yolks\nbrown sugar or sugar\ncognac or grand marnier		2024oscarsspecial
+1309	Pastéis de Nata	\N	milk\nsweet cherries\nsugar\nflour\negg yolks\nbrown sugar or sugar\ncognac or grand marnier		2024oscarsspecial
 1310	dashi	\N	eggs\nscallions whites in rounds greens for garnish\nmirin\nsoy sauce\nsake\nsugar\nchicken thigh\nrice for serving		oyakodon
 1311	cake	\N	dark brown sugar\ncake flour\nsour cream\nbutter\nmedjool date pitted &\nflour		sticky-toffee-coffee-cake
-1312	buttermilk bacon fat bechamel ingredients:	\N	flour rolling\nfrozen hashbrowns according package instructions\nthick cut bacon\nbeef\ncheddar cheese		bobsburgers-potato-lasagna
+1312	Loaded Baked Potato Lasagna	\N	flour rolling\nfrozen hashbrowns according package instructions\nthick cut bacon\nbeef\ncheddar cheese		bobsburgers-potato-lasagna
 1313	Spiedini alla Romana	\N	crusty bread\ntomato puree\nmozzarella cheese\nchicken stock\ncapers drained & dried\ndry white wine\nparsley chopped, more for garnish\ncooking olive oil		spiedini-alla-romana
-1314	duck cake:	\N	butter\nsugar\nflour\nmilk\nbuttermilk\neggs		bluey-duck-cake
+1314	Duck Cake	\N	butter\nsugar\nflour\nmilk\nbuttermilk\neggs		bluey-duck-cake
 1315	tuna sauté	\N	slab bluefin tuna loin\nbasil packed\nparsley stems packed\nchive stems packed\nmirin		one-piece-tuna-saute
 1316	Leftover Caviar Pasta	\N	butter\nthin long pasta\nleftover champagne or dry white wine\ncreme fraiche\nchampagne vinegar or white wine vinegar\nlemon juice		leftover-caviar-pasta
 1317	icing:	\N	ripe strawberries washed +\nbutter\nflour\nsugar		mean-girls-toaster-strudel
@@ -5479,9 +5505,9 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1334	egg wash	\N	pork shoulder\nbread flour more\nhot dog buns\nfat back\nmilk\negg\neggs		triple-deluxe-dog-hot-dog-detective
 1335	cookie nachos	\N	strawberries washed hulled +\nflour\nrolled oats\nsugar		cookie-nachos-sweet-tooth
 1336	The Crispiest Sandwich inspired by They Kidnapped my Son on Christmas	\N	fry oil		crispiest-sandwich-kidnapped-on-christmas
-1337	baked bacon	\N	boneless skinless chicken breast butterfied\nbuttermilk\nflour		crispiest-sandwich-kidnapped-on-christmas
+1337	fried chicken cutlets	\N	boneless skinless chicken breast butterfied\nbuttermilk\nflour		crispiest-sandwich-kidnapped-on-christmas
 1338	Nipples of Venus inspired by Amadeus	\N	chestnuts drained\nwhite chocolate wafers or bars\nbittersweet chocolate\ndark chocolate\nsugar\nbutter\nbrandy		nipples-of-venus-amadeus
-1339	basil gel	\N	gelatin sheets\nflour\ndeli style low moisture mozzarella cheese\ntomatoes on the vine\ntomato paste\nvegetable oil more for greasing\nbasil		chicago-deep-dish-the-bear
+1339	Chicago Deep-Dish Pizza	\N	gelatin sheets\nflour\ndeli style low moisture mozzarella cheese\ntomatoes on the vine\ntomato paste\nvegetable oil more for greasing\nbasil		chicago-deep-dish-the-bear
 1340	savory cannoli	\N	pitted oil packed cerignola black olives\nmortadella\npistachios\nmilk\nparmesan cheese		savory-cannoli-the-bear
 1341	potato chip tortilla	\N	eggs\nrusset potatoes\nfry oil\nchives\nbutter		potato-chip-omelet-the-bear
 1342	WINGS	\N	chicken wings		wings
@@ -5491,7 +5517,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1346	stabilized whipped cream icing	\N	sugar\nheavy cream\neggs\nstrawberries\nmascarpone cheese\nself rising flour		looney-cake-succession
 1347	monte cristo patty melt	\N	flour\nmilk\negg		monte-cristo-american-dad
 1348	el burdigato hot dog	\N	pepperoni\nbeef\nlean beef		el-burdigato-teen-titans-go
-1349	carnitas cuban sliders	\N	pork shoulder cut into two three inch pieces\nlard\ncoca cola preferably mexican\ncorn tortillas\nevaporated milk		carnitas
+1349	carnitas	\N	pork shoulder cut into two three inch pieces\nlard\ncoca cola preferably mexican\ncorn tortillas\nevaporated milk		carnitas
 1350	sorbet popsicle	\N	frozen blueberries\nsugar\ncoconut cream chilled\nraspberries\nsweetened condensed milk\nlemon juice		glowing-popsicles-the-mandalorian
 1351	pistachio crusted lamb chops	\N	butter\nthick preserved lemons\nwhite wine vinegar\npanko breadcrumbs\ntarragon\negg yolks\ncooking olive oil		tylers-bull-the-menu
 1352	BARBACOA DE RES CON CONSOMÉ	\N	g or 1 masa		barbacoa-de-res
@@ -5514,7 +5540,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1369	pigs a blanket	\N	store bought puff pastry\ncocktail franks\nfull size precooked sausage\negg		pigs-in-a-blanket-office
 1370	Home Alone Special	\N	heavy cream		home-alone-special
 1371	no churn ice cream sundae	\N	milk\nshort pasta\nmild yellow cheddar\nsan marzano tomatoes		home-alone-special
-1372	beer chicken	\N	chicken\nbaby potatoes\nbrussels sprouts\nbeer\nhen of the wood or maitake mushrooms\nchicken stock\ngarlic cloves smashed		beer-can-chicken
+1372	beer can chicken	\N	chicken\nbaby potatoes\nbrussels sprouts\nbeer\nhen of the wood or maitake mushrooms\nchicken stock\ngarlic cloves smashed		beer-can-chicken
 1373	meatballs	\N	beef\npork\nveal\nwhite bread crusts removed, torn into pieces\nbuttermilk\npacked parsley\negg\nuncured pancetta\ngarlic		meatballs-30rock
 1374	Sausages inspired by God of War: Ragnarok	\N	wild boar meat		sausages-ragnarok
 1375	boar sausage	\N	yellow onion\nfat back or pork belly\npork or chicken stock\nsalt		sausages-ragnarok
@@ -5533,14 +5559,14 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1388	wasabi buffalo wings	\N	chicken wings\nshishito peppers\nbutter\nsushi rice vinegar more as necessary\ngarlic\njalapeño peppers\nwasabi paste		wasabi-buffalo-wings-the-simpsons
 1389	EVERYTHING Bagel inspired by Everything Everywhere All At Once	\N	flour		everything-bagel-eeao
 1390	everything bagel	\N	every spice available\nbarley malt syrup		everything-bagel-eeao
-1391	maconara	\N	dried spaghetti\npanko breadcrumbs\naged yellow cheddar cheese\nguanciale\nhen of the woods or maitake mushrooms cut/torn into bite size pieces\nthick cut bacon\ndried macaroni or cavatappi		carbonara-anything
+1391	Carbonara Anything	\N	dried spaghetti\npanko breadcrumbs\naged yellow cheddar cheese\nguanciale\nhen of the woods or maitake mushrooms cut/torn into bite size pieces\nthick cut bacon\ndried macaroni or cavatappi		carbonara-anything
 1392	choodles	\N	milk\ninstant chicken ramen\nmeat\nscallions\nfrozen shrimp\nthick cut bacon		ramen-hacks
 1393	hot dog chili	\N	lean beef\nprocessed american cheese\nbeef\ntomato sauce\ncheddar cheese\nbeef suet\ntomatoes green chilies		footlong-taco-dogs-bobs-burgers
 1394	late night pasta	\N	dried pasta\ncherry tomatoes washed\nmozzarella cheese\nparmesan cheese more garnish\ngarlic thinly\nbutter\ntomato paste\nbasil\nparsley more garnish		go-to-pasta
 1395	cheese guava filling:	\N	flour\nbeef\nboneless skinless chicken breast\nqueso blanco\nguava paste\ncooking olive oil		empanadas
 1396	cinnamon orange churros	\N	sugar\nbutter\neggs\nmilk\nflour		churrons-broad-city
 1397	herb butter	\N	lobster\neggs\nbutter\nblack pepper\nparsley\ndill\ngarlic\nmarjoram		lobster-scrambled-eggs-seinfeld
-1398	egg wash	\N	flour\nmilk\nunsalted european style butter\nchocolate\nsugar\nbutter		chocolate-croissants-its-complicated
+1398	Chocolate Croissants	\N	flour\nmilk\nunsalted european style butter\nchocolate\nsugar\nbutter		chocolate-croissants-its-complicated
 1399	souvlaki	\N	~2 pork neck or or boneless skinless chicken breast\nfull fat plain greek yogurt\nfrozen french fries\nwooden skewers		souvlaki
 1400	babish’s double butter cookies	\N	butter\nflour\nbrown sugar\nwhite sugar\neggs\nsemi sweet chocolate\ndark chocolate\nsemi sweet chocolate chips		bobbys-cookies-king-of-the-hill
 1401	fortified fish stock	\N	fortified fish stock\nfish stock\nhead on prawns\nspanish paella rice\nprawn heads or shells\nclams\ncuttlefish or squid cleaned		seafood-paella-parks-and-rec
@@ -5554,7 +5580,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1409	beer braised corned beef	\N	beef brisket\nred white baby potatoes\ncinnamon\nsour cream\nsalt\ncardamom pods		corned-beef
 1410	crimson tears tea	\N	octopus\ngarlic\ndried lily flowers\nchili flakes\ndried nettles\nhibiscus flowers\nginger		land-octopus-elden-ring
 1411	“if looks could kale” burger	\N	beef or veggie burger mix\nroast chuck\nchard stems\nblack beans drained\nshort grain brown rice\ncurly kale washed dried +\ngruyere cheese		if-looks-could-kale
-1412	babish chicken picatta	\N	flour\nchicken stock preferably homemade\ncapellini spaghetti, or angel hair pasta,\nlinguini\nunsalted butter &\ndry white wine\ncapers\ncapers drained		chicken-piccata
+1412	Chicken Piccata	\N	flour\nchicken stock preferably homemade\ncapellini spaghetti, or angel hair pasta,\nlinguini\nunsalted butter &\ndry white wine\ncapers\ncapers drained		chicken-piccata
 1413	ranch aioli	\N	beef\namerican cheese\ndinner rolls horizontally toasted\nflour\nbreadcrumbs\nvegetable oil		sliders-three-ways
 1414	crema mayonnaise	\N	funyuns\ncarrots\npurple cabbage\ngummy bears		seven-layer-salad-himym
 1415	everything bagel filling	\N	flour\nbutter\nbrown sugar		sweet-and-savory-babka
@@ -5573,7 +5599,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1428	TURKEY: 5-WAYS	\N	turkey thawed neck or giblets removed		turkey-5-ways
 1429	complex shrimp scampi	\N	frozen shrimp defrosted\nshrimp deveined\ndry white wine\nlinguine pasta\nfettuccine pasta\nbutter\nparsley\ngarlic cloves thinly		shrimp-scampi-basics
 1430	pappardelle pasta	\N	chicken stock\nbeef\npork\nlamb\nflour\npancetta\ndry white wine		bolognese
-1431	hazelnuts baklava	\N	phyllo dough\nhazelnuts\npistachio de shelled\nbutter\nsugar\ndark chocolate\nhoney		baklava
+1431	chocolate hazelnut baklava	\N	phyllo dough\nhazelnuts\npistachio de shelled\nbutter\nsugar\ndark chocolate\nhoney		baklava
 1432	PIZZA DOUGH	\N	flour		pizza-dough
 1433	new york style pizza	\N	low moisture mozzarella		pizza-dough
 1434	BRAISED SHORT RIBS	\N	short ribs\nchicken stock\namber ale\ncarrots into pieces\ngarlic\nprune juice		short-ribs
@@ -5582,7 +5608,7 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1437	POTATO HASH	\N	russet or yukon gold potatoes		potato-hash
 1438	sweet potato hash	\N	eggs\nbacon\nvegetable oil		potato-hash
 1439	kimchi	\N	garlic\ngochugaru\nonion\nginger\nfish sauce\nsalt\nsugar\nrice vinegar		kimchi
-1440	fonduta	\N	desired cheese\nyellow & white cheddar\nfontina cheese\ndry white wine\nbeer\nmilk\nbutter		cheese-fondue
+1440	Cheese Fondue	\N	desired cheese\nyellow & white cheddar\nfontina cheese\ndry white wine\nbeer\nmilk\nbutter		cheese-fondue
 1441	mochi dough	\N	heavy cream\nmilk\nsugar\negg yolks		mochi-icecream
 1442	beef stroganoff pasta	\N	chicken stock\ncan san marzano tomatoes crushed\nmild or spicy italian sausage casings removed\ndry white wine\nsour cream		onepot-pasta
 1443	tangy butter for chocolate babka toast	\N	milk\nhalf & half or heavy cream\ncream cheese\nwhite sugar		french-toast
@@ -5592,13 +5618,13 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1447	cake	\N	flour\nbutter\nsour cream\nsugar\ndark brown sugar\neggs\nturbinado sugar		coffeecake
 1448	gorgonzola cream sauce	\N	full fat ricotta\nbasil\nheavy cream\nflour\nparmesan cheese		gnocchi
 1449	pork chop pan sauce	\N	chicken\nchicken stock\nshallots\nstock\ndry white wine\nparsley		pan-sauces
-1450	deep frying	\N	chicken		chimichangas
+1450	Chimichangas	\N	chicken		chimichangas
 1451	semifreddo	\N	flour\nheavy cream\nbuttermilk\ncarrots\nlight brown sugar\neggs		ice-cream-sandwiches
 1452	NASHVILLE HOT CHICKEN	\N	chicken		hot-chicken
 1453	nashville hot chicken	\N	flour\nmilk\nlard\nvegetable oil\neggs\ncayenne pepper		hot-chicken
 1454	LATKES (POTATO PANCAKES)	\N	russet potatoes		latkes
 1455	toppings	\N	eggs\npanko breadcrumbs		latkes
-1456	chocolate chip cookies	\N	chickpeas\nflour\ncan crushed tomatoes\ngarbanzo beans\nliquid from chickpeas		chickpeas
+1456	chickpea (aquafaba) chocolate chip cookies	\N	chickpeas\nflour\ncan crushed tomatoes\ngarbanzo beans\nliquid from chickpeas		chickpeas
 1457	meat stew peas	\N	yukon gold potatoes\nlamb\ndark irish stout\nbeef or bone broth\npeas\nbutter\nchives\nmilk		shepherdspie
 1458	SOURDOUGH BREAD	\N	flour		sourdough-bread
 1459	estimated schedule	\N	wheat flour\nmature starter		sourdough-bread
@@ -5619,6 +5645,190 @@ COPY public.recipe (id, name, image_link, raw_ingredient_list, raw_procedure, ep
 1474	Scrambled Eggs on Toast	\N	Eggs\nGoat Cheese\nChives\nBread	?	eggs
 1475	Simple Shrimp Scampi	\N	2 tsp kosher salt (+ more to taste)\n½ lb linguine pasta\n3 Tbsp unsalted butter\n2 Tbsp olive oil\n3 garlic cloves, crushed\n¼ tsp crushed red pepper flakes\n½ cup dry white wine\n1 lb frozen shrimp, defrosted and peeled\n1 tsp freshly ground black pepper\nJuice of 1 large lemon\n2 Tbsp parsley, chopped		shrimp-scampi
 1476	Sunny-Side Up Eggs	\N	1 Egg	?	eggs
+1477	level 4: cheesesteak kit style	\N			10-levels-of-cheesesteak
+1478	level 5: classic homemade cheesesteak	\N			10-levels-of-cheesesteak
+1479	level 6: chicken cheesesteak	\N			10-levels-of-cheesesteak
+1480	level 7: proper homemade cheesesteak	\N			10-levels-of-cheesesteak
+1481	level 8: shop-style ribeye cheesesteak	\N			10-levels-of-cheesesteak
+1482	eomuk guk	\N			kpop-demon-hunters-airplane-feast
+1483	skewers	\N			kpop-demon-hunters-airplane-feast
+1484	dipping sauce	\N			kpop-demon-hunters-airplane-feast
+1485	gimbap	\N			kpop-demon-hunters-airplane-feast
+1486	level 6: no prep chicken noodle soup	\N			10-levels-chicken-noodle-soup
+1487	level 7: simple from-scratch	\N			10-levels-chicken-noodle-soup
+1488	stock	\N			10-levels-chicken-noodle-soup
+1489	soup base	\N			10-levels-chicken-noodle-soup
+1490	level 8: matzo ball soup	\N			10-levels-chicken-noodle-soup
+1491	level 9: avgolemono	\N			10-levels-chicken-noodle-soup
+1492	level 10: fine dining chicken noodle soup	\N			10-levels-chicken-noodle-soup
+1493	pasta dough	\N			10-levels-chicken-noodle-soup
+1494	spinach artichoke dip monkey bread	\N			super-bowl-snacks-for-the-win-or-with-babish
+1495	monkey bread	\N			super-bowl-snacks-for-the-win-or-with-babish
+1496	garlic butter	\N			super-bowl-snacks-for-the-win-or-with-babish
+1497	spinach artichoke dip	\N			super-bowl-snacks-for-the-win-or-with-babish
+1498	homemade mayo	\N			super-bowl-snacks-for-the-win-or-with-babish
+1499	poutine bites	\N			super-bowl-snacks-for-the-win-or-with-babish
+1500	potato cups	\N			super-bowl-snacks-for-the-win-or-with-babish
+1501	million dollar deviled eggs	\N			super-bowl-snacks-for-the-win-or-with-babish
+1502	$1 spaghetti and meatballs	\N			5-levels-of-spaghetti-or-with-babish
+1503	lentil meatball mixture	\N			5-levels-of-spaghetti-or-with-babish
+1504	panade	\N			5-levels-of-spaghetti-or-with-babish
+1505	lentil meatballs	\N			5-levels-of-spaghetti-or-with-babish
+1506	$10 spaghetti and meatballs	\N			5-levels-of-spaghetti-or-with-babish
+1507	$10 meatballs	\N			5-levels-of-spaghetti-or-with-babish
+1508	$25 spaghetti and meatballs	\N			5-levels-of-spaghetti-or-with-babish
+1509	$50 spaghetti and meatballs	\N			5-levels-of-spaghetti-or-with-babish
+1510	toast	\N			ultimate-french-toast-or-with-babish
+1511	pain de mie	\N			ultimate-french-toast-or-with-babish
+1512	poolish	\N			ultimate-french-toast-or-with-babish
+1513	preserved lemon blueberry compote	\N			ultimate-french-toast-or-with-babish
+1514	red miso maple syrup	\N			ultimate-french-toast-or-with-babish
+1515	crème fraîche chantilly	\N			ultimate-french-toast-or-with-babish
+1516	french toast custard	\N			ultimate-french-toast-or-with-babish
+1517	beef prep	\N			ultimate-pot-roast-or-with-babish
+1518	braised vegetable prep	\N			ultimate-pot-roast-or-with-babish
+1519	bouquet garni	\N			ultimate-pot-roast-or-with-babish
+1520	mashed potatoes	\N			ultimate-pot-roast-or-with-babish
+1521	roasted vegetables	\N			ultimate-pot-roast-or-with-babish
+1522	$200 beef wellington	\N			beef-wellington-or-with-babish
+1523	mushroom duxelles	\N			beef-wellington-or-with-babish
+1524	$20 beef wellington	\N			beef-wellington-or-with-babish
+1525	beef prep ($20 wellington)	\N			beef-wellington-or-with-babish
+1526	mushroom duxelle	\N			beef-wellington-or-with-babish
+1527	butter block	\N			beef-wellington-or-with-babish
+1528	red miso puff pastry	\N			beef-wellington-or-with-babish
+1529	bacon	\N			coq-au-vin
+1530	vegetables	\N			coq-au-vin
+1531	bouquet garni	\N			coq-au-vin
+1532	coq au vin sauce	\N			coq-au-vin
+1533	butter mushrooms	\N			coq-au-vin
+1534	pearl onions	\N			coq-au-vin
+1535	buttered noodles	\N			coq-au-vin
+1536	beurre monté sauce	\N			coq-au-vin
+1537	steak cuts: technique	\N			steak
+1538	new york strip steak	\N			steak
+1539	boneless short ribs	\N			steak
+1540	hot jus	\N			steak
+1541	london broil	\N			steak
+1542	ribeye	\N			steak
+1543	hanger steak	\N			steak
+1544	filet mignon: steak tartare	\N			steak
+1545	steak	\N			steak
+1546	fallout: the vault dweller's official cookbook	\N			fallout-fancy-lad-snack-cakes-inspired-by-fallout-76
+1547	cake	\N			fallout-fancy-lad-snack-cakes-inspired-by-fallout-76
+1548	marshmallow cream cheese frosting	\N			fallout-fancy-lad-snack-cakes-inspired-by-fallout-76
+1549	white chocolate fondant coating	\N			fallout-fancy-lad-snack-cakes-inspired-by-fallout-76
+1550	babish version	\N			fallout-fancy-lad-snack-cakes-inspired-by-fallout-76
+1551	sponge cake batter	\N			fallout-fancy-lad-snack-cakes-inspired-by-fallout-76
+1552	whipped white chocolate ganache	\N			fallout-fancy-lad-snack-cakes-inspired-by-fallout-76
+1553	spiced cake soak	\N			fallout-fancy-lad-snack-cakes-inspired-by-fallout-76
+1554	fondant coating	\N			fallout-fancy-lad-snack-cakes-inspired-by-fallout-76
+1555	level 3: blue box	\N			10-levels-of-mac-and-cheese
+1556	mac	\N			10-levels-of-mac-and-cheese
+1557	cheese sauce	\N			10-levels-of-mac-and-cheese
+1558	level 4: evaporated milk	\N			10-levels-of-mac-and-cheese
+1559	level 5: one pot inspired by america's test kitchen	\N			10-levels-of-mac-and-cheese
+1560	level 6: deep fried mac & cheese	\N			10-levels-of-mac-and-cheese
+1561	level 7: classic mornay	\N			10-levels-of-mac-and-cheese
+1562	level 8: molecular gastronomy - sodium citrate	\N			10-levels-of-mac-and-cheese
+1563	level 9: sparing no expense	\N			10-levels-of-mac-and-cheese
+1564	quadruple stacked ham sandwich	\N			quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv
+1565	scampi shrimp	\N			quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv
+1566	eggplant sandwich	\N			quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv
+1567	ham & sweet potato sandwich	\N			quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv
+1568	lettuce & honey ham sandwich	\N			quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv
+1569	shrimp & avocado sandwich	\N			quadruple-stacked-ham-sandwich-inspired-by-final-fantasy-xv
+1570	deep fried burger bomb	\N			deep-fried-burger-bomb
+1571	burger patties	\N			deep-fried-burger-bomb
+1572	cheese sauce	\N			deep-fried-burger-bomb
+1573	burgers	\N			deep-fried-burger-bomb
+1574	short rib bones snack	\N			deep-fried-burger-bomb
+1575	cheese dough balls	\N			deep-fried-burger-bomb
+1576	duck breast salad	\N			3-course-dinner-inspired-by-drop
+1577	duck	\N			3-course-dinner-inspired-by-drop
+1578	pickled red onion	\N			3-course-dinner-inspired-by-drop
+1579	mango ginger sauce	\N			3-course-dinner-inspired-by-drop
+1580	pomegranate sauce	\N			3-course-dinner-inspired-by-drop
+1581	salad	\N			3-course-dinner-inspired-by-drop
+1582	pork tenderloin medallions with bourbon sauce	\N			5-weeknight-recipes-for-pork-tenderloin
+1583	medallions	\N			5-weeknight-recipes-for-pork-tenderloin
+1584	bourbon pan sauce	\N			5-weeknight-recipes-for-pork-tenderloin
+1585	pork schnitzel	\N			5-weeknight-recipes-for-pork-tenderloin
+1586	pork souvlaki	\N			5-weeknight-recipes-for-pork-tenderloin
+1587	souvlaki spice mix	\N			5-weeknight-recipes-for-pork-tenderloin
+1588	japanese-style big mac	\N			japanese-style-big-mac-inspired-by-weathering-with-you
+1589	bun	\N			japanese-style-big-mac-inspired-by-weathering-with-you
+1590	tangzhong	\N			japanese-style-big-mac-inspired-by-weathering-with-you
+1591	beef patties	\N			japanese-style-big-mac-inspired-by-weathering-with-you
+1592	teriyaki sauce	\N			japanese-style-big-mac-inspired-by-weathering-with-you
+1593	buns	\N			japanese-style-big-mac-inspired-by-weathering-with-you
+1594	traditional cheesecake	\N			cheesecake-inspired-by-junior's-cheesecakes
+1595	cheesecake batter	\N			cheesecake-inspired-by-junior's-cheesecakes
+1596	sponge cake	\N			cheesecake-inspired-by-junior's-cheesecakes
+1597	sponge cake batter	\N			cheesecake-inspired-by-junior's-cheesecakes
+1598	egg whites mixture	\N			cheesecake-inspired-by-junior's-cheesecakes
+1599	cheesecake	\N			cheesecake-inspired-by-junior's-cheesecakes
+1600	strawberry cheesecake	\N			cheesecake-inspired-by-junior's-cheesecakes
+1601	nilla wafer crust	\N			cheesecake-inspired-by-junior's-cheesecakes
+1602	strawberry topping	\N			cheesecake-inspired-by-junior's-cheesecakes
+1603	nilla wafer crumble	\N			cheesecake-inspired-by-junior's-cheesecakes
+1604	basic egg salad sandwich	\N			egg-salad-inspired-by-futurama
+1605	sandwich	\N			egg-salad-inspired-by-futurama
+1606	egg salad	\N			egg-salad-inspired-by-futurama
+1607	japanese-inspired egg salad sandwich	\N			egg-salad-inspired-by-futurama
+1608	shokupan dough	\N			egg-salad-inspired-by-futurama
+1609	tangzhong	\N			egg-salad-inspired-by-futurama
+1610	homemade yolk mayo	\N			egg-salad-inspired-by-futurama
+1611	gourmet egg salad	\N			egg-salad-inspired-by-futurama
+1612	sandwich assembly	\N			egg-salad-inspired-by-futurama
+1613	shrimp stock	\N			shrimp-7-ways
+1614	shrimp cocktail	\N			shrimp-7-ways
+1615	shrimp	\N			shrimp-7-ways
+1616	cocktail sauce	\N			shrimp-7-ways
+1617	thai coconut curry	\N			shrimp-7-ways
+1618	tomato confit	\N			my-top-5-easy-sexy-dishes
+1619	pasta puttanesca	\N			my-top-5-easy-sexy-dishes
+1620	puttanesca	\N			my-top-5-easy-sexy-dishes
+1621	pork tenderloin with romesco saucerom	\N			my-top-5-easy-sexy-dishes
+1622	romesco sauce	\N			my-top-5-easy-sexy-dishes
+1623	pork tenderloin	\N			my-top-5-easy-sexy-dishes
+1624	fennel salad	\N			my-top-5-easy-sexy-dishes
+1625	filet mignon with chimichurri	\N			my-top-5-easy-sexy-dishes
+1626	deviled eggs	\N			the-egg-bar-inspired-by-severance
+1627	hard boiled eggs	\N			the-egg-bar-inspired-by-severance
+1628	homemade mayo	\N			the-egg-bar-inspired-by-severance
+1629	regular deviled eggs	\N			the-egg-bar-inspired-by-severance
+1630	purple deviled eggs	\N			the-egg-bar-inspired-by-severance
+1631	waffle soldiers	\N			the-egg-bar-inspired-by-severance
+1632	boiled eggs	\N			the-egg-bar-inspired-by-severance
+1633	scotch eggs	\N			the-egg-bar-inspired-by-severance
+1634	crème anglaise	\N			whimsical-parfait-inspired-by-darker-than-black
+1635	ice cream flavors:	\N			whimsical-parfait-inspired-by-darker-than-black
+1636	chocolate flavor	\N			whimsical-parfait-inspired-by-darker-than-black
+1637	vanilla flavor	\N			whimsical-parfait-inspired-by-darker-than-black
+1638	matcha flavor	\N			whimsical-parfait-inspired-by-darker-than-black
+1639	strawberry flavor	\N			whimsical-parfait-inspired-by-darker-than-black
+1640	hot fudge sauce	\N			whimsical-parfait-inspired-by-darker-than-black
+1641	choux pastry :	\N			whimsical-parfait-inspired-by-darker-than-black
+1642	pastry cream	\N			whimsical-parfait-inspired-by-darker-than-black
+1643	milk mixture	\N			whimsical-parfait-inspired-by-darker-than-black
+1644	pierogoi dough & assembly	\N			pierogis
+1645	pierogoi dough	\N			pierogis
+1646	potato filling	\N			pierogis
+1647	beef filling	\N			pierogis
+1648	mushroom sauerkraut filling	\N			pierogis
+1649	applesauce	\N			pierogis
+1650	homemade sour cream	\N			pierogis
+1651	whipped ricotta & toppings	\N			date-night-2
+1652	whipped ricotta	\N			date-night-2
+1653	confit tomatoes	\N			date-night-2
+1654	basil oil	\N			date-night-2
+1655	deconstructed pesto	\N			date-night-2
+1656	browned butter sage	\N			date-night-2
+1657	cornish hen & sauces	\N			date-night-2
+1658	cornish hen	\N			date-night-2
+1659	simple mustard pan sauce	\N			date-night-2
+1660	gremolata	\N			date-night-2
 \.
 
 
@@ -5892,6 +6102,17 @@ COPY public.reference (id, type, name, description, external_link, image_link) F
 636	video_game	ARC Raiders	Embark Studios' free-to-play third-person extraction shooter set on a hostile alien-attacked Earth.	\N	\N
 637	movie	KPop Demon Hunters	2025 Sony Pictures Animation/Netflix film about a K-pop girl group who moonlight as demon hunters.	\N	\N
 638	movie	Tampopo	Juzo Itami's 1985 Japanese 'ramen western' about a widowed noodle-shop owner perfecting her recipe.	\N	\N
+639	\N	Fallout	\N	\N	\N
+640	\N	Shrek 2	\N	\N	\N
+641	\N	Mr. & Mrs. Smith	\N	\N	\N
+642	\N	2024 Oscars	\N	\N	\N
+643	\N	Bluey	\N	\N	\N
+644	\N	Mean Girls	\N	\N	\N
+645	\N	Rick	\N	\N	\N
+646	\N	Morty	\N	\N	\N
+647	\N	LAST-MINUTE	\N	\N	\N
+648	\N	Lots of Things	\N	\N	\N
+649	\N	Alfredo alla Scrofa	\N	\N	\N
 \.
 
 
@@ -5940,21 +6161,21 @@ COPY public.tag (id, axis, name, external_id) FROM stdin;
 -- Name: guest_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.guest_id_seq', 74, true);
+SELECT pg_catalog.setval('public.guest_id_seq', 84, true);
 
 
 --
 -- Name: recipe_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.recipe_id_seq', 1476, true);
+SELECT pg_catalog.setval('public.recipe_id_seq', 1660, true);
 
 
 --
 -- Name: reference_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.reference_id_seq', 638, true);
+SELECT pg_catalog.setval('public.reference_id_seq', 649, true);
 
 
 --


### PR DESCRIPTION
## Summary

Regenerated `datasets/*.json` and `ibdb/db_dump.sql` by running `flask sync build export` against the current `data/` tree on master. This rolls up all merged curate work since the last refresh.

Build counts:

- 33 tags
- 35 guests (post-collision-repair from #117/#118)
- 276 references
- 637 episodes
- 1641 recipes

The build pipeline lives on the private `migrate-to-babish-sh` branch; this PR carries only the data-derived artifacts.

## Diff shape (force-pushed; previous version reordered keys alphabetically)

| File | Δ lines |
|---|---:|
| `datasets/ibdb.episodes.json` | +2 145 / -690 |
| `datasets/ibdb.guests.json` | +225 / -11 |
| `datasets/ibdb.recipes.json` | +3 458 / -698 |
| `datasets/ibdb.references.json` | +255 / -63 |
| `datasets/ibdb.tags.json` | +358 / -462 |
| `ibdb/db_dump.sql` | +338 / -117 |

The original push was ~40k+/40k lines because Flask 3 alphabetizes JSON keys by default and previous exports were produced by an older Flask that preserved `Model.serialize()` insertion order. Set `app.json.sort_keys = False` on the build branch (separate, unpushed commit on `migrate-to-babish-sh`) and re-ran the export — the diff now shows only real content changes.

## Test plan

- [ ] `git diff master..refresh-datasets-after-curate-batches -- datasets/` shows only the 5 dataset files
- [ ] `git diff master..refresh-datasets-after-curate-batches -- ibdb/` shows only `db_dump.sql`
- [ ] All 35 guest names unique in the exported `ibdb.guests.json`